### PR TITLE
propagate nodeSelector to pod spec

### DIFF
--- a/internal/controller/deployment.go
+++ b/internal/controller/deployment.go
@@ -118,10 +118,6 @@ func generateContainersDef(cluster *valkeyiov1alpha1.ValkeyCluster) []corev1.Con
 
 func createClusterDeployment(cluster *valkeyiov1alpha1.ValkeyCluster) *appsv1.Deployment {
 	containers := generateContainersDef(cluster)
-	nodeSelector := cluster.Spec.NodeSelector
-	if cluster.Spec.Affinity != nil {
-		nodeSelector = nil
-	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: cluster.Name + "-",
@@ -140,8 +136,8 @@ func createClusterDeployment(cluster *valkeyiov1alpha1.ValkeyCluster) *appsv1.De
 				Spec: corev1.PodSpec{
 					Containers:   containers,
 					Affinity:     cluster.Spec.Affinity,
-					NodeSelector: nodeSelector,
-					Tolerations: cluster.Spec.Tolerations,
+					NodeSelector: cluster.Spec.NodeSelector,
+					Tolerations:  cluster.Spec.Tolerations,
 					Volumes: []corev1.Volume{
 						{
 							Name: "scripts",

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -106,27 +106,6 @@ func TestCreateClusterDeployment_SetsNodeSelector(t *testing.T) {
 	assert.Equal(t, nodeSelector, d.Spec.Template.Spec.NodeSelector, "node selector should match spec")
 }
 
-func TestCreateClusterDeployment_NodeSelectorIgnoredWhenAffinitySet(t *testing.T) {
-	nodeSelector := map[string]string{
-		"disktype": "ssd",
-	}
-	affinity := &corev1.Affinity{
-		NodeAffinity: &corev1.NodeAffinity{},
-	}
-	cluster := &valkeyv1.ValkeyCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "mycluster"},
-		Spec: valkeyv1.ValkeyClusterSpec{
-			Image:        "container:version",
-			NodeSelector: nodeSelector,
-			Affinity:     affinity,
-		},
-	}
-
-	d := createClusterDeployment(cluster)
-
-	assert.Nil(t, d.Spec.Template.Spec.NodeSelector, "node selector should be nil when affinity set")
-}
-
 func TestGenerateContainersDef(t *testing.T) {
 	t.Run("should return only valkey-server when exporter is disabled", func(t *testing.T) {
 		cluster := &valkeyv1.ValkeyCluster{


### PR DESCRIPTION
[Issue](https://github.com/valkey-io/valkey-operator/issues/31)

Testing in an EKS cluster with 2 values for label `topology.kubernetes.io/zone`:
<img width="1154" height="43" alt="Screenshot 2026-01-29 at 6 10 52 PM" src="https://github.com/user-attachments/assets/26ef5d8f-8c31-4227-98ee-4bcaab52fa37" />

Without adding `nodeSelector`, when applying `config/samples/v1alpha1_valkeycluster.yaml`, valkey pods were placed on nodes with labels `topology.kubernetes.io/zone=us-east-1b` and `topology.kubernetes.io/zone=us-east-1c`:

<img width="858" height="169" alt="Screenshot 2026-01-29 at 4 51 43 PM" src="https://github.com/user-attachments/assets/5581d749-7a90-4ffe-9e13-fa32f0b61b33" />

After adding `nodeSelector: topology.kubernetes.io/zone: us-east-1b` in the manifest, nodeSelector was successfully applied:
<img width="857" height="113" alt="Screenshot 2026-01-29 at 5 27 54 PM" src="https://github.com/user-attachments/assets/d2184cd4-e2a3-4b98-b829-c22fabefff17" />

and valkey pods were only placed on nodes with label `topology.kubernetes.io/zone=us-east-1b`.
<img width="856" height="154" alt="Screenshot 2026-01-29 at 4 52 38 PM" src="https://github.com/user-attachments/assets/ad4b7294-07e3-41a1-90a6-a6b5d1202db9" />

If we change the node selector to `topology.kubernetes.io/zone: us-east-1a`, the pods stayed pending indefinitely because there's no node with this label:
<img width="1021" height="114" alt="Screenshot 2026-01-29 at 11 16 01 PM" src="https://github.com/user-attachments/assets/03755682-a1bc-4796-bb3c-b5b73100306e" />

Multiple selectors:
Adding `nodeSelector:
  topology.kubernetes.io/zone: us-east-1b
  kubernetes.io/hostname: ip-10-9-58-63.ec2.internal` in the manifest put all valkey pods on the same node in `us-east-1b`:
<img width="687" height="450" alt="Screenshot 2026-01-31 at 3 43 06 PM" src="https://github.com/user-attachments/assets/614ccbb9-6c6e-452d-a6f5-d1cf9512a6e3" />
