### PR TITLE
Handle post-failover pod replacement gracefully

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -128,11 +128,11 @@ func podRoleAndShard(address string, pods *corev1.PodList) (string, int) {
 // assignSlotsToNewPrimary. Instead it should fall through to
 // replicateToShardPrimary, which will either succeed (case 1) or return an
 // error and retry on the next reconcile (case 2).
-func shardExistsInTopology(state *valkey.ClusterState, shardIndex int, selfAddress string, pods *corev1.PodList) bool {
+func shardExistsInTopology(state *valkey.ClusterState, shardIndex int, pods *corev1.PodList) bool {
 	si := strconv.Itoa(shardIndex)
 	for i := range pods.Items {
 		p := &pods.Items[i]
-		if p.Labels[LabelShardIndex] != si || p.Status.PodIP == selfAddress || p.Status.PodIP == "" {
+		if p.Labels[LabelShardIndex] != si || p.Status.PodIP == "" {
 			continue
 		}
 		for _, shard := range state.Shards {
@@ -151,11 +151,11 @@ func shardExistsInTopology(state *valkey.ClusterState, shardIndex int, selfAddre
 // primary, regardless of its node-index label. This handles the post-failover
 // case where node-index=1 (or higher) was promoted by Valkey.
 // Returns ("", "") if no primary is found.
-func findShardPrimary(state *valkey.ClusterState, shardIndex int, selfAddress string, pods *corev1.PodList) (nodeID, ip string) {
+func findShardPrimary(state *valkey.ClusterState, shardIndex int, pods *corev1.PodList) (nodeID, ip string) {
 	si := strconv.Itoa(shardIndex)
 	for i := range pods.Items {
 		p := &pods.Items[i]
-		if p.Labels[LabelShardIndex] != si || p.Status.PodIP == selfAddress || p.Status.PodIP == "" {
+		if p.Labels[LabelShardIndex] != si || p.Status.PodIP == "" {
 			continue
 		}
 		for _, shard := range state.Shards {

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -442,7 +442,7 @@ func (r *ValkeyClusterReconciler) addValkeyNode(ctx context.Context, cluster *va
 		// new slots. Instead it joins as a replica. If the failover hasn't
 		// completed yet, replicateToShardPrimary will return an error and
 		// the reconciler retries on the next cycle.
-		if shardExistsInTopology(state, shardIndex, node.Address, pods) {
+		if shardExistsInTopology(state, shardIndex, pods) {
 			log.V(1).Info("shard already exists in topology (post-failover); attaching as replica",
 				"shardIndex", shardIndex, "node", node.Address)
 			return r.replicateToShardPrimary(ctx, cluster, state, node, shardIndex, pods)
@@ -520,7 +520,7 @@ func (r *ValkeyClusterReconciler) replicateToShardPrimary(ctx context.Context, c
 	// against the live Valkey topology. This handles both the normal case
 	// (node-index=0 is the primary) and the post-failover case (a promoted
 	// replica is the primary).
-	primaryNodeId, primaryIP := findShardPrimary(state, shardIndex, node.Address, pods)
+	primaryNodeId, primaryIP := findShardPrimary(state, shardIndex, pods)
 	if primaryNodeId == "" {
 		return errors.New("primary Valkey node not found in cluster state for shard " + strconv.Itoa(shardIndex))
 	}


### PR DESCRIPTION
## Summary

When Valkey promotes a replica to primary during automatic failover and Kubernetes recreates the old node-index=0 pod, the reconciler previously tried to assign a new slot range to the replacement pod. This failed in a loop with `"no slots range to assign"` because all 16384 slots were already owned by the promoted replica, leaving the cluster stuck in `Degraded/NodeAddFailed`.

**Fix:** before assigning slots, `assignSlotsToPendingPrimaries` now checks the live Valkey topology (`shardExistsInTopology`) for any existing member in the same shard. If one exists (post-failover or mid-failover), the replacement pod joins as a replica instead. `replicateToShardPrimary` also gains a fallback (`findShardPrimary`) that scans all shard pods for the actual primary, since after failover node-index=0 is no longer the Valkey primary.

### What changed

- **`utils.go`** — two new helpers:
  - `shardHasLivePrimary`: checks if another pod in the same shard-index group is a slot-bearing primary in the live topology
  - `findShardPrimary`: scans all pods in a shard to find the actual Valkey primary regardless of node-index label
- **`valkeycluster_controller.go`**:
  - `addValkeyNode` step 2 now detects post-failover replacements and falls through to the replica path
  - `replicateToShardPrimary` tries node-index=0 first (fast path), then falls back to `findShardPrimary`

### Test plan

**1. Deploy a 3-shard, 1-replica cluster and wait for `Ready`**

```bash
kubectl apply -f config/samples/v1alpha1_valkeycluster.yaml
```

<img width="984" height="159" alt="Screenshot 2026-02-16 at 2 54 38 PM" src="https://github.com/user-attachments/assets/6f86b5d8-ec5c-4bd8-95b3-c6a419838f38" />
<img width="1013" height="112" alt="Screenshot 2026-02-16 at 2 57 59 PM" src="https://github.com/user-attachments/assets/10e06f70-00b9-4e7b-a801-c48902d5a19e" />

**2. Kill shard-0 primary**

```bash
kubectl delete pod valkeycluster-sample-0-0
```

<img width="1017" height="183" alt="Screenshot 2026-02-16 at 3 04 55 PM" src="https://github.com/user-attachments/assets/10e6a743-4377-4000-a214-355f95d0d75b" />

**3. Verify `valkeycluster-sample-0-1` is now the primary and `valkeycluster-sample-0-0` is its replica**

```bash
kubectl exec valkeycluster-sample-0-1 -- valkey-cli cluster nodes
```

<img width="976" height="154" alt="Screenshot 2026-02-16 at 3 05 47 PM" src="https://github.com/user-attachments/assets/bed1e52a-5387-4dd2-ab22-ef23d31d04a1" />