### PR TITLE
Add scale-out support with slot rebalancing

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -159,6 +159,8 @@ const (
 	ReasonSlotsUnassigned   = "SlotsUnassigned"
 	ReasonPrimaryLost       = "PrimaryLost"
 	ReasonNoSlots           = "NoSlotsAvailable"
+	ReasonRebalancingSlots  = "RebalancingSlots"
+	ReasonRebalanceFailed   = "RebalanceFailed"
 	ReasonUsersAclError     = "UsersACLError"
 )
 

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -72,6 +72,7 @@ Common reasons:
 - `Initializing` – initial cluster creation
 - `Reconciling` – general reconciliation in progress
 - `AddingNodes` – adding nodes to the cluster
+- `RebalancingSlots` – rebalancing hash slots across primaries
 - `ReconcileComplete` – reconciliation finished (typically with `status=False`)
 
 #### `Degraded`
@@ -86,6 +87,7 @@ Common reasons:
 - `NodeAddFailed` – failed to add a node to the cluster
 - `PrimaryLost` – primary lost in one or more shards
 - `NoSlotsAvailable` – no unassigned slots available for new shard
+- `RebalanceFailed` – slot rebalancing failed
 
 ---
 

--- a/internal/controller/migration.go
+++ b/internal/controller/migration.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+	"valkey.io/valkey-operator/internal/valkey"
+)
+
+const (
+	rebalanceSlotBatchSize    = 400
+	rebalanceKeysBatchSize    = 100
+	rebalanceMigrateTimeoutMs = 5000
+)
+
+func (r *ValkeyClusterReconciler) rebalanceSlots(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, shards []*valkey.ShardState) (bool, error) {
+	move, err := valkey.PlanRebalanceMove(shards, int(cluster.Spec.Shards), rebalanceSlotBatchSize)
+	if err != nil {
+		return false, err
+	}
+	if move == nil || len(move.Slots) == 0 {
+		return false, nil
+	}
+
+	log := logf.FromContext(ctx)
+	inProgress, err := slotMigrationInProgress(ctx, move.Src)
+	if err != nil {
+		return false, err
+	}
+	if inProgress {
+		log.V(1).Info("slot migration already in progress", "src", move.Src.Address)
+		return true, nil
+	}
+
+	known, err := nodeKnownToSource(ctx, move.Src, move.Dst)
+	if err != nil {
+		return false, err
+	}
+	if !known {
+		log.V(1).Info("destination node not known to source yet; waiting", "src", move.Src.Address, "dst", move.Dst.Address, "dstId", move.Dst.Id)
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "SlotsRebalancePending", "RebalanceSlots", "Waiting for %s to learn node %s", move.Src.Address, move.Dst.Address)
+		return true, nil
+	}
+
+	log.V(1).Info("rebalancing slots", "src", move.Src.Address, "dst", move.Dst.Address, "slots", len(move.Slots))
+	r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "SlotsRebalancing", "RebalanceSlots", "Moving %d slots from %s to %s", len(move.Slots), move.Src.Address, move.Dst.Address)
+
+	ranges := slotsToRanges(move.Slots)
+	if err := migrateSlotsAtomic(ctx, move.Src, move.Dst, ranges); err != nil {
+		if isSlotsNotServedByNode(err) {
+			log.V(1).Info("slots no longer served by source; will retry with fresh state", "src", move.Src.Address, "dst", move.Dst.Address)
+			return true, nil
+		}
+		if !isAtomicMigrationUnsupported(err) {
+			return false, err
+		}
+		log.V(1).Info("atomic slot migration unsupported; falling back to legacy migration", "src", move.Src.Address, "dst", move.Dst.Address)
+		for _, slot := range move.Slots {
+			if err := migrateSlotLegacy(ctx, move.Src, move.Dst, slot); err != nil {
+				return false, err
+			}
+		}
+	} else {
+		log.V(1).Info("atomic slot migration started", "src", move.Src.Address, "dst", move.Dst.Address, "ranges", len(ranges))
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "SlotsRebalancingAtomic", "RebalanceSlots", "Atomic migration started from %s to %s for %d slot ranges", move.Src.Address, move.Dst.Address, len(ranges))
+	}
+	return true, nil
+}
+
+func slotMigrationInProgress(ctx context.Context, src *valkey.NodeState) (bool, error) {
+	if src == nil || src.Client == nil {
+		return false, fmt.Errorf("missing source node")
+	}
+	log := logf.FromContext(ctx)
+	cmd := src.Client.B().Arbitrary("CLUSTER", "GETSLOTMIGRATIONS").Build()
+	migrations, err := src.Client.Do(ctx, cmd).ToArray()
+	if err != nil {
+		if isAtomicMigrationUnsupported(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("getslotmigrations failed on %s: %w", src.Address, err)
+	}
+	for _, migration := range migrations {
+		values, parseErr := migration.AsStrMap()
+		if parseErr != nil {
+			log.V(1).Info("unable to parse slot migration entry; treating as in progress", "src", src.Address, "error", parseErr)
+			return true, nil
+		}
+		state := strings.ToLower(values["state"])
+		if state == "" {
+			log.V(1).Info("slot migration entry missing state; treating as in progress", "src", src.Address)
+			return true, nil
+		}
+		if !isSlotMigrationTerminal(state) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isSlotMigrationTerminal(state string) bool {
+	switch strings.ToLower(state) {
+	case "success", "failed", "canceled", "cancelled":
+		return true
+	default:
+		return false
+	}
+}
+
+func nodeKnownToSource(ctx context.Context, src *valkey.NodeState, dst *valkey.NodeState) (bool, error) {
+	if src == nil || dst == nil || src.Client == nil {
+		return false, fmt.Errorf("missing source or destination node")
+	}
+	if dst.Id == "" {
+		return false, nil
+	}
+	cmd := src.Client.B().ClusterNodes().Build()
+	nodes, err := src.Client.Do(ctx, cmd).ToString()
+	if err != nil {
+		return false, fmt.Errorf("cluster nodes failed on %s: %w", src.Address, err)
+	}
+	return strings.Contains(nodes, dst.Id), nil
+}
+
+func migrateSlotsAtomic(ctx context.Context, src *valkey.NodeState, dst *valkey.NodeState, ranges []valkey.SlotsRange) error {
+	if src == nil || dst == nil {
+		return fmt.Errorf("missing source or destination node")
+	}
+	if len(ranges) == 0 {
+		return nil
+	}
+	cmd := src.Client.B().Arbitrary("CLUSTER", "MIGRATESLOTS")
+	for _, slotRange := range ranges {
+		cmd = cmd.Args(
+			"SLOTSRANGE",
+			strconv.Itoa(slotRange.Start),
+			strconv.Itoa(slotRange.End),
+			"NODE",
+			dst.Id,
+		)
+	}
+	if err := src.Client.Do(ctx, cmd.Build()).Error(); err != nil {
+		return fmt.Errorf("migrateslots failed from %s to %s: %w", src.Address, dst.Address, err)
+	}
+	return nil
+}
+
+func migrateSlotLegacy(ctx context.Context, src *valkey.NodeState, dst *valkey.NodeState, slot int) error {
+	if src == nil || dst == nil {
+		return fmt.Errorf("missing source or destination node")
+	}
+
+	if err := src.Client.Do(ctx, src.Client.B().ClusterSetslot().Slot(int64(slot)).Migrating().NodeId(dst.Id).Build()).Error(); err != nil {
+		return fmt.Errorf("setslot migrating failed for slot %d on %s: %w", slot, src.Address, err)
+	}
+	if err := dst.Client.Do(ctx, dst.Client.B().ClusterSetslot().Slot(int64(slot)).Importing().NodeId(src.Id).Build()).Error(); err != nil {
+		return fmt.Errorf("setslot importing failed for slot %d on %s: %w", slot, dst.Address, err)
+	}
+
+	for {
+		keys, err := src.Client.Do(ctx, src.Client.B().ClusterGetkeysinslot().Slot(int64(slot)).Count(int64(rebalanceKeysBatchSize)).Build()).AsStrSlice()
+		if err != nil {
+			return fmt.Errorf("getkeysinslot failed for slot %d on %s: %w", slot, src.Address, err)
+		}
+		if len(keys) == 0 {
+			break
+		}
+		for _, key := range keys {
+			if err := src.Client.Do(ctx, src.Client.B().Migrate().Host(dst.Address).Port(int64(dst.Port)).Key(key).DestinationDb(0).Timeout(rebalanceMigrateTimeoutMs).Replace().Build()).Error(); err != nil {
+				return fmt.Errorf("migrate failed for slot %d key %s from %s to %s: %w", slot, key, src.Address, dst.Address, err)
+			}
+		}
+	}
+
+	if err := dst.Client.Do(ctx, dst.Client.B().ClusterSetslot().Slot(int64(slot)).Node().NodeId(dst.Id).Build()).Error(); err != nil {
+		return fmt.Errorf("setslot node failed for slot %d on %s: %w", slot, dst.Address, err)
+	}
+	if err := src.Client.Do(ctx, src.Client.B().ClusterSetslot().Slot(int64(slot)).Node().NodeId(dst.Id).Build()).Error(); err != nil {
+		return fmt.Errorf("setslot node failed for slot %d on %s: %w", slot, src.Address, err)
+	}
+	return nil
+}
+
+func slotsToRanges(slots []int) []valkey.SlotsRange {
+	if len(slots) == 0 {
+		return nil
+	}
+	ordered := append([]int(nil), slots...)
+	sort.Ints(ordered)
+	ranges := make([]valkey.SlotsRange, 0, len(ordered))
+	start := ordered[0]
+	prev := ordered[0]
+	for _, slot := range ordered[1:] {
+		if slot == prev+1 {
+			prev = slot
+			continue
+		}
+		ranges = append(ranges, valkey.SlotsRange{Start: start, End: prev})
+		start = slot
+		prev = slot
+	}
+	ranges = append(ranges, valkey.SlotsRange{Start: start, End: prev})
+	return ranges
+}
+
+func isAtomicMigrationUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unknown command") ||
+		strings.Contains(msg, "unknown subcommand") ||
+		strings.Contains(msg, "syntax error") ||
+		strings.Contains(msg, "wrong number of arguments") ||
+		strings.Contains(msg, "not supported")
+}
+
+func isSlotsNotServedByNode(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "slots are not served by this node")
+}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -182,6 +182,9 @@ func findShardPrimary(state *valkey.ClusterState, shardIndex int, pods *corev1.P
 			continue
 		}
 		for _, shard := range state.Shards {
+			if len(shard.Slots) == 0 {
+				continue
+			}
 			primary := shard.GetPrimaryNode()
 			if primary != nil && primary.Address == p.Status.PodIP {
 				return primary.Id, p.Status.PodIP
@@ -189,4 +192,12 @@ func findShardPrimary(state *valkey.ClusterState, shardIndex int, pods *corev1.P
 		}
 	}
 	return "", ""
+}
+
+func countSlots(ranges []valkey.SlotsRange) int {
+	count := 0
+	for _, slot := range ranges {
+		count += slot.End - slot.Start + 1
+	}
+	return count
 }

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -24,6 +24,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -309,6 +312,115 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 				))
 			}
 			Eventually(verifyCreatedUsers).Should(Succeed())
+		})
+
+		It("rebalances slots on scale out", func() {
+			const baseShards = 2
+			const scaleOutShards = 3
+			valkeyClusterName = "valkeycluster-scaleout"
+
+			By("ensuring the controller pod name is set")
+			cmd := exec.Command("kubectl", "get",
+				"pods", "-l", "control-plane=controller-manager",
+				"-o", "go-template={{ range .items }}"+
+					"{{ if not .metadata.deletionTimestamp }}"+
+					"{{ .metadata.name }}"+
+					"{{ \"\\n\" }}{{ end }}{{ end }}",
+				"-n", namespace,
+			)
+			podOutput, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to retrieve controller-manager pod information")
+			podNames := utils.GetNonEmptyLines(podOutput)
+			Expect(podNames).NotTo(BeEmpty(), "expected a controller pod running")
+
+			By("creating a smaller ValkeyCluster for scale-out")
+			scaleOutManifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  shards: %d
+  replicas: 1
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+`, valkeyClusterName, baseShards)
+			manifestFile := filepath.Join(os.TempDir(), "valkeycluster-scaleout.yaml")
+			err = os.WriteFile(manifestFile, []byte(scaleOutManifest), 0644)
+			Expect(err).NotTo(HaveOccurred(), "Failed to write scale-out manifest file")
+			defer os.Remove(manifestFile)
+
+			cmd = exec.Command("kubectl", "delete", "valkeycluster", valkeyClusterName, "--ignore-not-found=true")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "apply", "-f", manifestFile)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply scale-out ValkeyCluster CR")
+
+			By("waiting for the cluster to be ready before scaling")
+			verifyReadyForScaleOut := func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(valkeyClusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
+				g.Expect(cr.Status.ReadyShards).To(Equal(int32(baseShards)))
+			}
+			Eventually(verifyReadyForScaleOut, 10*time.Minute, 2*time.Second).Should(Succeed())
+
+			By(fmt.Sprintf("scaling the cluster to %d shards", scaleOutShards))
+			cmd = exec.Command("kubectl", "patch", "valkeycluster", valkeyClusterName,
+				"--type=merge", "-p", fmt.Sprintf(`{"spec":{"shards":%d}}`, scaleOutShards))
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to patch ValkeyCluster shards")
+
+			By("verifying all primaries receive slots after scale out")
+			verifySlotRebalance := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", valkeyClusterName),
+					"-o", "jsonpath={.items[0].metadata.name}")
+				podName, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(podName)).NotTo(BeEmpty(), "Expected a valkey pod")
+
+				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "--",
+					"valkey-cli", "-c", "-h", "127.0.0.1", "CLUSTER", "NODES")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				lines := utils.GetNonEmptyLines(output)
+				masterWithSlots := 0
+				for _, line := range lines {
+					fields := strings.Fields(line)
+					if len(fields) < 9 {
+						continue
+					}
+					if !strings.Contains(fields[2], "master") {
+						continue
+					}
+					masterWithSlots++
+				}
+				g.Expect(masterWithSlots).To(Equal(scaleOutShards), "Expected all primaries to own slots after rebalance")
+			}
+			Eventually(verifySlotRebalance, 10*time.Minute, 2*time.Second).Should(Succeed())
+
+			By(fmt.Sprintf("waiting for the cluster to report %d ready shards", scaleOutShards))
+			verifyScaledOut := func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(valkeyClusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.Shards).To(Equal(int32(scaleOutShards)))
+				g.Expect(cr.Status.ReadyShards).To(Equal(int32(scaleOutShards)))
+				g.Expect(cr.Status.State).To(Or(
+					Equal(valkeyiov1alpha1.ClusterStateReady),
+					Equal(valkeyiov1alpha1.ClusterStateReconciling),
+				))
+			}
+			Eventually(verifyScaledOut, 10*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("cleaning up the scale-out cluster")
+			cmd = exec.Command("kubectl", "delete", "valkeycluster", valkeyClusterName, "--wait=false")
+			_, _ = utils.Run(cmd)
 		})
 	})
 


### PR DESCRIPTION
### Summary

- Adds the ability to scale out a ValkeyCluster by increasing `spec.shards`. New shard deployments are created automatically, and hash slots are incrementally migrated from existing primaries to new ones using `CLUSTER MIGRATESLOTS` (with a legacy `MIGRATE` fallback for older Valkey versions).
- Introduces `effectiveShards` to include slot-less pending primaries in health checks and rebalancing decisions, since `GetClusterState` classifies them as `PendingNodes` until they own slots.
- Adds a guard in `findShardPrimary` to skip slot-less shards, preventing replicas from being attached to primaries that haven't received slots yet during scale-out.

### Key changes

**New files:**
- `internal/controller/migration.go` — Slot migration orchestration: `rebalanceSlots` calls `PlanRebalanceMove` each reconcile to compute a single bounded move, checks for in-progress migrations via `CLUSTER GETSLOTMIGRATIONS`, then executes via `CLUSTER MIGRATESLOTS` (atomic) or per-key `MIGRATE` (legacy fallback).
- `internal/controller/replicas.go` — `countSlots` helper for shard slot counting.

**Modified files:**
- `valkeycluster_controller.go` — Reconcile loop now builds `allShards` (effective shards including slot-less scale-out primaries), uses it for health checks and replica count validation, and calls `rebalanceSlots` after health checks pass. `assignSlotsToPendingPrimaries` gracefully returns 0 when no unassigned slots are available (scale-out case).
- `utils.go` — `findShardPrimary` skips shards with 0 slots to prevent premature replication during scale-out.
- `valkeycluster_types.go` — New status reasons: `RebalancingSlots`, `RebalanceFailed`.
- `status-conditions.md` — Documents the new status reasons.

**E2E test:**
- `"scales out by adding a new shard"` — Creates a 2-shard cluster, patches to 3 shards, verifies all 3 primaries own slots, and the cluster reaches Ready state.

### Test plan

- [ ] Unit tests pass (`go test ./internal/valkey/...`)
- [ ] E2E: Scale out from 2 to 3 shards — verify slot redistribution and Ready state
- [ ] E2E: Scale out from 3 to 5 shards — verify rebalancing converges
- [ ] Verify no unnecessary rebalancing during initial cluster creation (±1 tolerance)
- [ ] Verify replicas are not attached until their primary receives slots