### PR TITLE
Add basic reconcile metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/valkey-io/valkey-go v1.0.68
 	go.uber.org/zap v1.27.0
@@ -50,7 +51,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +39,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 	"valkey.io/valkey-operator/internal/valkey"
 )
@@ -50,6 +54,30 @@ const (
 
 	// Error messages
 	statusUpdateFailedMsg = "failed to update status"
+)
+
+var (
+	reconcileDuration = promauto.With(metrics.Registry).NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:                            "valkey_operator_reconcile_duration_seconds",
+			Help:                            "Valkey Operator reconcile duration",
+			Buckets:                         prometheus.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: 1 * time.Hour,
+		},
+		[]string{"controller"},
+	)
+	reconcileErrors = promauto.With(metrics.Registry).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "valkey_operator_reconcile_errors_total",
+			Help: "Number of errors when performing reconcile",
+		},
+		[]string{"controller"},
+	)
+
+	valkeyControllerReconcileDuration = reconcileDuration.WithLabelValues("ValkeyCluster")
+	valkeyControllerReconcileErrors   = reconcileErrors.WithLabelValues("ValkeyCluster")
 )
 
 // ValkeyClusterReconciler reconciles a ValkeyCluster object
@@ -98,6 +126,17 @@ var scripts embed.FS
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.1/pkg/reconcile
 func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	reconcileStart := time.Now()
+	res, err := r.reconcile(ctx, req)
+
+	valkeyControllerReconcileDuration.Observe(time.Since(reconcileStart).Seconds())
+	if err != nil {
+		valkeyControllerReconcileErrors.Inc()
+	}
+	return res, err
+}
+
+func (r *ValkeyClusterReconciler) reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 	log.V(1).Info("reconcile...")
 


### PR DESCRIPTION
Add basic metrics to monitor the reconcile loop.
* Histogram of reconcile timing.
* Counter for errors.
* Wrap the main reconcile function to make capturing the metrics easier.
* Future proof this to be able to handle add new control loops later.