### PR TITLE
Add scale-in support with slot draining

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -167,8 +167,6 @@ const (
 	ReasonRebalancingSlots  = "RebalancingSlots"
 	ReasonRebalanceFailed   = "RebalanceFailed"
 	ReasonUsersAclError     = "UsersACLError"
-	ReasonDrainingSlots     = "DrainingSlots"
-	ReasonDrainFailed       = "DrainFailed"
 )
 
 // +kubebuilder:object:root=true

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -72,8 +72,7 @@ Common reasons:
 - `Initializing` – initial cluster creation
 - `Reconciling` – general reconciliation in progress
 - `AddingNodes` – adding nodes to the cluster
-- `RebalancingSlots` – rebalancing hash slots across primaries
-- `DrainingSlots` – draining hash slots from excess shards during scale-down
+- `RebalancingSlots` – rebalancing hash slots across primaries (scale-out and scale-in)
 - `ReconcileComplete` – reconciliation finished (typically with `status=False`)
 
 #### `Degraded`
@@ -88,8 +87,7 @@ Common reasons:
 - `NodeAddFailed` – failed to add a node to the cluster
 - `PrimaryLost` – primary lost in one or more shards
 - `NoSlotsAvailable` – no unassigned slots available for new shard
-- `RebalanceFailed` – slot rebalancing failed
-- `DrainFailed` – slot draining failed during scale-down
+- `RebalanceFailed` – slot rebalancing failed (scale-out or scale-in)
 
 ---
 
@@ -188,9 +186,9 @@ These events track the formation and changes to the Valkey cluster topology.
 | `ReplicaCreationFailed` | Warning | Replica creation fails |
 | `PrimaryLost` | Warning | Primary is lost in a shard (requires failover) |
 
-### Scale-down events
+### Scale-in events
 
-These events are emitted during scale-down operations.
+These events are emitted during scale-in operations.
 
 | Event Type | Type | Description |
 |---|---|---|

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -91,7 +91,7 @@ var scripts embed.FS
 //     primary-labeled pending nodes via CLUSTER ADDSLOTSRANGE.
 //  8. Phase 3 – Replicate: batch-attach all replica-labeled pending nodes
 //     to their matching primaries via CLUSTER REPLICATE.
-//  9. Scale-down: if the cluster has more shards than desired, drain slots
+//  9. Scale-in: if the cluster has more shards than desired, drain slots
 //     from excess shards via CLUSTER MIGRATESLOTS and delete their
 //     Deployments once fully drained.
 //  10. Verify that the expected number of shards and replicas exist.
@@ -221,8 +221,8 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// and include them as empty shards for health checks and rebalancing.
 	allShards := effectiveShards(state, pods)
 
-	// Handle scale-down: drain excess shards and clean up leftover deployments.
-	if result, done := r.handleScaleDown(ctx, cluster, state, pods); done {
+	// Handle scale-in: drain excess shards and clean up leftover deployments.
+	if result, requeue := r.handleScaleIn(ctx, cluster, state, pods); requeue {
 		return result, nil
 	}
 
@@ -430,9 +430,9 @@ func (r *ValkeyClusterReconciler) upsertDeployments(ctx context.Context, cluster
 	nodesPerShard := 1 + int(cluster.Spec.Replicas)
 	created := 0
 	expected := int(cluster.Spec.Shards) * nodesPerShard
-	for shard := range int(cluster.Spec.Shards) {
-		for ni := range nodesPerShard {
-			if err := r.ensureDeployment(ctx, cluster, shard, ni, expected, &created); err != nil {
+	for shardIndex := range int(cluster.Spec.Shards) {
+		for nodeIndex := range nodesPerShard {
+			if err := r.ensureDeployment(ctx, cluster, shardIndex, nodeIndex, expected, &created); err != nil {
 				return err
 			}
 		}
@@ -885,44 +885,45 @@ func effectiveShards(state *valkey.ClusterState, pods *corev1.PodList) []*valkey
 	return shards
 }
 
-// handleScaleDown drains excess shards and cleans up leftover deployments.
-// Returns (result, true) when the caller should return early.
-func (r *ValkeyClusterReconciler) handleScaleDown(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, state *valkey.ClusterState, pods *corev1.PodList) (ctrl.Result, bool) {
+// handleScaleIn drains excess shards and cleans up leftover deployments.
+// Returns (result, true) when work was done or an error occurred and the
+// caller should requeue instead of continuing to health checks.
+func (r *ValkeyClusterReconciler) handleScaleIn(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, state *valkey.ClusterState, pods *corev1.PodList) (ctrl.Result, bool) {
 	log := logf.FromContext(ctx)
 
 	if len(state.Shards) > int(cluster.Spec.Shards) {
 		drained, err := r.drainExcessShards(ctx, cluster, state, pods)
 		if err != nil {
-			log.Error(err, "scale-down draining failed")
-			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "DrainFailed", "ScaleDown", "Failed to drain excess shards: %v", err)
-			setCondition(cluster, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonDrainFailed, err.Error(), metav1.ConditionTrue)
-			setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonReconciling, "Scaling down cluster", metav1.ConditionFalse)
-			setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonDrainingSlots, "Draining slots from excess shards", metav1.ConditionTrue)
+			log.Error(err, "scale-in draining failed")
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "DrainFailed", "ScaleIn", "Failed to drain excess shards: %v", err)
+			setCondition(cluster, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonRebalanceFailed, err.Error(), metav1.ConditionTrue)
+			setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonReconciling, "Scaling in cluster", metav1.ConditionFalse)
+			setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonRebalancingSlots, "Rebalancing slots for scale-in", metav1.ConditionTrue)
 			_ = r.updateStatus(ctx, cluster, state)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, true
 		}
 		if drained {
 			meta.RemoveStatusCondition(&cluster.Status.Conditions, valkeyiov1alpha1.ConditionDegraded)
-			setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonReconciling, "Scaling down cluster", metav1.ConditionFalse)
-			setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonDrainingSlots, "Draining slots from excess shards", metav1.ConditionTrue)
+			setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonReconciling, "Scaling in cluster", metav1.ConditionFalse)
+			setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonRebalancingSlots, "Rebalancing slots for scale-in", metav1.ConditionTrue)
 			_ = r.updateStatus(ctx, cluster, state)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, true
 		}
 	}
 
-	// Clean up leftover deployments from a previous scale-down where drained
+	// Clean up leftover deployments from a previous scale-in where drained
 	// primaries became replicas before their deployments could be deleted.
-	if cleaned, err := r.deleteExcessDeployments(ctx, cluster); err != nil {
+	if deleted, err := r.deleteExcessDeployments(ctx, cluster); err != nil {
 		log.Error(err, "failed to delete excess deployments")
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, true
-	} else if cleaned {
+	} else if deleted {
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, true
 	}
 
 	return ctrl.Result{}, false
 }
 
-// drainExcessShards handles scale-down by migrating slots away from shards
+// drainExcessShards handles scale-in by migrating slots away from shards
 // whose pod shard-index >= spec.Shards. Once a shard is fully drained (0
 // slots), its deployments are deleted; forgetStaleNodes on the next reconcile
 // cleans up the Valkey topology.
@@ -933,8 +934,8 @@ func (r *ValkeyClusterReconciler) drainExcessShards(ctx context.Context, cluster
 
 	var remaining, draining []*valkey.ShardState
 	for _, shard := range state.Shards {
-		si := shardIndexFromState(shard, pods)
-		if si >= 0 && si < expectedShards {
+		shardIndex := shardIndexFromState(shard, pods)
+		if shardIndex >= 0 && shardIndex < expectedShards {
 			remaining = append(remaining, shard)
 		} else {
 			draining = append(draining, shard)
@@ -968,7 +969,7 @@ func (r *ValkeyClusterReconciler) drainExcessShards(ctx context.Context, cluster
 		}
 
 		log.V(1).Info("draining slots", "src", move.Src.Address, "dst", move.Dst.Address, "slots", len(move.Slots))
-		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "SlotsDraining", "ScaleDown", "Moving %d slots from %s to %s", len(move.Slots), move.Src.Address, move.Dst.Address)
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "SlotsDraining", "ScaleIn", "Moving %d slots from %s to %s", len(move.Slots), move.Src.Address, move.Dst.Address)
 
 		ranges := valkey.SlotsToRanges(move.Slots)
 		if err := valkey.MigrateSlotsAtomic(ctx, move.Src, move.Dst, ranges); err != nil {
@@ -982,13 +983,13 @@ func (r *ValkeyClusterReconciler) drainExcessShards(ctx context.Context, cluster
 
 	// All draining shards have 0 slots — delete their deployments.
 	for _, shard := range draining {
-		si := shardIndexFromState(shard, pods)
-		if si < 0 {
+		shardIndex := shardIndexFromState(shard, pods)
+		if shardIndex < 0 {
 			continue
 		}
 		nodesPerShard := 1 + int(cluster.Spec.Replicas)
-		for ni := range nodesPerShard {
-			name := deploymentName(cluster.Name, si, ni)
+		for nodeIndex := range nodesPerShard {
+			name := deploymentName(cluster.Name, shardIndex, nodeIndex)
 			dep := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -1000,8 +1001,8 @@ func (r *ValkeyClusterReconciler) drainExcessShards(ctx context.Context, cluster
 					return false, fmt.Errorf("delete deployment %s: %w", name, err)
 				}
 			} else {
-				log.V(1).Info("deleted deployment for drained shard", "deployment", name, "shard", si)
-				r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "DeploymentDeleted", "ScaleDown", "Deleted deployment %s (shard %d)", name, si)
+				log.V(1).Info("deleted deployment for drained shard", "deployment", name, "shard", shardIndex)
+				r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "DeploymentDeleted", "ScaleIn", "Deleted deployment %s (shard %d)", name, shardIndex)
 			}
 		}
 	}
@@ -1010,8 +1011,8 @@ func (r *ValkeyClusterReconciler) drainExcessShards(ctx context.Context, cluster
 
 // deleteExcessDeployments removes deployments that are outside the desired
 // spec: shard-index >= spec.Shards OR node-index >= 1 + spec.Replicas.
-// This catches leftover deployments from shard scale-down (where drained
-// primaries became replicas) and from replica scale-down.
+// This catches leftover deployments from shard scale-in (where drained
+// primaries became replicas) and from replica scale-in.
 func (r *ValkeyClusterReconciler) deleteExcessDeployments(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (bool, error) {
 	log := logf.FromContext(ctx)
 	allDeps := &appsv1.DeploymentList{}
@@ -1022,22 +1023,22 @@ func (r *ValkeyClusterReconciler) deleteExcessDeployments(ctx context.Context, c
 	deleted := false
 	for i := range allDeps.Items {
 		dep := &allDeps.Items[i]
-		si, err := strconv.Atoi(dep.Labels[LabelShardIndex])
+		shardIndex, err := strconv.Atoi(dep.Labels[LabelShardIndex])
 		if err != nil {
 			continue
 		}
-		ni, err := strconv.Atoi(dep.Labels[LabelNodeIndex])
+		nodeIndex, err := strconv.Atoi(dep.Labels[LabelNodeIndex])
 		if err != nil {
 			continue
 		}
-		if si >= int(cluster.Spec.Shards) || ni >= nodesPerShard {
+		if shardIndex >= int(cluster.Spec.Shards) || nodeIndex >= nodesPerShard {
 			if err := r.Delete(ctx, dep); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return false, fmt.Errorf("delete excess deployment %s: %w", dep.Name, err)
 				}
 			} else {
-				log.V(1).Info("deleted excess deployment", "name", dep.Name, "shard", si, "node", ni)
-				r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "DeploymentDeleted", "ScaleDown", "Deleted excess deployment %s (shard %d, node %d)", dep.Name, si, ni)
+				log.V(1).Info("deleted excess deployment", "name", dep.Name, "shard", shardIndex, "node", nodeIndex)
+				r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "DeploymentDeleted", "ScaleIn", "Deleted excess deployment %s (shard %d, node %d)", dep.Name, shardIndex, nodeIndex)
 				deleted = true
 			}
 		}
@@ -1049,9 +1050,9 @@ func (r *ValkeyClusterReconciler) deleteExcessDeployments(ctx context.Context, c
 // by matching any of its nodes' addresses to pod labels.
 func shardIndexFromState(shard *valkey.ShardState, pods *corev1.PodList) int {
 	for _, node := range shard.Nodes {
-		_, si := podRoleAndShard(node.Address, pods)
-		if si >= 0 {
-			return si
+		_, shardIndex := podRoleAndShard(node.Address, pods)
+		if shardIndex >= 0 {
+			return shardIndex
 		}
 	}
 	return -1

--- a/internal/valkey/cluster_rebalance.go
+++ b/internal/valkey/cluster_rebalance.go
@@ -112,8 +112,7 @@ func PlanDrainMove(src *ShardState, dsts []*ShardState, maxSlots int) (*SlotMove
 
 	var dstPrimary *NodeState
 	for _, shard := range dsts {
-		if p := shard.GetPrimaryNode(); p != nil {
-			dstPrimary = p
+		if dstPrimary = shard.GetPrimaryNode(); dstPrimary != nil {
 			break
 		}
 	}

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -401,10 +401,10 @@ spec:
 			Eventually(verifyScaledOut).Should(Succeed())
 		})
 
-		It("drains slots on scale down", func() {
+		It("drains slots on scale in", func() {
 			const initialShards = 3
-			const scaleDownShards = 2
-			valkeyClusterName = "valkeycluster-scaledown"
+			const scaleInShards = 2
+			valkeyClusterName = "valkeycluster-scalein"
 
 			By("creating a ValkeyCluster with 3 shards")
 			manifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
@@ -414,15 +414,8 @@ metadata:
 spec:
   shards: %d
   replicas: 1
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "100m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
 `, valkeyClusterName, initialShards)
-			manifestFile := filepath.Join(os.TempDir(), "valkeycluster-scaledown.yaml")
+			manifestFile := filepath.Join(os.TempDir(), "valkeycluster-scalein.yaml")
 			err := os.WriteFile(manifestFile, []byte(manifest), 0644)
 			Expect(err).NotTo(HaveOccurred())
 			defer os.Remove(manifestFile)
@@ -446,13 +439,13 @@ spec:
 			}
 			Eventually(verifyReady, 10*time.Minute, 2*time.Second).Should(Succeed())
 
-			By(fmt.Sprintf("scaling the cluster down to %d shards", scaleDownShards))
+			By(fmt.Sprintf("scaling the cluster in to %d shards", scaleInShards))
 			cmd = exec.Command("kubectl", "patch", "valkeycluster", valkeyClusterName,
-				"--type=merge", "-p", fmt.Sprintf(`{"spec":{"shards":%d}}`, scaleDownShards))
+				"--type=merge", "-p", fmt.Sprintf(`{"spec":{"shards":%d}}`, scaleInShards))
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to patch ValkeyCluster shards")
 
-			By("verifying that only 2 primaries own slots after scale down")
+			By("verifying that only 2 primaries own slots after scale in")
 			verifySlotDrain := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "pods",
 					"-l", fmt.Sprintf("app.kubernetes.io/instance=%s", valkeyClusterName),
@@ -479,9 +472,9 @@ spec:
 						primariesWithSlots++
 					}
 				}
-				g.Expect(primariesWithSlots).To(Equal(scaleDownShards), "Expected only %d primaries to own slots after scale down", scaleDownShards)
+				g.Expect(primariesWithSlots).To(Equal(scaleInShards), "Expected only %d primaries to own slots after scale in", scaleInShards)
 			}
-			Eventually(verifySlotDrain, 10*time.Minute, 2*time.Second).Should(Succeed())
+			Eventually(verifySlotDrain).Should(Succeed())
 
 			By("verifying deployments for excess shard are deleted")
 			verifyDeployments := func(g Gomega) {
@@ -491,20 +484,20 @@ spec:
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 				deployments := utils.GetNonEmptyLines(output)
-				expectedCount := scaleDownShards * (1 + 1) // shards * (1 primary + 1 replica)
+				expectedCount := scaleInShards * (1 + 1) // shards * (1 primary + 1 replica)
 				g.Expect(deployments).To(HaveLen(expectedCount),
-					"Expected %d deployments after scale down, got %d: %v", expectedCount, len(deployments), deployments)
+					"Expected %d deployments after scale in, got %d: %v", expectedCount, len(deployments), deployments)
 			}
-			Eventually(verifyDeployments, 5*time.Minute, 2*time.Second).Should(Succeed())
+			Eventually(verifyDeployments).Should(Succeed())
 
-			By(fmt.Sprintf("waiting for the cluster to report %d ready shards", scaleDownShards))
-			verifyScaledDown := func(g Gomega) {
+			By(fmt.Sprintf("waiting for the cluster to report %d ready shards", scaleInShards))
+			verifyScaledIn := func(g Gomega) {
 				cr, err := utils.GetValkeyClusterStatus(valkeyClusterName)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
-				g.Expect(cr.Status.ReadyShards).To(Equal(int32(scaleDownShards)))
+				g.Expect(cr.Status.ReadyShards).To(Equal(int32(scaleInShards)))
 			}
-			Eventually(verifyScaledDown, 10*time.Minute, 2*time.Second).Should(Succeed())
+			Eventually(verifyScaledIn).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
### Summary

- Adds shard scale-in to the reconcile loop: when `spec.shards` is reduced, excess shards are drained of their hash slots via `CLUSTER MIGRATESLOTS` (batched, atomic, Valkey >= 9.0) and their Deployments are deleted once fully drained. `forgetStaleNodes` on the next reconcile cleans up the Valkey topology.
- Introduces `PlanDrainMove` as the scale-in counterpart to `PlanRebalanceMove`, reusing the same `SlotMove` type, `takeSlotsFromRanges` helper, and migration pipeline (`SlotMigrationInProgress` -> gossip check -> `MigrateSlotsAtomic` -> `IsSlotsNotServedByNode` retry).
- Adds `deleteExcessDeployments` to clean up leftover Deployments from shards or replicas that exceed the desired spec, covering edge cases where drained primaries become replicas before their Deployments are removed.

### Changes

| File | What |
|---|---|
| `api/v1alpha1/valkeycluster_types.go` | New status reasons: `DrainingSlots`, `DrainFailed` |
| `docs/status-conditions.md` | Document new conditions and scale-in events |
| `internal/controller/valkeycluster_controller.go` | Reconcile loop: add drain phase before health checks, `drainExcessShards`, `deleteExcessDeployments`, `shardIndexFromState` |
| `internal/valkey/cluster_rebalance.go` | `PlanDrainMove` — plan a single batched slot move from a draining shard to a remaining shard |
| `internal/valkey/cluster_rebalance_test.go` | Unit tests for `PlanDrainMove` (basic, picks-first-dst, empty-src) |
| `test/e2e/valkeycluster_test.go` | E2E test: create 3-shard cluster, scale to 2, verify slot drain + deployment cleanup + ready status |

### Test plan

- [x] Unit tests pass (`go test ./internal/valkey/... ./internal/controller/...`)
- [x] Manual test: scale 5 -> 4 -> 3 shards, verified all 16384 slots evenly distributed (5462/5461/5461)
- [x] E2E test: `drains slots on scale in` (3 -> 2 shards)