### PR TITLE
Correcting controller-gen version in valkeynodes.valkey.io

### DIFF
--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: valkeynodes.valkey.io
 spec:
   group: valkey.io


### PR DESCRIPTION
Re-running `make manifests` to use version defined in Makefile.
`CONTROLLER_TOOLS_VERSION ?= v0.20.1`