### PR TITLE
feat: proactive failovers before cluster rolls

### DIFF
--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -52,6 +52,7 @@ Common reasons when `Ready=False`:
 - `ServiceError` – failed to create/update headless service
 - `ConfigMapError` – failed to create/update configuration
 - `UsersACLError` – failed to reconcile ACL users/secrets
+- `SystemUsersACLError` – failed to reconcile system/internal ACL users
 - `ValkeyNodeError` – failed to create/update ValkeyNode CRs
 - `ValkeyNodeListError` – failed to list ValkeyNodes
 - `Reconciling` – controller is making changes
@@ -206,6 +207,17 @@ These events are emitted during scale-in operations.
 | `SlotsDraining` | Normal | Slots are being migrated away from a draining shard |
 | `ValkeyNodeDeleted` | Normal | ValkeyNode for a drained shard is deleted |
 | `DrainFailed` | Warning | Failed to drain slots from excess shards |
+
+### Proactive failover events
+
+These events are emitted during proactive primary failovers (e.g., when a primary pod is being replaced due to a rolling update).
+
+| Event Type | Type | Description |
+|---|---|---|
+| `FailoverInitiated` | Normal | A `CLUSTER FAILOVER` command was sent to a replica to take over as primary |
+| `FailoverFailed` | Warning | The `CLUSTER FAILOVER` command returned an error |
+| `FailoverTimeout` | Warning | The failover did not complete within the allowed timeout |
+| `FailoverCompleted` | Normal | The replica has successfully become the new primary |
 
 ### Maintenance events
 

--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/client-go/tools/events"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+	"valkey.io/valkey-operator/internal/valkey"
+)
+
+const (
+	proactiveFailoverTimeout = 10 * time.Second
+	proactiveFailoverPoll    = 1 * time.Second
+
+	eventReasonFailoverInitiated = "FailoverInitiated"
+	eventReasonFailoverFailed    = "FailoverFailed"
+	eventReasonFailoverTimeout   = "FailoverTimeout"
+	eventReasonFailoverCompleted = "FailoverCompleted"
+	eventActionProactiveFailover = "ProactiveFailover"
+)
+
+// findFailoverShard returns the shard and its synced replicas if the node at
+// address is a primary that should be gracefully failed over before being
+// updated, or nil if no failover is needed.
+func findFailoverShard(state *valkey.ClusterState, address string) (*valkey.ShardState, []*valkey.NodeState) {
+	shard := state.FindShardForAddress(address)
+	if shard == nil {
+		return nil, nil
+	}
+	primary := shard.GetPrimaryNode()
+	if primary == nil || primary.Address != address {
+		return nil, nil
+	}
+	replicas := shard.GetSyncedReplicas()
+	if len(replicas) == 0 {
+		return nil, nil
+	}
+	return shard, replicas
+}
+
+// proactiveFailover issues CLUSTER FAILOVER to the best synced replica in shard,
+// then polls until the replica reports role:master or the timeout is reached.
+// shard must be non-nil; replicas must be non-empty.
+func proactiveFailover(ctx context.Context, recorder events.EventRecorder, cluster *valkeyiov1alpha1.ValkeyCluster, shard *valkey.ShardState, replicas []*valkey.NodeState) error {
+	log := logf.FromContext(ctx)
+	primaryAddress := shard.GetPrimaryNode().Address
+
+	// Pick the first synced replica as the failover target. The ordering is
+	// determined by node discovery order — no priority scheme is applied yet.
+	target := replicas[0]
+	log.Info("initiating proactive failover", "shard", shard.Id, "target", target.Address)
+
+	// Emit FailoverInitiated before the command so observers see the event at
+	// the moment the failover begins, not after.
+	recorder.Eventf(cluster, nil, corev1.EventTypeNormal, eventReasonFailoverInitiated, eventActionProactiveFailover, "Initiated failover from %s to %s in shard %s", primaryAddress, target.Address, shard.Id)
+
+	err := target.Client.Do(ctx, target.Client.B().ClusterFailover().Build()).Error()
+	if err != nil {
+		recorder.Eventf(cluster, nil, corev1.EventTypeWarning, eventReasonFailoverFailed, eventActionProactiveFailover, "CLUSTER FAILOVER command failed on %s: %v", target.Address, err)
+		return fmt.Errorf("CLUSTER FAILOVER failed on %s: %w", target.Address, err)
+	}
+
+	timer := time.NewTimer(proactiveFailoverTimeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(proactiveFailoverPoll)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			recorder.Eventf(cluster, nil, corev1.EventTypeWarning, eventReasonFailoverTimeout, eventActionProactiveFailover, "Failover to %s in shard %s did not complete within %s", target.Address, shard.Id, proactiveFailoverTimeout)
+			return fmt.Errorf("failover to %s timed out after %s", target.Address, proactiveFailoverTimeout)
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			info, err := target.Client.Do(ctx, target.Client.B().Info().Section("replication").Build()).ToString()
+			if err != nil {
+				log.V(1).Info("failed to query INFO replication during failover poll", "target", target.Address, "err", err)
+				continue
+			}
+			role := parseValkeyRole(info)
+			if role == RolePrimary {
+				recorder.Eventf(cluster, nil, corev1.EventTypeNormal, eventReasonFailoverCompleted, eventActionProactiveFailover, "Failover completed: %s is now primary in shard %s", target.Address, shard.Id)
+				log.Info("proactive failover completed", "newPrimary", target.Address, "shard", shard.Id)
+				return nil
+			}
+		}
+	}
+}
+
+// nodeRequiresRoll returns true when the node has a running pod whose spec
+// differs from the desired spec, meaning a spec update will trigger a pod roll.
+func nodeRequiresRoll(current *valkeyiov1alpha1.ValkeyNode, desired *valkeyiov1alpha1.ValkeyNode) bool {
+	return current.Status.PodIP != "" && !equality.Semantic.DeepEqual(current.Spec, desired.Spec)
+}
+
+// anyNodeRequiresRoll returns true if any existing ValkeyNode in the list has
+// a spec diff against what the cluster would build for it. Used as a cheap
+// pre-flight check to avoid opening Valkey connections on steady-state reconciles.
+func anyNodeRequiresRoll(cluster *valkeyiov1alpha1.ValkeyCluster, nodeList *valkeyiov1alpha1.ValkeyNodeList) bool {
+	byName := make(map[string]*valkeyiov1alpha1.ValkeyNode, len(nodeList.Items))
+	for i := range nodeList.Items {
+		byName[nodeList.Items[i].Name] = &nodeList.Items[i]
+	}
+	nodesPerShard := 1 + int(cluster.Spec.Replicas)
+	for shardIndex := range int(cluster.Spec.Shards) {
+		for nodeIndex := range nodesPerShard {
+			desired := buildClusterValkeyNode(cluster, shardIndex, nodeIndex)
+			if current, ok := byName[desired.Name]; ok && nodeRequiresRoll(current, desired) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/controller/failover_test.go
+++ b/internal/controller/failover_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+	"valkey.io/valkey-operator/internal/valkey"
+)
+
+func TestFindFailoverShard(t *testing.T) {
+	t.Run("primary with synced replica returns shard", func(t *testing.T) {
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-1",
+					PrimaryId: "node-1",
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "node-1", Flags: []string{"master"}},
+						{Address: "10.0.0.2", Id: "node-2", Flags: []string{"slave"}, Info: map[string]string{"master_link_status": "up"}},
+					},
+				},
+			},
+		}
+		shard, replicas := findFailoverShard(state, "10.0.0.1")
+		assert.NotNil(t, shard)
+		assert.Len(t, replicas, 1)
+	})
+
+	t.Run("replica address returns nil", func(t *testing.T) {
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-1",
+					PrimaryId: "node-1",
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "node-1", Flags: []string{"master"}},
+						{Address: "10.0.0.2", Id: "node-2", Flags: []string{"slave"}, Info: map[string]string{"master_link_status": "up"}},
+					},
+				},
+			},
+		}
+		shard, replicas := findFailoverShard(state, "10.0.0.2")
+		assert.Nil(t, shard)
+		assert.Nil(t, replicas)
+	})
+
+	t.Run("primary with no replicas returns nil", func(t *testing.T) {
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-1",
+					PrimaryId: "node-1",
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "node-1", Flags: []string{"master"}},
+					},
+				},
+			},
+		}
+		shard, replicas := findFailoverShard(state, "10.0.0.1")
+		assert.Nil(t, shard)
+		assert.Nil(t, replicas)
+	})
+
+	t.Run("primary with unsynced replica returns nil", func(t *testing.T) {
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-1",
+					PrimaryId: "node-1",
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "node-1", Flags: []string{"master"}},
+						{Address: "10.0.0.2", Id: "node-2", Flags: []string{"slave"}, Info: map[string]string{"master_link_status": "down"}},
+					},
+				},
+			},
+		}
+		shard, replicas := findFailoverShard(state, "10.0.0.1")
+		assert.Nil(t, shard)
+		assert.Nil(t, replicas)
+	})
+
+	t.Run("unknown address returns nil", func(t *testing.T) {
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-1",
+					PrimaryId: "node-1",
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "node-1", Flags: []string{"master"}},
+					},
+				},
+			},
+		}
+		shard, replicas := findFailoverShard(state, "10.0.0.99")
+		assert.Nil(t, shard)
+		assert.Nil(t, replicas)
+	})
+}
+
+func TestNodeRequiresRoll(t *testing.T) {
+	t.Run("different spec with pod IP requires roll", func(t *testing.T) {
+		current := &valkeyiov1alpha1.ValkeyNode{}
+		current.Spec.Image = "valkey:8.1"
+		current.Status.PodIP = "10.0.0.1"
+		desired := &valkeyiov1alpha1.ValkeyNode{}
+		desired.Spec.Image = "valkey:8.2"
+		assert.True(t, nodeRequiresRoll(current, desired))
+	})
+
+	t.Run("same spec does not require roll", func(t *testing.T) {
+		current := &valkeyiov1alpha1.ValkeyNode{}
+		current.Spec.Image = "valkey:8.1"
+		current.Status.PodIP = "10.0.0.1"
+		desired := &valkeyiov1alpha1.ValkeyNode{}
+		desired.Spec.Image = "valkey:8.1"
+		assert.False(t, nodeRequiresRoll(current, desired))
+	})
+
+	t.Run("different spec but no pod IP does not require roll", func(t *testing.T) {
+		current := &valkeyiov1alpha1.ValkeyNode{}
+		current.Spec.Image = "valkey:8.1"
+		desired := &valkeyiov1alpha1.ValkeyNode{}
+		desired.Spec.Image = "valkey:8.2"
+		assert.False(t, nodeRequiresRoll(current, desired))
+	})
+}

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -128,7 +128,15 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	if requeue, err := r.reconcileValkeyNodes(ctx, cluster); err != nil {
+	nodes := &valkeyiov1alpha1.ValkeyNodeList{}
+	if err := r.List(ctx, nodes, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{LabelCluster: cluster.Name})); err != nil {
+		log.Error(err, "failed to list ValkeyNodes")
+		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeListError, err.Error(), metav1.ConditionFalse)
+		_ = r.updateStatus(ctx, cluster, nil)
+		return ctrl.Result{}, err
+	}
+
+	if requeue, err := r.reconcileValkeyNodes(ctx, cluster, nodes); err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeError, err.Error(), metav1.ConditionFalse)
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
@@ -137,14 +145,6 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonUpdatingNodes, "Updating ValkeyNodes", metav1.ConditionTrue)
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
-	}
-
-	nodes := &valkeyiov1alpha1.ValkeyNodeList{}
-	if err := r.List(ctx, nodes, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{LabelCluster: cluster.Name})); err != nil {
-		log.Error(err, "failed to list ValkeyNodes")
-		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeListError, err.Error(), metav1.ConditionFalse)
-		_ = r.updateStatus(ctx, cluster, nil)
-		return ctrl.Result{}, err
 	}
 	state := r.getValkeyClusterState(ctx, nodes)
 	defer state.CloseClients()
@@ -414,16 +414,28 @@ aclfile /config/users/users.acl`,
 //	mycluster-0-0, mycluster-0-1, mycluster-0-2,
 //	mycluster-1-0, mycluster-1-1, mycluster-1-2,
 //	mycluster-2-0, mycluster-2-1, mycluster-2-2.
-func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (bool, error) {
+func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, nodes *valkeyiov1alpha1.ValkeyNodeList) (bool, error) {
 	log := logf.FromContext(ctx)
 
 	nodesPerShard := 1 + int(cluster.Spec.Replicas)
 	totalCreated := 0
 
+	// Scrape cluster state once for proactive failover decisions, but only
+	// when at least one node actually needs a roll. During initial bootstrap
+	// no nodes exist, so state stays nil. The snapshot is safe to reuse
+	// across the loop because nodes are iterated replicas-first (the primary
+	// is last in each shard), and after an update we requeue immediately,
+	// re-scraping fresh state.
+	var clusterState *valkey.ClusterState
+	if anyNodeRequiresRoll(cluster, nodes) {
+		clusterState = r.getValkeyClusterState(ctx, nodes)
+		defer clusterState.CloseClients()
+	}
+
 	for shardIndex := range int(cluster.Spec.Shards) {
 		// Iterate nodeIndex in reverse order (replicas before primary)
 		for nodeIndex := nodesPerShard - 1; nodeIndex >= 0; nodeIndex-- {
-			requeue, nodeCreated, err := r.reconcileValkeyNode(ctx, cluster, shardIndex, nodeIndex)
+			requeue, nodeCreated, err := r.reconcileValkeyNode(ctx, cluster, shardIndex, nodeIndex, clusterState)
 			if err != nil {
 				return false, err
 			}
@@ -445,7 +457,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 // reconcileValkeyNode reconciles a single ValkeyNode for (shardIndex, nodeIndex).
 // Returns (requeue, nodeCreated, err). requeue signals the caller should stop
 // iterating and wait before processing the next node.
-func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex, nodeIndex int) (bool, bool, error) {
+func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex, nodeIndex int, clusterState *valkey.ClusterState) (bool, bool, error) {
 	log := logf.FromContext(ctx)
 
 	desired := buildClusterValkeyNode(cluster, shardIndex, nodeIndex)
@@ -455,6 +467,27 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, clust
 			Namespace: desired.Namespace,
 		},
 	}
+
+	// Check if proactive failover is needed before updating.
+	if clusterState != nil {
+		current := &valkeyiov1alpha1.ValkeyNode{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(node), current); err != nil {
+			if !apierrors.IsNotFound(err) {
+				log.V(1).Info("could not fetch current ValkeyNode for failover check, skipping",
+					"name", node.Name, "err", err)
+			}
+		} else if nodeRequiresRoll(current, desired) {
+			if shard, replicas := findFailoverShard(clusterState, current.Status.PodIP); shard != nil {
+				log.Info("proactive failover before rolling primary",
+					"name", node.Name, "address", current.Status.PodIP)
+				if err := proactiveFailover(ctx, r.Recorder, cluster, shard, replicas); err != nil {
+					log.Info("proactive failover did not complete, proceeding with roll",
+						"name", node.Name, "err", err)
+				}
+			}
+		}
+	}
+
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, node, func() error {
 		node.Labels = desired.Labels
 		node.Spec = desired.Spec

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -443,12 +443,22 @@ var _ = Describe("reconcileValkeyNodes", func() {
 		return node.Spec.Image
 	}
 
+	// reconcileNodes lists the current ValkeyNodes and calls reconcileValkeyNodes.
+	reconcileNodes := func() (bool, error) {
+		GinkgoHelper()
+		nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+		Expect(k8sClient.List(testCtx, nodeList,
+			client.InNamespace("default"),
+			client.MatchingLabels{LabelCluster: clusterName})).To(Succeed())
+		return r.reconcileValkeyNodes(testCtx, cluster, nodeList)
+	}
+
 	// createAllNodes runs a single reconcile that creates all 4 ValkeyNode CRs.
 	// On first reconcile every position is Created so the loop completes without
 	// triggering an early-exit requeue.
 	createAllNodes := func() {
 		GinkgoHelper()
-		requeue, err := r.reconcileValkeyNodes(testCtx, cluster)
+		requeue, err := reconcileNodes()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse(), "initial create pass must not requeue")
 	}
@@ -474,7 +484,7 @@ var _ = Describe("reconcileValkeyNodes", func() {
 		}
 
 		By("reconciling with no spec change")
-		requeue, err := r.reconcileValkeyNodes(testCtx, cluster)
+		requeue, err := reconcileNodes()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 
@@ -501,7 +511,7 @@ var _ = Describe("reconcileValkeyNodes", func() {
 				rvsBefore[n] = getResourceVersion(n)
 			}
 
-			requeue, err := r.reconcileValkeyNodes(testCtx, cluster)
+			requeue, err := reconcileNodes()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(requeue).To(BeTrue(), "expected requeue after updating %s", name)
 
@@ -532,7 +542,7 @@ var _ = Describe("reconcileValkeyNodes", func() {
 		for _, name := range allNodes {
 			rvsFinal[name] = getResourceVersion(name)
 		}
-		requeue, err := r.reconcileValkeyNodes(testCtx, cluster)
+		requeue, err := reconcileNodes()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 		for _, name := range allNodes {
@@ -549,7 +559,7 @@ var _ = Describe("reconcileValkeyNodes", func() {
 		cluster.Spec.Image = "valkey/valkey:9.1.0"
 
 		By("first reconcile: " + node01 + " (shard 0 replica) is updated and left not-ready")
-		requeue, err := r.reconcileValkeyNodes(testCtx, cluster)
+		requeue, err := reconcileNodes()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue())
 
@@ -563,7 +573,7 @@ var _ = Describe("reconcileValkeyNodes", func() {
 		}
 
 		By("reconciling while " + node01 + " is not ready (and ObservedGeneration is stale): rollout must pause")
-		requeue, err = r.reconcileValkeyNodes(testCtx, cluster)
+		requeue, err = reconcileNodes()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue(), "expected requeue while %s is not ready", node01)
 		for name, rv := range rvOthers {
@@ -575,7 +585,7 @@ var _ = Describe("reconcileValkeyNodes", func() {
 
 		By("marking " + node01 + " ready: rollout resumes and " + node00 + " is updated next")
 		setReady(node01)
-		requeue, err = r.reconcileValkeyNodes(testCtx, cluster)
+		requeue, err = reconcileNodes()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue())
 		Expect(getImage(node00)).To(Equal("valkey/valkey:9.1.0"))
@@ -640,7 +650,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 	}
 
 	It("creates the ValkeyNode and emits ValkeyNodeCreated event", func() {
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 		Expect(created).To(BeTrue())
@@ -651,12 +661,12 @@ var _ = Describe("reconcileValkeyNode", func() {
 	})
 
 	It("updates the ValkeyNode spec, emits ValkeyNodeUpdated event, and signals requeue", func() {
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		cluster.Spec.Image = "valkey/valkey:9.1.0"
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue())
 		Expect(created).To(BeFalse())
@@ -666,25 +676,25 @@ var _ = Describe("reconcileValkeyNode", func() {
 	})
 
 	It("signals requeue when node is unchanged but not yet ready", func() {
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		// Status.Ready defaults to false after creation
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue())
 		Expect(created).To(BeFalse())
 	})
 
 	It("does not requeue when node is unchanged and ready", func() {
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		setNodeReady(true)
 
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 		Expect(created).To(BeFalse())
@@ -692,7 +702,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 
 	It("signals requeue when node is unchanged but ObservedGeneration is stale", func() {
 		// Create the node
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Mark ready but leave ObservedGeneration at 0
@@ -707,7 +717,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 		// Because ObservedGeneration > 0 guard: newly created node with
 		// ObservedGeneration=0 falls through to the Ready check, which
 		// passes (Ready=true). No requeue.
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 		Expect(created).To(BeFalse())
@@ -723,13 +733,13 @@ var _ = Describe("reconcileValkeyNode", func() {
 
 		// Change cluster spec to trigger an update on next reconcile
 		cluster.Spec.Image = "valkey/valkey:9.1.0"
-		requeue, _, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		requeue, _, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue(), "should requeue after updating node")
 
 		// Next reconcile: spec matches (OperationResultNone), but
 		// Generation (2) != ObservedGeneration (1) — must requeue.
-		requeue, created, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex)
+		requeue, created, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue(), "should requeue while ObservedGeneration is stale")
 		Expect(created).To(BeFalse())

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -48,7 +48,7 @@ type ShardState struct {
 	Nodes     []*NodeState
 }
 
-// ShardState represents the current state of a cluster.
+// ClusterState represents the current state of a cluster.
 type ClusterState struct {
 	Shards       []*ShardState
 	PendingNodes []*NodeState
@@ -138,6 +138,19 @@ func (s *ClusterState) GetUnassignedSlots() []SlotsRange {
 	return remaining
 }
 
+// FindShardForAddress returns the shard containing a node with the given IP
+// address, or nil if no shard contains that address.
+func (s *ClusterState) FindShardForAddress(address string) *ShardState {
+	for _, shard := range s.Shards {
+		for _, node := range shard.Nodes {
+			if node.Address == address {
+				return shard
+			}
+		}
+	}
+	return nil
+}
+
 // GetPrimaryNode returns the primary NodeState object
 func (s *ShardState) GetPrimaryNode() *NodeState {
 	idx := slices.IndexFunc(s.Nodes, func(n *NodeState) bool { return n.Id == s.PrimaryId })
@@ -145,6 +158,26 @@ func (s *ShardState) GetPrimaryNode() *NodeState {
 		return s.Nodes[idx]
 	}
 	return nil
+}
+
+// GetSyncedReplicas returns replica nodes that are connected and have their
+// replication link up (master_link_status:up). Nodes with fail/pfail flags
+// are excluded.
+func (s *ShardState) GetSyncedReplicas() []*NodeState {
+	var replicas []*NodeState
+	for _, node := range s.Nodes {
+		if node.Id == s.PrimaryId {
+			continue
+		}
+		if slices.Contains(node.Flags, "fail") || slices.Contains(node.Flags, "pfail") {
+			continue
+		}
+		if node.Info["master_link_status"] != "up" {
+			continue
+		}
+		replicas = append(replicas, node)
+	}
+	return replicas
 }
 
 // GetSlots returns slots assigned to myself, same format as in CLUSTER NODES.

--- a/internal/valkey/clusterstate_test.go
+++ b/internal/valkey/clusterstate_test.go
@@ -115,6 +115,124 @@ func TestSubtractSlotsRange(t *testing.T) {
 	}
 }
 
+func TestClusterState_FindShardForAddress(t *testing.T) {
+	state := &ClusterState{
+		Shards: []*ShardState{
+			{
+				Id:        "shard-1",
+				PrimaryId: "node-1",
+				Nodes: []*NodeState{
+					{Address: "10.0.0.1", Id: "node-1", Flags: []string{"master", "myself"}},
+					{Address: "10.0.0.2", Id: "node-2", Flags: []string{"slave"}},
+				},
+			},
+			{
+				Id:        "shard-2",
+				PrimaryId: "node-3",
+				Nodes: []*NodeState{
+					{Address: "10.0.0.3", Id: "node-3", Flags: []string{"master"}},
+				},
+			},
+		},
+	}
+
+	t.Run("found in first shard", func(t *testing.T) {
+		shard := state.FindShardForAddress("10.0.0.1")
+		if shard == nil || shard.Id != "shard-1" {
+			t.Errorf("expected shard-1, got %v", shard)
+		}
+	})
+
+	t.Run("found replica in first shard", func(t *testing.T) {
+		shard := state.FindShardForAddress("10.0.0.2")
+		if shard == nil || shard.Id != "shard-1" {
+			t.Errorf("expected shard-1, got %v", shard)
+		}
+	})
+
+	t.Run("found in second shard", func(t *testing.T) {
+		shard := state.FindShardForAddress("10.0.0.3")
+		if shard == nil || shard.Id != "shard-2" {
+			t.Errorf("expected shard-2, got %v", shard)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		shard := state.FindShardForAddress("10.0.0.99")
+		if shard != nil {
+			t.Errorf("expected nil, got %v", shard)
+		}
+	})
+}
+
+func TestShardState_GetSyncedReplicas(t *testing.T) {
+	primary := &NodeState{
+		Id:      "primary-id",
+		Address: "10.0.0.1",
+		Flags:   []string{"myself", "master"},
+		Info:    map[string]string{"role": "master"},
+	}
+	syncedReplica := &NodeState{
+		Id:      "replica-1-id",
+		Address: "10.0.0.2",
+		Flags:   []string{"slave"},
+		Info:    map[string]string{"role": "slave", "master_link_status": "up"},
+	}
+	unsyncedReplica := &NodeState{
+		Id:      "replica-2-id",
+		Address: "10.0.0.3",
+		Flags:   []string{"slave"},
+		Info:    map[string]string{"role": "slave", "master_link_status": "down"},
+	}
+	failingReplica := &NodeState{
+		Id:      "replica-3-id",
+		Address: "10.0.0.4",
+		Flags:   []string{"slave", "fail"},
+		Info:    map[string]string{"role": "slave", "master_link_status": "up"},
+	}
+	pfailReplica := &NodeState{
+		Id:      "replica-4-id",
+		Address: "10.0.0.5",
+		Flags:   []string{"slave", "pfail"},
+		Info:    map[string]string{"role": "slave", "master_link_status": "up"},
+	}
+
+	shard := &ShardState{
+		Id:        "shard-0",
+		PrimaryId: "primary-id",
+		Slots:     []SlotsRange{{0, 5461}},
+		Nodes:     []*NodeState{primary, syncedReplica, unsyncedReplica, failingReplica, pfailReplica},
+	}
+
+	replicas := shard.GetSyncedReplicas()
+	if len(replicas) != 1 {
+		t.Fatalf("expected 1 synced replica, got %d", len(replicas))
+	}
+	if replicas[0].Id != "replica-1-id" {
+		t.Errorf("expected replica-1-id, got %s", replicas[0].Id)
+	}
+}
+
+func TestShardState_GetSyncedReplicas_Empty(t *testing.T) {
+	primary := &NodeState{
+		Id:      "primary-id",
+		Address: "10.0.0.1",
+		Flags:   []string{"myself", "master"},
+		Info:    map[string]string{"role": "master"},
+	}
+	shard := &ShardState{
+		Id:        "shard-0",
+		PrimaryId: "primary-id",
+		Slots:     []SlotsRange{{0, 5461}},
+		Nodes:     []*NodeState{primary},
+	}
+
+	replicas := shard.GetSyncedReplicas()
+	if len(replicas) != 0 {
+		t.Fatalf("expected 0 synced replicas, got %d", len(replicas))
+	}
+}
+
 func TestGetUnassignedSlots(t *testing.T) {
 	// A shard with no unassigned slots
 	cluster := ClusterState{


### PR DESCRIPTION
Before a pod is removed, it is first checked if it is currently a primary of a shard. If it is, then it fails over to a healthy replica.

This should help improve the stability of the cluster as rolls are introduced.