### PR TITLE
Add default system users (#110)

### DIFF
--- a/api/v1alpha1/valkeyacls_types.go
+++ b/api/v1alpha1/valkeyacls_types.go
@@ -21,6 +21,7 @@ type UserAclSpec struct {
 
 	// Username
 	// +kubebuilder:required:message=A username is required
+	// +kubebuilder:validation:XValidation:message="Username cannot start with '_'",rule="!self.startsWith('_')"
 	Name string `json:"name"`
 
 	// If the user is enabled or not

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -173,6 +173,7 @@ const (
 	ReasonRebalanceFailed     = "RebalanceFailed"
 	ReasonUsersAclError       = "UsersACLError"
 	ReasonUpdatingNodes       = "UpdatingNodes"
+	ReasonSystemUsersAclError = "SystemUsersACLError"
 )
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -100,7 +100,7 @@ type ExporterSpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Enable or disable the exporter sidecar container
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // ValkeyClusterStatus defines the observed state of ValkeyCluster.

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -100,7 +100,7 @@ type ExporterSpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Enable or disable the exporter sidecar container
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 }
 
 // ValkeyClusterStatus defines the observed state of ValkeyCluster.

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -2566,6 +2566,8 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                required:
+                - enabled
                 type: object
               image:
                 description: Override the default Valkey image

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -2746,6 +2746,9 @@ spec:
                     name:
                       description: Username
                       type: string
+                      x-kubernetes-validations:
+                      - message: Username cannot start with '_'
+                        rule: '!self.startsWith(''_'')'
                     nopass:
                       default: false
                       description: Do not apply a password to this user

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -2566,8 +2566,6 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
-                required:
-                - enabled
                 type: object
               image:
                 description: Override the default Valkey image

--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -2570,6 +2570,8 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                required:
+                - enabled
                 type: object
               image:
                 description: Image is the Valkey container image to use.

--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -2570,8 +2570,6 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
-                required:
-                - enabled
                 type: object
               image:
                 description: Image is the Valkey container image to use.

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: valkey/valkey-operator
+  newTag: v0.0.1

--- a/internal/controller/metrics_exporter.go
+++ b/internal/controller/metrics_exporter.go
@@ -25,7 +25,7 @@ import (
 )
 
 // generateMetricsExporterContainerDef generates the container definition for the metrics exporter sidecar.
-func generateMetricsExporterContainerDef(exporter valkeyiov1alpha1.ExporterSpec, labels map[string]string) corev1.Container {
+func generateMetricsExporterContainerDef(exporter valkeyiov1alpha1.ExporterSpec, clusterName string) corev1.Container {
 	exporterImage := DefaultExporterImage
 	if exporter.Image != "" {
 		exporterImage = exporter.Image
@@ -40,7 +40,7 @@ func generateMetricsExporterContainerDef(exporter valkeyiov1alpha1.ExporterSpec,
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: getSystemPasswordSecretName(labels[LabelCluster]),
+							Name: getSystemPasswordSecretName(clusterName),
 						},
 						Key: exporterUser,
 					},

--- a/internal/controller/metrics_exporter.go
+++ b/internal/controller/metrics_exporter.go
@@ -25,7 +25,7 @@ import (
 )
 
 // generateMetricsExporterContainerDef generates the container definition for the metrics exporter sidecar.
-func generateMetricsExporterContainerDef(exporter valkeyiov1alpha1.ExporterSpec) corev1.Container {
+func generateMetricsExporterContainerDef(exporter valkeyiov1alpha1.ExporterSpec, labels map[string]string) corev1.Container {
 	exporterImage := DefaultExporterImage
 	if exporter.Image != "" {
 		exporterImage = exporter.Image
@@ -33,7 +33,21 @@ func generateMetricsExporterContainerDef(exporter valkeyiov1alpha1.ExporterSpec)
 	return corev1.Container{
 		Name:  "metrics-exporter",
 		Image: exporterImage,
-		Args:  []string{fmt.Sprintf("--redis.addr=localhost:%d", DefaultPort)},
+		Env: []corev1.EnvVar{
+			{Name: "REDIS_USER", Value: exporterUser},
+			{
+				Name: "REDIS_PASSWORD",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: getSystemPasswordSecretName(labels[LabelCluster]),
+						},
+						Key: exporterUser,
+					},
+				},
+			},
+		},
+		Args: []string{fmt.Sprintf("--redis.addr=localhost:%d", DefaultPort)},
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "metrics",

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -41,9 +41,11 @@ const (
 )
 
 var (
+	operatorUser   = "_operator"
+	exporterUser   = "_exporter"
 	systemUsersAcl = map[string]string{
-		"_operator": "+@all",
-		"_exporter": "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
+		operatorUser: "+@all",
+		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
 	}
 )
 
@@ -387,7 +389,7 @@ func createSystemUsersPasswordSecret(ctx context.Context, apiClient client.Clien
 			Namespace: cluster.Namespace,
 			Labels:    labels(cluster),
 			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
+				{
 					Kind: cluster.Kind,
 					Name: cluster.Name,
 					UID:  cluster.UID,
@@ -396,7 +398,7 @@ func createSystemUsersPasswordSecret(ctx context.Context, apiClient client.Clien
 		},
 	}
 
-	for user, _ := range systemUsersAcl {
+	for user := range systemUsersAcl {
 		systemUsersSecret.Data[user] = []byte(generatePassword())
 	}
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -104,7 +104,7 @@ func (r *ValkeyClusterReconciler) findReferencedClusters(ctx context.Context, se
 	return requests
 }
 
-func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
+func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (string, error) {
 	log := logf.FromContext(ctx)
 	log.Info("getting system users secret: " + cluster.Name)
 	var systemsAcls strings.Builder
@@ -116,7 +116,7 @@ func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, c
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "failed to fetch system users secret")
-			return err
+			return "", err
 		}
 		systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, r.Client, cluster)
 
@@ -137,14 +137,8 @@ func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, c
 		}
 		fmt.Fprintf(&systemsAcls, "%s\n", buildUserAcl(userAcl, []string{passwordHash}))
 	}
-	systemUsersAclsBytes := []byte(systemsAcls.String())
 
-	if err := r.upsertInternalAclSecret(ctx, cluster, systemUsersAclsBytes); err != nil {
-		log.Error(err, "failed to reconcile system users ACL")
-		return err
-	}
-
-	return nil
+	return systemsAcls.String(), nil
 }
 
 func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
@@ -171,10 +165,17 @@ func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster
 		acl := buildUserAcl(user, passwords)
 		fmt.Fprintf(&usersAcls, "%s\n", acl)
 	}
+	// append system users ACL
+	systemUsersAcl, err := r.createSystemUsersAcl(ctx, cluster)
+	if err != nil {
+		log.Error(err, "failed to generate system users ACL")
+		return err
+	}
+	fmt.Fprintf(&usersAcls, "%s\n", systemUsersAcl)
 	usersAclsBytes := []byte(usersAcls.String())
 
 	// update the internal ACL secret with the generated users ACLs
-	err := r.upsertInternalAclSecret(ctx, cluster, usersAclsBytes)
+	err = r.upsertInternalAclSecret(ctx, cluster, usersAclsBytes)
 	if err != nil {
 		log.Error(err, "failed to reconcile users ACL")
 		return err
@@ -353,6 +354,7 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 
 func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, aclBytes []byte) error {
 	log := logf.FromContext(ctx)
+	aclHash := fmt.Sprintf("%x", sha256.Sum256(aclBytes))
 	// An "internal" secrets object is used for synchronization
 	internalSecretName := getInternalSecretName(cluster.Name)
 	internalAclSecret := &corev1.Secret{}
@@ -368,8 +370,6 @@ func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, c
 		// Internal secret was not found.
 		// Init, and add metadata to the new Secret object
 		log.V(2).Info("creating internal secret", "secretName", internalSecretName)
-
-		aclHash := fmt.Sprintf("%x", sha256.Sum256(aclBytes))
 
 		internalAclSecret.ObjectMeta = metav1.ObjectMeta{
 			Name:      internalSecretName,
@@ -398,29 +398,29 @@ func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, c
 		}
 
 		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "InternalSecretsCreated", "ReconcileUsers", "Created internal ACLs")
-
-		// All good; new internal Secret with contents created
-
-		// Calculate, and compare the hashes to
-		// determine if anything needs updating. If the hashes are the
-		// same, don't update as that would cause infinite reconciliation
-
-		if !upsertAnnotation(internalAclSecret, hashAnnotationKey, aclHash) {
-			log.V(1).Info("internal ACLs unchanged")
-			return nil
-		}
-
-		// Hashes are different; Update the acl contents of the internal secret
-		internalAclSecret.Data[aclFilename] = aclBytes
-
-		// Update secret
-		if err := r.Update(ctx, internalAclSecret); err != nil {
-			log.Error(err, "Failed to update internal secret")
-			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsUpdateFailed", "ReconcileUsers", "Failed to update internal secret: %v", err)
-			return err
-		}
-
-		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "InternalSecretsUpdated", "ReconcileUsers", "Synchronized internal ACLs")
+		return nil
 	}
+	// All good; new internal Secret with contents created
+
+	// Calculate, and compare the hashes to
+	// determine if anything needs updating. If the hashes are the
+	// same, don't update as that would cause infinite reconciliation
+
+	if !upsertAnnotation(internalAclSecret, hashAnnotationKey, aclHash) {
+		log.V(1).Info("internal ACLs unchanged")
+		return nil
+	}
+
+	// Hashes are different; Update the acl contents of the internal secret
+	internalAclSecret.Data[aclFilename] = aclBytes
+
+	// Update secret
+	if err := r.Update(ctx, internalAclSecret); err != nil {
+		log.Error(err, "Failed to update internal secret")
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsUpdateFailed", "ReconcileUsers", "Failed to update internal secret: %v", err)
+		return err
+	}
+
+	r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "InternalSecretsUpdated", "ReconcileUsers", "Synchronized internal ACLs")
 	return nil
 }

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
 	"sort"
@@ -39,12 +40,23 @@ const (
 	aclFilename       = "users.acl"
 )
 
+var (
+	systemUsersAcl = map[string]string{
+		"_operator": "",
+		"_exporter": "",
+	}
+)
+
 func getInternalSecretName(clusterName string) string {
 	return "internal-" + clusterName + "-acl"
 }
 
 func getDefaultSecretName(clusterName string) string {
 	return clusterName + "-users"
+}
+
+func getSystemPasswordSecretName(clusterName string) string {
+	return "internal-" + clusterName + "-system-passwords"
 }
 
 // When a Secret is updated, Watch() calls this function to discover
@@ -88,6 +100,46 @@ func (r *ValkeyClusterReconciler) findReferencedClusters(ctx context.Context, se
 	}
 
 	return requests
+}
+
+func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
+	log := logf.FromContext(ctx)
+
+	var systemsAcls strings.Builder
+	systemUserSecret := &corev1.Secret{}
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      getSystemPasswordSecretName(cluster.Name),
+	}, systemUserSecret)
+	if err != nil {
+		*systemUserSecret, err = createSystemUsersPasswordSecret(ctx, r.Client, cluster)
+		if err != nil {
+			log.Error(err, "failed to create system user password secret")
+			return err
+		}
+	}
+	for user, acl := range systemUsersAcl {
+		passwordHash := fmt.Sprintf("%x", sha256.Sum256(systemUserSecret.Data[user]))
+		userAcl := valkeyiov1alpha1.UserAclSpec{
+			Name:    user,
+			Enabled: true,
+			RawAcl:  acl,
+			PasswordSecret: valkeyiov1alpha1.PasswordSecretSpec{
+				Name: systemUserSecret.Name,
+				Keys: []string{user},
+			},
+		}
+		fmt.Fprintf(&systemsAcls, "%s\n", buildUserAcl(userAcl, []string{passwordHash}))
+	}
+	systemUsersAclsBytes := []byte(systemsAcls.String())
+
+	err = r.upsertInternalAclSecret(ctx, cluster, systemUsersAclsBytes)
+	if err != nil {
+		log.Error(err, "failed to reconcile system users ACL")
+		return err
+	}
+
+	return nil
 }
 
 func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"math/big"
 	"sort"
 	"strings"
 
@@ -38,6 +39,7 @@ import (
 const (
 	hashAnnotationKey = "valkey.io/internal-acl-hash"
 	aclFilename       = "users.acl"
+	passwordLength    = 26
 )
 
 var (
@@ -324,10 +326,18 @@ func isPreHashedPassword(password []byte) bool {
 	return password[0] == 35 && len(password) == 65
 }
 
-// GeneratePassword creates a random (alphanumeric) 26 chars long password using rand.Text()
-func generatePassword() string {
-	randstr := rand.Text()
-	return randstr
+// GeneratePassword creates a random (alphanumeric) n chars long password
+func generatePassword(length int) ([]byte, error) {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	ret := make([]byte, length)
+	for i := range length {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = letters[num.Int64()]
+	}
+	return ret, nil
 }
 
 func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Context, apiClient client.Client, cluster *valkeyiov1alpha1.ValkeyCluster) (*corev1.Secret, error) {
@@ -351,7 +361,13 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
 			continue
 		}
-		systemUsersSecret.Data[user] = []byte(generatePassword())
+		password, err := generatePassword(passwordLength)
+		if err != nil {
+			log.Error(err, "Failed to generate random password", "username", user)
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to generate random password: %v", err)
+			return &systemUsersSecret, err
+		}
+		systemUsersSecret.Data[user] = password
 	}
 
 	err := apiClient.Create(ctx, &systemUsersSecret)

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -121,6 +121,9 @@ func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, c
 		}
 	}
 	for user, acl := range systemUsersAcl {
+		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
+			continue
+		}
 		passwordHash := fmt.Sprintf("%x", sha256.Sum256(systemUserSecret.Data[user]))
 		userAcl := valkeyiov1alpha1.UserAclSpec{
 			Name:    user,
@@ -366,6 +369,18 @@ func fetchUserPasswords(ctx context.Context, user valkeyiov1alpha1.UserAclSpec, 
 	}
 
 	return passwords, nil
+}
+
+func fetchSystemUserPassword(ctx context.Context, username string, apiClient client.Client, clusterName, clusterNamespace string) (string, error) {
+	systemSecret := &corev1.Secret{}
+	err := apiClient.Get(ctx, types.NamespacedName{
+		Namespace: clusterNamespace,
+		Name:      getSystemPasswordSecretName(clusterName),
+	}, systemSecret)
+	if err != nil {
+		return "", err
+	}
+	return string(systemSecret.Data[username]), nil
 }
 
 // Check if byte-string begins with # (byte 35) and is 65 total characters long.

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -41,9 +41,10 @@ const (
 )
 
 var (
-	operatorUser   = "_operator"
-	exporterUser   = "_exporter"
-	systemUsersAcl = map[string]string{
+	operatorUser    = "_operator"
+	exporterUser    = "_exporter"
+	systemUsers     = []string{operatorUser, exporterUser}
+	systemUsersAcls = map[string]string{
 		operatorUser: "+@all",
 		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
 	}
@@ -121,7 +122,7 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 		systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, r.Client, cluster)
 
 	}
-	for user, acl := range systemUsersAcl {
+	for _, user := range systemUsers {
 		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
 			continue
 		}
@@ -129,7 +130,7 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 		userAcl := valkeyiov1alpha1.UserAclSpec{
 			Name:    user,
 			Enabled: true,
-			RawAcl:  acl,
+			RawAcl:  systemUsersAcls[user],
 			PasswordSecret: valkeyiov1alpha1.PasswordSecretSpec{
 				Name: systemUserSecret.Name,
 				Keys: []string{user},
@@ -244,7 +245,6 @@ func fetchUserPasswords(ctx context.Context, user valkeyiov1alpha1.UserAclSpec, 
 	if user.NoPassword {
 		return []string{}, nil
 	}
-
 	// Look for a Secret matching the user-provided name, or clusterName-users
 	userSecretName := getDefaultSecretName(clusterName)
 	if user.PasswordSecret.Name != "" {
@@ -261,7 +261,7 @@ func fetchUserPasswords(ctx context.Context, user valkeyiov1alpha1.UserAclSpec, 
 			log.Error(err, "failed to fetch acl secret")
 			return []string{}, err
 		}
-		log.V(1).Info("Users secret not found", "userSecretName", userSecretName)
+		log.V(1).Info("Users secret not found", "userSecretName", userSecretName, "user", user.Name)
 
 		// The Secret was not found; And since NoPassword is false, then we cannot add this user
 		return []string{}, fmt.Errorf("no password or reference found")
@@ -344,7 +344,7 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 		r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to grab ownership of system users secret: %v", err)
 		return &systemUsersSecret, err
 	}
-	for user := range systemUsersAcl {
+	for _, user := range systemUsers {
 		systemUsersSecret.Data[user] = []byte(generatePassword())
 	}
 
@@ -410,7 +410,6 @@ func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, c
 		log.V(1).Info("internal ACLs unchanged")
 		return nil
 	}
-
 	// Hashes are different; Update the acl contents of the internal secret
 	internalAclSecret.Data[aclFilename] = aclBytes
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -116,6 +116,7 @@ func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster
 	}
 	usersAclsBytes := []byte(usersAcls.String())
 
+<<<<<<< HEAD
 	// Calculate hash of the ACL file contents
 	internalAclHash := fmt.Sprintf("%x", sha256.Sum256(usersAclsBytes))
 
@@ -184,11 +185,14 @@ func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster
 	if err := r.Update(ctx, internalAclSecret); err != nil {
 		log.Error(err, "Failed to update internal secret")
 		r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsUpdateFailed", "ReconcileUsers", "Failed to update internal secret: %v", err)
+=======
+	// update the internal ACL secret with the generated users ACLs
+	err := r.upsertInternalAclSecret(ctx, cluster, usersAclsBytes)
+	if err != nil {
+		log.Error(err, "failed to reconcile users ACL")
+>>>>>>> 5f787ba (add func upsertInternalAclSecret)
 		return err
 	}
-
-	r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "InternalSecretsUpdated", "ReconcileUsers", "Synchronized internal ACLs")
-
 	// All is good; The internal secret will be auto-mounted in the deployment
 	return nil
 }
@@ -314,4 +318,109 @@ func fetchUserPasswords(ctx context.Context, user valkeyiov1alpha1.UserAclSpec, 
 // If so, we assume this is a pre-hashed sha256 password.
 func isPreHashedPassword(password []byte) bool {
 	return password[0] == 35 && len(password) == 65
+}
+
+func generatePassword() string {
+	randstr := rand.Text()
+	// hasher := sha256.New()
+	// hasher.Write([]byte(randstr))
+	// hashBytes := hasher.Sum(nil)
+	return randstr
+}
+
+func createSystemUsersPasswordSecret(ctx context.Context, apiClient client.Client, cluster *valkeyiov1alpha1.ValkeyCluster) (corev1.Secret, error) {
+	systemUsersSecret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getSystemPasswordSecretName(cluster.Name),
+			Namespace: cluster.Namespace,
+			Labels:    labels(cluster),
+			OwnerReferences: []metav1.OwnerReference{
+				metav1.OwnerReference{
+					Kind: cluster.Kind,
+					Name: cluster.Name,
+					UID:  cluster.UID,
+				},
+			},
+		},
+	}
+
+	for user, _ := range systemUsersAcl {
+		systemUsersSecret.Data[user] = []byte(generatePassword())
+	}
+
+	err := apiClient.Create(ctx, &systemUsersSecret)
+	return systemUsersSecret, err
+}
+
+func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, aclBytes []byte) error {
+	log := logf.FromContext(ctx)
+	// An "internal" secrets object is used for synchronization
+	internalSecretName := getInternalSecretName(cluster.Name)
+	internalAclSecret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      internalSecretName,
+		Namespace: cluster.Namespace,
+	}, internalAclSecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to fetch internal acl secret")
+			return err
+		}
+
+		// Internal secret was not found.
+		// Init, and add metadata to the new Secret object
+		log.V(2).Info("creating internal secret", "secretName", internalSecretName)
+
+		internalAclSecret.ObjectMeta = metav1.ObjectMeta{
+			Name:      internalSecretName,
+			Namespace: cluster.Namespace,
+			Labels:    labels(cluster),
+			// Annotations: map[string]string{
+			// hashAnnotationKey: internalAclHash,
+			// },
+		}
+		// internalAclSecret.Data = map[string][]byte{
+		// aclFilename: usersAclsBytes,
+		// }
+
+		// Register ownership of the new internal Secret
+		if err := controllerutil.SetControllerReference(cluster, internalAclSecret, r.Scheme); err != nil {
+			log.Error(err, "Failed to grab ownership of internal secret")
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to grab ownership of internal secret: %v", err)
+			return err
+		}
+
+		// Create the internal Secret
+		if err := r.Create(ctx, internalAclSecret); err != nil {
+			log.Error(err, "Failed to create internal secret")
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to create internal secret: %v", err)
+			return err
+		}
+
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "InternalSecretsCreated", "ReconcileUsers", "Created internal ACLs")
+
+		// All good; new internal Secret with contents created
+
+		// Calculate, and compare the hashes to
+		// determine if anything needs updating. If the hashes are the
+		// same, don't update as that would cause infinite reconciliation
+
+		aclHash := fmt.Sprintf("%x", sha256.Sum256(aclBytes))
+		if !upsertAnnotation(internalAclSecret, hashAnnotationKey, aclHash) {
+			log.V(1).Info("internal ACLs unchanged")
+			return nil
+		}
+
+		// Hashes are different; Update the acl contents of the internal secret
+		internalAclSecret.Data[aclFilename] = aclBytes
+
+		// Update secret
+		if err := r.Update(ctx, internalAclSecret); err != nil {
+			log.Error(err, "Failed to update internal secret")
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsUpdateFailed", "ReconcileUsers", "Failed to update internal secret: %v", err)
+			return err
+		}
+
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "InternalSecretsUpdated", "ReconcileUsers", "Synchronized internal ACLs")
+	}
+	return nil
 }

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -42,8 +42,8 @@ const (
 
 var (
 	systemUsersAcl = map[string]string{
-		"_operator": "",
-		"_exporter": "",
+		"_operator": "+@all",
+		"_exporter": "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
 	}
 )
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -45,7 +45,9 @@ var (
 	exporterUser    = "_exporter"
 	systemUsers     = []string{operatorUser, exporterUser}
 	systemUsersAcls = map[string]string{
+		// TODO: tighten the permission for the operator user
 		operatorUser: "+@all",
+		// the ACL rawstring for exporter is taken from the redis_exporter documentation: https://github.com/oliver006/redis_exporter#authenticating-with-redis
 		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
 	}
 )
@@ -322,11 +324,9 @@ func isPreHashedPassword(password []byte) bool {
 	return password[0] == 35 && len(password) == 65
 }
 
+// GeneratePassword creates a random (alphanumeric) 26 chars long password using rand.Text()
 func generatePassword() string {
 	randstr := rand.Text()
-	// hasher := sha256.New()
-	// hasher.Write([]byte(randstr))
-	// hashBytes := hasher.Sum(nil)
 	return randstr
 }
 
@@ -348,6 +348,9 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 		return &systemUsersSecret, err
 	}
 	for _, user := range systemUsers {
+		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
+			continue
+		}
 		systemUsersSecret.Data[user] = []byte(generatePassword())
 	}
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -106,7 +106,7 @@ func (r *ValkeyClusterReconciler) findReferencedClusters(ctx context.Context, se
 
 func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
 	log := logf.FromContext(ctx)
-
+	log.Info("getting system users secret: " + cluster.Name)
 	var systemsAcls strings.Builder
 	systemUserSecret := &corev1.Secret{}
 	err := r.Client.Get(ctx, types.NamespacedName{
@@ -114,11 +114,12 @@ func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, c
 		Name:      getSystemPasswordSecretName(cluster.Name),
 	}, systemUserSecret)
 	if err != nil {
-		*systemUserSecret, err = createSystemUsersPasswordSecret(ctx, r.Client, cluster)
-		if err != nil {
-			log.Error(err, "failed to create system user password secret")
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to fetch system users secret")
 			return err
 		}
+		systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, r.Client, cluster)
+
 	}
 	for user, acl := range systemUsersAcl {
 		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
@@ -138,8 +139,7 @@ func (r *ValkeyClusterReconciler) reconcileSystemUsersAcl(ctx context.Context, c
 	}
 	systemUsersAclsBytes := []byte(systemsAcls.String())
 
-	err = r.upsertInternalAclSecret(ctx, cluster, systemUsersAclsBytes)
-	if err != nil {
+	if err := r.upsertInternalAclSecret(ctx, cluster, systemUsersAclsBytes); err != nil {
 		log.Error(err, "failed to reconcile system users ACL")
 		return err
 	}
@@ -173,81 +173,10 @@ func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster
 	}
 	usersAclsBytes := []byte(usersAcls.String())
 
-<<<<<<< HEAD
-	// Calculate hash of the ACL file contents
-	internalAclHash := fmt.Sprintf("%x", sha256.Sum256(usersAclsBytes))
-
-	// An "internal" secrets object is used for synchronization
-	internalSecretName := getInternalSecretName(cluster.Name)
-	internalAclSecret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{
-		Name:      internalSecretName,
-		Namespace: cluster.Namespace,
-	}, internalAclSecret); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.Error(err, "failed to fetch internal acl secret")
-			return err
-		}
-
-		// Internal secret was not found.
-		// Init, and add metadata to the new Secret object
-		log.V(2).Info("creating internal secret", "secretName", internalSecretName)
-
-		internalAclSecret.ObjectMeta = metav1.ObjectMeta{
-			Name:      internalSecretName,
-			Namespace: cluster.Namespace,
-			Labels:    labels(cluster),
-			Annotations: map[string]string{
-				hashAnnotationKey: internalAclHash,
-			},
-		}
-		internalAclSecret.Data = map[string][]byte{
-			aclFilename: usersAclsBytes,
-		}
-		internalAclSecret.Type = AclSecretType
-
-		// Register ownership of the new internal Secret
-		if err := controllerutil.SetControllerReference(cluster, internalAclSecret, r.Scheme); err != nil {
-			log.Error(err, "Failed to grab ownership of internal secret")
-			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to grab ownership of internal secret: %v", err)
-			return err
-		}
-
-		// Create the internal Secret
-		if err := r.Create(ctx, internalAclSecret); err != nil {
-			log.Error(err, "Failed to create internal secret")
-			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to create internal secret: %v", err)
-			return err
-		}
-
-		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "InternalSecretsCreated", "ReconcileUsers", "Created internal ACLs")
-
-		// All good; new internal Secret with contents created
-		return nil
-	}
-
-	// Internal Secret exists; Calculate, and compare the hashes to
-	// determine if anything needs updating. If the hashes are the
-	// same, don't update as that would cause infinite reconciliation
-
-	if !upsertAnnotation(internalAclSecret, hashAnnotationKey, internalAclHash) {
-		log.V(1).Info("internal ACLs unchanged")
-		return nil
-	}
-
-	// Hashes are different; Update the acl contents of the internal secret
-	internalAclSecret.Data[aclFilename] = usersAclsBytes
-
-	// Update secret
-	if err := r.Update(ctx, internalAclSecret); err != nil {
-		log.Error(err, "Failed to update internal secret")
-		r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsUpdateFailed", "ReconcileUsers", "Failed to update internal secret: %v", err)
-=======
 	// update the internal ACL secret with the generated users ACLs
 	err := r.upsertInternalAclSecret(ctx, cluster, usersAclsBytes)
 	if err != nil {
 		log.Error(err, "failed to reconcile users ACL")
->>>>>>> 5f787ba (add func upsertInternalAclSecret)
 		return err
 	}
 	// All is good; The internal secret will be auto-mounted in the deployment
@@ -397,28 +326,29 @@ func generatePassword() string {
 	return randstr
 }
 
-func createSystemUsersPasswordSecret(ctx context.Context, apiClient client.Client, cluster *valkeyiov1alpha1.ValkeyCluster) (corev1.Secret, error) {
+func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Context, apiClient client.Client, cluster *valkeyiov1alpha1.ValkeyCluster) (*corev1.Secret, error) {
+	log := logf.FromContext(ctx)
+
 	systemUsersSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getSystemPasswordSecretName(cluster.Name),
 			Namespace: cluster.Namespace,
 			Labels:    labels(cluster),
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind: cluster.Kind,
-					Name: cluster.Name,
-					UID:  cluster.UID,
-				},
-			},
 		},
+		Data: map[string][]byte{},
 	}
-
+	// Register ownership of the new internal Secret
+	if err := controllerutil.SetControllerReference(cluster, &systemUsersSecret, r.Scheme); err != nil {
+		log.Error(err, "Failed to grab ownership of system users secret")
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to grab ownership of system users secret: %v", err)
+		return &systemUsersSecret, err
+	}
 	for user := range systemUsersAcl {
 		systemUsersSecret.Data[user] = []byte(generatePassword())
 	}
 
 	err := apiClient.Create(ctx, &systemUsersSecret)
-	return systemUsersSecret, err
+	return &systemUsersSecret, err
 }
 
 func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, aclBytes []byte) error {
@@ -439,17 +369,19 @@ func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, c
 		// Init, and add metadata to the new Secret object
 		log.V(2).Info("creating internal secret", "secretName", internalSecretName)
 
+		aclHash := fmt.Sprintf("%x", sha256.Sum256(aclBytes))
+
 		internalAclSecret.ObjectMeta = metav1.ObjectMeta{
 			Name:      internalSecretName,
 			Namespace: cluster.Namespace,
 			Labels:    labels(cluster),
-			// Annotations: map[string]string{
-			// hashAnnotationKey: internalAclHash,
-			// },
+			Annotations: map[string]string{
+				hashAnnotationKey: aclHash,
+			},
 		}
-		// internalAclSecret.Data = map[string][]byte{
-		// aclFilename: usersAclsBytes,
-		// }
+		internalAclSecret.Data = map[string][]byte{
+			aclFilename: aclBytes,
+		}
 
 		// Register ownership of the new internal Secret
 		if err := controllerutil.SetControllerReference(cluster, internalAclSecret, r.Scheme); err != nil {
@@ -473,7 +405,6 @@ func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, c
 		// determine if anything needs updating. If the hashes are the
 		// same, don't update as that would cause infinite reconciliation
 
-		aclHash := fmt.Sprintf("%x", sha256.Sum256(aclBytes))
 		if !upsertAnnotation(internalAclSecret, hashAnnotationKey, aclHash) {
 			log.V(1).Info("internal ACLs unchanged")
 			return nil

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -110,7 +110,7 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 	log.Info("getting system users secret: " + cluster.Name)
 	var systemsAcls strings.Builder
 	systemUserSecret := &corev1.Secret{}
-	err := r.Client.Get(ctx, types.NamespacedName{
+	err := r.Get(ctx, types.NamespacedName{
 		Namespace: cluster.Namespace,
 		Name:      getSystemPasswordSecretName(cluster.Name),
 	}, systemUserSecret)
@@ -120,7 +120,10 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 			return "", err
 		}
 		systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, r.Client, cluster)
-
+		if err != nil {
+			log.Error(err, "failed to create system user secret")
+			return "", err
+		}
 	}
 	for _, user := range systemUsers {
 		if user == exporterUser && !cluster.Spec.Exporter.Enabled {

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -385,6 +385,7 @@ func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, c
 		internalAclSecret.Data = map[string][]byte{
 			aclFilename: aclBytes,
 		}
+		internalAclSecret.Type = AclSecretType
 
 		// Register ownership of the new internal Secret
 		if err := controllerutil.SetControllerReference(cluster, internalAclSecret, r.Scheme); err != nil {

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -344,6 +344,7 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 	log := logf.FromContext(ctx)
 
 	systemUsersSecret := corev1.Secret{
+		Type: AclSecretType,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getSystemPasswordSecretName(cluster.Name),
 			Namespace: cluster.Namespace,

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -122,6 +122,11 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	if err := r.reconcileSystemUsersAcl(ctx, cluster); err != nil {
+		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonSystemUsersAclError, err.Error(), metav1.ConditionFalse)
+		return ctrl.Result{}, err
+	}
+
 	if err := r.reconcileUsersAcl(ctx, cluster); err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonUsersAclError, err.Error(), metav1.ConditionFalse)
 		return ctrl.Result{}, err

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -152,6 +152,12 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 	operatorPassword, err := fetchSystemUserPassword(ctx, operatorUser, r.Client, cluster.Name, cluster.Namespace)
+	if err != nil {
+		log.Error(err, "failed to retrieve system user password")
+		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonSystemUsersAclError, err.Error(), metav1.ConditionFalse)
+		_ = r.updateStatus(ctx, cluster, nil)
+		return ctrl.Result{}, nil
+	}
 	state := r.getValkeyClusterState(ctx, nodes, operatorUser, operatorPassword)
 	defer state.CloseClients()
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -156,7 +156,8 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
 	}
-	state := r.getValkeyClusterState(ctx, nodes)
+	operatorPassword, err := fetchSystemUserPassword(ctx, operatorUser, r.Client, cluster.Name, cluster.Namespace)
+	state := r.getValkeyClusterState(ctx, nodes, operatorUser, operatorPassword)
 	defer state.CloseClients()
 
 	r.forgetStaleNodes(ctx, cluster, state, nodes)
@@ -543,7 +544,7 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 	}
 }
 
-func (r *ValkeyClusterReconciler) getValkeyClusterState(ctx context.Context, nodes *valkeyiov1alpha1.ValkeyNodeList) *valkey.ClusterState {
+func (r *ValkeyClusterReconciler) getValkeyClusterState(ctx context.Context, nodes *valkeyiov1alpha1.ValkeyNodeList, username, password string) *valkey.ClusterState {
 	ips := []string{}
 	for _, node := range nodes.Items {
 		if node.Status.PodIP == "" {
@@ -551,7 +552,7 @@ func (r *ValkeyClusterReconciler) getValkeyClusterState(ctx context.Context, nod
 		}
 		ips = append(ips, node.Status.PodIP)
 	}
-	return valkey.GetClusterState(ctx, ips, DefaultPort)
+	return valkey.GetClusterState(ctx, ips, DefaultPort, username, password)
 }
 
 // findMeetTarget picks the best node to MEET all isolated nodes against.
@@ -1138,6 +1139,7 @@ func (r *ValkeyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&valkeyiov1alpha1.ValkeyNode{}).
+		Owns(&corev1.Secret{}).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findReferencedClusters),

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -122,11 +122,6 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcileSystemUsersAcl(ctx, cluster); err != nil {
-		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonSystemUsersAclError, err.Error(), metav1.ConditionFalse)
-		return ctrl.Result{}, err
-	}
-
 	if err := r.reconcileUsersAcl(ctx, cluster); err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonUsersAclError, err.Error(), metav1.ConditionFalse)
 		return ctrl.Result{}, err

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -115,7 +115,8 @@ func (r *ValkeyNodeReconciler) ensureStatefulSet(ctx context.Context, node *valk
 			Namespace: desired.Namespace,
 		},
 	}
-	aclSecretName := getInternalSecretName(desired.Labels["app.kubernetes.io/instance"])
+	log.V(1).Info("getting internal secret", "node-labels", desired.Labels)
+	aclSecretName := getInternalSecretName(desired.Labels[LabelCluster])
 	aclSecret := &corev1.Secret{}
 	err = r.Get(ctx, types.NamespacedName{
 		Name:      aclSecretName,
@@ -152,7 +153,8 @@ func (r *ValkeyNodeReconciler) ensureDeployment(ctx context.Context, node *valke
 			Namespace: desired.Namespace,
 		},
 	}
-	aclSecretName := getInternalSecretName(desired.Labels["app.kubernetes.io/instance"])
+	log.V(1).Info("getting internal secret", "node-labels", desired.Labels)
+	aclSecretName := getInternalSecretName(desired.Labels[LabelCluster])
 	aclSecret := &corev1.Secret{}
 	err = r.Get(ctx, types.NamespacedName{
 		Name:      aclSecretName,

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,9 +116,21 @@ func (r *ValkeyNodeReconciler) ensureStatefulSet(ctx context.Context, node *valk
 			Namespace: desired.Namespace,
 		},
 	}
+	aclSecretName := getInternalSecretName(node.Labels[LabelCluster])
+	aclSecret := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      aclSecretName,
+		Namespace: node.Namespace,
+	}, aclSecret)
+	if err != nil {
+		return err
+	}
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, sts, func() error {
 		sts.Labels = desired.Labels
 		sts.Spec = desired.Spec
+		sts.Spec.Template.Annotations = map[string]string{
+			hashAnnotationKey: aclSecret.Annotations[hashAnnotationKey],
+		}
 		return controllerutil.SetControllerReference(node, sts, r.Scheme)
 	})
 	if err != nil {
@@ -140,9 +153,22 @@ func (r *ValkeyNodeReconciler) ensureDeployment(ctx context.Context, node *valke
 			Namespace: desired.Namespace,
 		},
 	}
+	aclSecretName := getInternalSecretName(node.Labels[LabelCluster])
+	aclSecret := &corev1.Secret{}
+	err = r.Get(ctx, types.NamespacedName{
+		Name:      aclSecretName,
+		Namespace: node.Namespace,
+	}, aclSecret)
+	if err != nil {
+		return err
+	}
+
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, dep, func() error {
 		dep.Labels = desired.Labels
 		dep.Spec = desired.Spec
+		dep.Spec.Template.Annotations = map[string]string{
+			hashAnnotationKey: aclSecret.Annotations[hashAnnotationKey],
+		}
 		return controllerutil.SetControllerReference(node, dep, r.Scheme)
 	})
 	if err != nil {

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -69,7 +69,6 @@ func (r *ValkeyNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err := r.Get(ctx, req.NamespacedName, node); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-
 	if err := r.ensureConfigMap(ctx, node); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -116,11 +115,11 @@ func (r *ValkeyNodeReconciler) ensureStatefulSet(ctx context.Context, node *valk
 			Namespace: desired.Namespace,
 		},
 	}
-	aclSecretName := getInternalSecretName(node.Labels[LabelCluster])
+	aclSecretName := getInternalSecretName(desired.Labels["app.kubernetes.io/instance"])
 	aclSecret := &corev1.Secret{}
 	err = r.Get(ctx, types.NamespacedName{
 		Name:      aclSecretName,
-		Namespace: node.Namespace,
+		Namespace: desired.Namespace,
 	}, aclSecret)
 	if err != nil {
 		return err
@@ -153,11 +152,11 @@ func (r *ValkeyNodeReconciler) ensureDeployment(ctx context.Context, node *valke
 			Namespace: desired.Namespace,
 		},
 	}
-	aclSecretName := getInternalSecretName(node.Labels[LabelCluster])
+	aclSecretName := getInternalSecretName(desired.Labels["app.kubernetes.io/instance"])
 	aclSecret := &corev1.Secret{}
 	err = r.Get(ctx, types.NamespacedName{
 		Name:      aclSecretName,
-		Namespace: node.Namespace,
+		Namespace: desired.Namespace,
 	}, aclSecret)
 	if err != nil {
 		return err

--- a/internal/controller/valkeynode_controller_test.go
+++ b/internal/controller/valkeynode_controller_test.go
@@ -63,6 +63,9 @@ var _ = Describe("ValkeyNode Controller", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      resourceName,
 						Namespace: "default",
+						Labels: map[string]string{
+							LabelCluster: resourceName,
+						},
 					},
 					Spec: valkeyiov1alpha1.ValkeyNodeSpec{
 						WorkloadType: valkeyiov1alpha1.WorkloadTypeStatefulSet,
@@ -207,7 +210,13 @@ var _ = Describe("ValkeyNode Controller", func() {
 			err := k8sClient.Get(ctx, typeNamespacedName, node)
 			if err != nil && apierrors.IsNotFound(err) {
 				Expect(k8sClient.Create(ctx, &valkeyiov1alpha1.ValkeyNode{
-					ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: "default"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: "default",
+						Labels: map[string]string{
+							LabelCluster: resourceName,
+						},
+					},
 					Spec: valkeyiov1alpha1.ValkeyNodeSpec{
 						WorkloadType: valkeyiov1alpha1.WorkloadTypeDeployment,
 					},

--- a/internal/controller/valkeynode_controller_test.go
+++ b/internal/controller/valkeynode_controller_test.go
@@ -49,6 +49,10 @@ var _ = Describe("ValkeyNode Controller", func() {
 			Name:      "valkey-" + resourceName,
 			Namespace: "default",
 		}
+		secretName := types.NamespacedName{
+			Name:      getInternalSecretName(resourceName),
+			Namespace: "default",
+		}
 
 		BeforeEach(func() {
 			By("creating the custom resource for the Kind ValkeyNode")
@@ -66,6 +70,19 @@ var _ = Describe("ValkeyNode Controller", func() {
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
+			By("creating the ACL secret")
+			secret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, secretName, secret)
+			if err != nil && apierrors.IsNotFound(err) {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getInternalSecretName(resourceName),
+						Namespace: "default",
+					},
+					Type: AclSecretType,
+				}
+				Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			}
 		})
 
 		AfterEach(func() {
@@ -82,6 +99,10 @@ var _ = Describe("ValkeyNode Controller", func() {
 			node := &valkeyiov1alpha1.ValkeyNode{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, node)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, node)).To(Succeed())
+
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, secretName, secret)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
 		})
 
 		It("should create a ConfigMap and StatefulSet on first reconcile", func() {
@@ -179,6 +200,7 @@ var _ = Describe("ValkeyNode Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{Name: resourceName, Namespace: "default"}
 		childName := types.NamespacedName{Name: "valkey-" + resourceName, Namespace: "default"}
+		secretName := types.NamespacedName{Name: getInternalSecretName(resourceName), Namespace: "default"}
 
 		BeforeEach(func() {
 			node := &valkeyiov1alpha1.ValkeyNode{}
@@ -190,6 +212,15 @@ var _ = Describe("ValkeyNode Controller", func() {
 						WorkloadType: valkeyiov1alpha1.WorkloadTypeDeployment,
 					},
 				})).To(Succeed())
+			}
+			secret := &corev1.Secret{}
+			err = k8sClient.Get(ctx, secretName, secret)
+			if err != nil && apierrors.IsNotFound(err) {
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: getInternalSecretName(resourceName), Namespace: "default"},
+					Type:       AclSecretType,
+				}
+				Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 			}
 		})
 
@@ -205,6 +236,9 @@ var _ = Describe("ValkeyNode Controller", func() {
 			node := &valkeyiov1alpha1.ValkeyNode{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, node)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, node)).To(Succeed())
+			secret := &corev1.Secret{}
+			Expect(k8sClient.Get(ctx, secretName, secret)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
 		})
 
 		It("should create a Deployment and no StatefulSet", func() {

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -216,7 +216,7 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 
 	// Add exporter sidecar if enabled.
 	if node.Spec.Exporter.Enabled {
-		containers = append(containers, generateMetricsExporterContainerDef(node.Spec.Exporter))
+		containers = append(containers, generateMetricsExporterContainerDef(node.Spec.Exporter, node.Labels))
 	}
 
 	return mergePatchContainers(containers, node.Spec.Containers)

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -216,7 +216,7 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 
 	// Add exporter sidecar if enabled.
 	if node.Spec.Exporter.Enabled {
-		containers = append(containers, generateMetricsExporterContainerDef(node.Spec.Exporter, node.Labels))
+		containers = append(containers, generateMetricsExporterContainerDef(node.Spec.Exporter, node.Labels[LabelCluster]))
 	}
 
 	return mergePatchContainers(containers, node.Spec.Containers)

--- a/internal/controller/valkeynode_resources_test.go
+++ b/internal/controller/valkeynode_resources_test.go
@@ -422,14 +422,14 @@ func TestParseValkeyRole(t *testing.T) {
 func TestBuildExporterContainer(t *testing.T) {
 	t.Run("default image", func(t *testing.T) {
 		exporter := valkeyv1.ExporterSpec{Enabled: true}
-		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
+		c := generateMetricsExporterContainerDef(exporter, "")
 		assert.Equal(t, DefaultExporterImage, c.Image)
 		assert.Equal(t, "metrics-exporter", c.Name)
 	})
 
 	t.Run("custom image", func(t *testing.T) {
 		exporter := valkeyv1.ExporterSpec{Enabled: true, Image: "custom:1.0"}
-		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
+		c := generateMetricsExporterContainerDef(exporter, "")
 		assert.Equal(t, "custom:1.0", c.Image)
 	})
 
@@ -440,13 +440,13 @@ func TestBuildExporterContainer(t *testing.T) {
 			},
 		}
 		exporter := valkeyv1.ExporterSpec{Enabled: true, Resources: resources}
-		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
+		c := generateMetricsExporterContainerDef(exporter, "")
 		assert.Equal(t, resources, c.Resources)
 	})
 
 	t.Run("args contain redis addr", func(t *testing.T) {
 		exporter := valkeyv1.ExporterSpec{Enabled: true}
-		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
+		c := generateMetricsExporterContainerDef(exporter, "")
 		require.Len(t, c.Args, 1)
 		assert.Contains(t, c.Args[0], "--redis.addr=localhost:6379")
 	})

--- a/internal/controller/valkeynode_resources_test.go
+++ b/internal/controller/valkeynode_resources_test.go
@@ -422,14 +422,14 @@ func TestParseValkeyRole(t *testing.T) {
 func TestBuildExporterContainer(t *testing.T) {
 	t.Run("default image", func(t *testing.T) {
 		exporter := valkeyv1.ExporterSpec{Enabled: true}
-		c := generateMetricsExporterContainerDef(exporter)
+		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
 		assert.Equal(t, DefaultExporterImage, c.Image)
 		assert.Equal(t, "metrics-exporter", c.Name)
 	})
 
 	t.Run("custom image", func(t *testing.T) {
 		exporter := valkeyv1.ExporterSpec{Enabled: true, Image: "custom:1.0"}
-		c := generateMetricsExporterContainerDef(exporter)
+		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
 		assert.Equal(t, "custom:1.0", c.Image)
 	})
 
@@ -440,13 +440,13 @@ func TestBuildExporterContainer(t *testing.T) {
 			},
 		}
 		exporter := valkeyv1.ExporterSpec{Enabled: true, Resources: resources}
-		c := generateMetricsExporterContainerDef(exporter)
+		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
 		assert.Equal(t, resources, c.Resources)
 	})
 
 	t.Run("args contain redis addr", func(t *testing.T) {
 		exporter := valkeyv1.ExporterSpec{Enabled: true}
-		c := generateMetricsExporterContainerDef(exporter)
+		c := generateMetricsExporterContainerDef(exporter, map[string]string{})
 		require.Len(t, c.Args, 1)
 		assert.Contains(t, c.Args[0], "--redis.addr=localhost:6379")
 	})

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -64,7 +64,7 @@ type SlotsRange struct {
 }
 
 // GetClusterState connects to Valkey nodes and scrapes the current state.
-func GetClusterState(ctx context.Context, addresses []string, port int) *ClusterState {
+func GetClusterState(ctx context.Context, addresses []string, port int, username, password string) *ClusterState {
 	state := ClusterState{
 		Shards:       make([]*ShardState, 0),
 		PendingNodes: make([]*NodeState, 0),
@@ -72,7 +72,7 @@ func GetClusterState(ctx context.Context, addresses []string, port int) *Cluster
 
 	for _, address := range addresses {
 		// Attempt to connect to the Valkey node and extract information.
-		node := getNodeState(ctx, address, port)
+		node := getNodeState(ctx, address, port, username, password)
 		if node != nil {
 			// Check if node is pending to be added.
 			if node.IsPrimary() && len(node.GetSlots()) == 0 {
@@ -215,12 +215,14 @@ func (n *NodeState) GetFailingNodes() []NodeState {
 }
 
 // Connect to a single Valkey node and scrapes its current state.
-func getNodeState(ctx context.Context, address string, port int) *NodeState {
+func getNodeState(ctx context.Context, address string, port int, username string, password string) *NodeState {
 	log := logf.FromContext(ctx)
 
 	opt := vclient.ClientOption{
 		InitAddress:       []string{fmt.Sprintf("%s:%d", address, port)},
 		ForceSingleClient: true, // Don't connect to another cluster node.
+		Username:          username,
+		Password:          password,
 	}
 
 	client, err := vclient.NewClient(opt)

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -231,7 +231,7 @@ func getNodeState(ctx context.Context, address string, port int, username string
 			return nil
 		}
 		// fallback to unauthenticated
-		log.V(1).Info("fall back to unauthenticated default user on WRONGPASS error")
+		log.Info("fall back to unauthenticated default user on WRONGPASS error")
 		opt.Username = ""
 		opt.Password = ""
 		client, err = vclient.NewClient(opt)

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -224,10 +224,9 @@ func getNodeState(ctx context.Context, address string, port int, username string
 		Username:          username,
 		Password:          password,
 	}
-
 	client, err := vclient.NewClient(opt)
 	if err != nil {
-		log.Info("failed to create Valkey client", "err", err)
+		log.Error(err, "failed to create Valkey client")
 		return nil
 	}
 

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -226,8 +226,19 @@ func getNodeState(ctx context.Context, address string, port int, username string
 	}
 	client, err := vclient.NewClient(opt)
 	if err != nil {
-		log.Error(err, "failed to create Valkey client")
-		return nil
+		if !strings.Contains(err.Error(), "WRONGPASS") {
+			log.Error(err, "failed to create Valkey client")
+			return nil
+		}
+		// fallback to unauthenticated
+		log.V(1).Info("fall back to unauthenticated default user on WRONGPASS error")
+		opt.Username = ""
+		opt.Password = ""
+		client, err = vclient.NewClient(opt)
+		if err != nil {
+			log.Error(err, "failed to create Valkey client")
+			return nil
+		}
 	}
 
 	node := NodeState{Client: client,

--- a/test/e2e/metrics_exporter_test.go
+++ b/test/e2e/metrics_exporter_test.go
@@ -361,13 +361,18 @@ spec:
 			By("Waiting for pod to be running")
 			Eventually(func(g Gomega) {
 				args := []string{
-					"get", "pods", "-l", "valkey.io/cluster=" + valkeyName,
-					"-o", "jsonpath={.items[0].status.phase}",
+					"get", "pods",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", valkeyName),
+					"-o", "go-template={{ range .items }}{{ range .status.conditions }}" +
+						"{{ if and (eq .type \"Ready\") (eq .status \"True\")}}" +
+						"{{ $.metadata.name}} {{ \"\\n\" }}" +
+						"{{ end }}{{ end }}{{ end }}",
 				}
 				cmd := exec.Command("kubectl", args...)
-				out, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod status")
-				g.Expect(out).To(Equal("Running"), "Pod should be running")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				podStatuses := utils.GetNonEmptyLines(output)
+				g.Expect(podStatuses).To(HaveLen(1), "Expected Pod to be ready")
 			}).Should(Succeed())
 
 			By("verifying created users")

--- a/test/e2e/metrics_exporter_test.go
+++ b/test/e2e/metrics_exporter_test.go
@@ -285,7 +285,7 @@ spec:
 		})
 	})
 
-	Context("Metrics Exporter Disabled", func() {
+	Context("Metrics Exporter Disabled", Label("metrics-exporter", "disabled"), func() {
 		It("should deploy ValkeyCluster without metrics exporter when disabled", func() {
 			valkeyName := "valkeycluster-no-exporter"
 			// Create ValkeyCluster YAML with exporter explicitly disabled
@@ -320,6 +320,16 @@ spec:
 				out, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "ValkeyNodes not found")
 				g.Expect(out).To(ContainSubstring(valkeyName))
+			}).Should(Succeed())
+
+			By("Verifying the exporter user password is not created")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secret", "internal-"+valkeyName+"-system-passwords",
+					"-o", "jsonpath={.data._exporter}",
+				)
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "system user password secret not found")
+				g.Expect(out).To(Equal(""), "_exporter password is created")
 			}).Should(Succeed())
 
 			By("Verifying pod has only 1 container (server)")
@@ -359,6 +369,34 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod status")
 				g.Expect(out).To(Equal("Running"), "Pod should be running")
 			}).Should(Succeed())
+
+			By("verifying created users")
+			verifyCreatedUsers := func(g Gomega) {
+				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyName)
+
+				cmd := exec.Command("kubectl", "run", "client",
+					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",
+					"valkey-cli", "-c", "-h", clusterFqdn, "ACL", "LIST")
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "wait", "pod/client",
+					"--for=jsonpath={.status.phase}=Succeeded", "--timeout=30s")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "logs", "client")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "delete", "pod", "client",
+					"--wait=true", "--timeout=30s")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(output).NotTo(ContainSubstring("user _exporter"))
+			}
+			Eventually(verifyCreatedUsers).Should(Succeed())
 
 			By("Cleaning up test resources")
 			cmd = exec.Command("kubectl", "delete", "valkeycluster", valkeyName, "--ignore-not-found=true")

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -82,6 +82,21 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 			}
 			Eventually(verifyConfigMapExists).Should(Succeed())
 
+			By("validating the system user ACLs")
+			verifySystemUserAcls := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secret",
+					"internal-"+valkeyClusterName+"-system-passwords",
+					"-o", "jsonpath={.data}",
+				)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "Failed to retrieve system user ACLs secret")
+				g.Expect(output).To(SatisfyAll(
+					ContainSubstring("_operator"),
+					ContainSubstring("_exporter"),
+				))
+			}
+			Eventually(verifySystemUserAcls).Should(Succeed())
+
 			By("validating ValkeyNodes")
 			verifyValkeyNodesExist := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "valkeynodes",
@@ -234,6 +249,7 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 				g.Expect(output).To(ContainSubstring("ServiceCreated"), "ServiceCreated event should appear in describe")
 				g.Expect(output).To(ContainSubstring("ConfigMapCreated"), "ConfigMapCreated event should appear in describe")
 				g.Expect(output).To(ContainSubstring("ValkeyNodeCreated"), "ValkeyNodeCreated event should appear in describe")
+				g.Expect(output).To(ContainSubstring("InternalSecretsCreated"), "InternalSecretsCreated event should appear in describe")
 				// PrimaryCreated, ClusterMeetBatch, ReplicaCreated and ClusterReady may not always
 				// appear in describe output due to rate-limiting (see kubernetes/kubernetes#136061).
 				// We verify these through cluster status instead of strictly requiring the events.
@@ -269,7 +285,47 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 				g.Expect(output).To(ContainSubstring("cluster_state:ok"))
 			}
 			Eventually(verifyClusterAccess).Should(Succeed())
+			By("get the original ACL hash")
+			cmd = exec.Command("kubectl", "get", "pod",
+				"-o", "jsonpath={.items[0].metadata.annotations.valkey\\.io/internal-acl-hash}",
+			)
+			aclHash, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
 
+			By("delete system users password secret")
+			secretName := "internal-" + valkeyClusterName + "-system-passwords"
+			cmd = exec.Command("kubectl", "delete", "secret", secretName)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("validating system users passwords secret is recreated if deleted")
+			verifySecretRecreation := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secret", secretName)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			Eventually(verifySecretRecreation).Should(Succeed())
+
+			By("validating valkey-operator fallback to default user")
+			verifyAuthFallback := func(g Gomega) {
+				cmd := exec.Command("kubectl", "logs",
+					"-n", namespace, "-l", "app.kubernetes.io/name=valkey-operator")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(ContainSubstring("fall back to unauthenticated default user on WRONGPASS error"))
+			}
+			Eventually(verifyAuthFallback).Should(Succeed())
+
+			By("validating pod is recreated with new ACL")
+			verifyPodRoll := func(g Gomega) {
+				cmd = exec.Command("kubectl", "get", "pod",
+					"-o", "jsonpath={.items[0].metadata.annotations.valkey\\.io/internal-acl-hash}",
+				)
+				newAclHash, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(newAclHash).NotTo(Equal(aclHash))
+			}
+			Eventually(verifyPodRoll, 5*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
 		It("creates a cluster with custom users", func() {
@@ -332,6 +388,8 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 					ContainSubstring("user alice on"),
 					ContainSubstring("user bob on nopass"),
 					ContainSubstring("user david on"),
+					ContainSubstring("user _exporter on"),
+					ContainSubstring("user _operator on"),
 				))
 			}
 			Eventually(verifyCreatedUsers).Should(Succeed())

--- a/test/e2e/valkeynode_test.go
+++ b/test/e2e/valkeynode_test.go
@@ -44,21 +44,36 @@ var _ = Describe("ValkeyNode", func() {
 	// createStandaloneValkeyNode applies a ValkeyNode manifest and returns a cleanup func.
 	// workloadType must be "StatefulSet" or "Deployment".
 	createStandaloneValkeyNode := func(name, workloadType string) func() {
+		// create the internal ACL secret
+		secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+type: valkey.io/acl
+metadata:
+  name: internal-%s-acl
+`, name)
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(secretManifest)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create internal ACL secret internal-%s-acl", name)
 		manifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
 kind: ValkeyNode
 metadata:
   name: %s
+  labels:
+    valkey.io/cluster: %s
 spec:
   workloadType: %s
-`, name, workloadType)
+`, name, name, workloadType)
 
-		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
 		cmd.Stdin = strings.NewReader(manifest)
-		_, err := utils.Run(cmd)
+		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create ValkeyNode %s", name)
 
 		return func() {
 			cmd := exec.Command("kubectl", "delete", "valkeynode", name, "--ignore-not-found=true", "--wait=false")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "secret", "internal-"+name+"-acl", "--ignore-not-found=true", "--wait=false")
 			_, _ = utils.Run(cmd)
 		}
 	}
@@ -72,7 +87,7 @@ spec:
 		}).Should(Succeed())
 	}
 
-	Context("standalone StatefulSet", func() {
+	Context("standalone StatefulSet", Label("valkeynode"), func() {
 		const nodeName = "valkeynode-sts-e2e"
 
 		It("creates owned resources and populates status with role", func() {
@@ -146,7 +161,7 @@ spec:
 		})
 	})
 
-	Context("standalone Deployment", func() {
+	Context("standalone Deployment", Label("valkeynode"), func() {
 		const nodeName = "valkeynode-deploy-e2e"
 
 		It("creates owned resources and populates status with role", func() {
@@ -201,7 +216,7 @@ spec:
 		})
 	})
 
-	Context("pod deletion recovery", func() {
+	Context("pod deletion recovery", Label("valkeynode"), func() {
 		const nodeName = "valkeynode-recovery-e2e"
 
 		It("status tracks pod lifecycle and recovers after pod deletion", func() {
@@ -240,7 +255,7 @@ spec:
 		})
 	})
 
-	Context("external ConfigMap", func() {
+	Context("external ConfigMap", Label("valkeynode", "external-cm"), func() {
 		const nodeName = "valkeynode-extcm-e2e"
 		const cmName = "valkeynode-extcm-scripts"
 
@@ -280,13 +295,26 @@ data:
 			}()
 
 			By("creating a ValkeyNode that references the external ConfigMap")
+			secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+type: valkey.io/acl
+metadata:
+  name: internal-%s-acl
+`, nodeName)
+
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(secretManifest)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create internal ACL secret")
 			nodeManifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
 kind: ValkeyNode
 metadata:
   name: %s
+  labels:
+    valkey.io/cluster: %s
 spec:
   scriptsConfigMapName: %s
-`, nodeName, cmName)
+`, nodeName, nodeName, cmName)
 
 			cmd = exec.Command("kubectl", "apply", "-f", "-")
 			cmd.Stdin = strings.NewReader(nodeManifest)
@@ -294,6 +322,8 @@ spec:
 			Expect(err).NotTo(HaveOccurred(), "Failed to create ValkeyNode with external ConfigMap")
 			defer func() {
 				cmd := exec.Command("kubectl", "delete", "valkeynode", nodeName, "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "internal-"+nodeName+"-acl", "--ignore-not-found=true", "--wait=false")
 				_, _ = utils.Run(cmd)
 			}()
 


### PR DESCRIPTION
implements #110
- add defaults system users `_operator`  and `_exporter`
    - update `GetClusterState`, `GetNodeState` functions to connect to Valkey using `_operator` user
    - fall back to `default` (unauthenticated on WRONGPASS error) 
    - `metrics-exporter` container will connect using `_exporter` user (by setting `REDIS_USER`, `REDIS_PASSWORD` env variables)
- add CEL validation to reject users with named started with `_`
- add ACL hash annotation to pod template, when the internal ACL secret (`internal-<clusterName>-acl`) changed, the pods will be recreated automatically