### PR TITLE
fix: allow slot assignment for single-node clusters (#131)

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -652,10 +652,14 @@ func (r *ValkeyClusterReconciler) assignSlotsToPendingPrimaries(ctx context.Cont
 	//    MEET'd yet and must go through Phase 1 first. Without this guard
 	//    a single pod that starts before its peers would get slots while
 	//    isolated, creating a disconnected shard primary.
+	//    Exception: when the entire expected cluster is a single node
+	//    (1 shard, 0 replicas), isolation is the permanent correct state,
+	//    there is nobody to MEET, so the guard is skipped.
 	//  - post-failover replacements whose shard already has a live primary.
+	isSingleNodeCluster := shardsRequired == 1 && cluster.Spec.Replicas == 0
 	primaries := make([]*valkey.NodeState, 0, len(state.PendingNodes))
 	for _, node := range state.PendingNodes {
-		if node.IsIsolated() {
+		if node.IsIsolated() && !isSingleNodeCluster {
 			continue
 		}
 		role, shardIndex := nodeRoleAndShard(node.Address, nodes)

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -328,6 +328,86 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 			Eventually(verifyPodRoll, 5*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
+		It("creates a single-shard zero-replica cluster", Label("single-node"), func() {
+			const singleNodeClusterName = "cluster-single-node"
+
+			defer func() {
+				cmd := exec.Command("kubectl", "delete", "valkeycluster", singleNodeClusterName, "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+			}()
+
+			By("creating the CR with 1 shard and 0 replicas")
+			manifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  shards: 1
+  replicas: 0
+`, singleNodeClusterName)
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(manifest)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create single-node ValkeyCluster CR")
+
+			By("validating ValkeyNodes")
+			verifyValkeyNodesExist := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "valkeynodes",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", singleNodeClusterName),
+					"-o", "go-template={{ range .items }}{{ .metadata.name }}{{ \"\\n\" }}{{ end }}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				nodes := utils.GetNonEmptyLines(output)
+				g.Expect(nodes).To(HaveLen(1), "Expected 1 ValkeyNode")
+			}
+			Eventually(verifyValkeyNodesExist).Should(Succeed())
+
+			By("validating the ValkeyCluster CR reaches Ready state")
+			verifyCrStatus := func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(singleNodeClusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
+				g.Expect(cr.Status.Shards).To(Equal(int32(1)))
+				g.Expect(cr.Status.ReadyShards).To(Equal(int32(1)))
+
+				slotsAssignedCond := utils.FindCondition(cr.Status.Conditions, valkeyiov1alpha1.ConditionSlotsAssigned)
+				g.Expect(slotsAssignedCond).NotTo(BeNil(), "SlotsAssigned condition not found")
+				g.Expect(slotsAssignedCond.Status).To(Equal(metav1.ConditionTrue))
+			}
+			Eventually(verifyCrStatus, 5*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("validating cluster access")
+			verifyClusterAccess := func(g Gomega) {
+				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", singleNodeClusterName)
+
+				cmd := exec.Command("kubectl", "run", "client",
+					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",
+					"valkey-cli", "-c", "-h", clusterFqdn, "CLUSTER", "INFO")
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "wait", "pod/client",
+					"--for=jsonpath={.status.phase}=Succeeded", "--timeout=30s")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "logs", "client")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "delete", "pod", "client",
+					"--wait=true", "--timeout=30s")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(output).To(ContainSubstring("cluster_state:ok"))
+				g.Expect(output).To(ContainSubstring("cluster_slots_assigned:16384"))
+				g.Expect(output).To(ContainSubstring("cluster_size:1"))
+			}
+			Eventually(verifyClusterAccess).Should(Succeed())
+		})
+
 		It("creates a cluster with custom users", func() {
 			const withUserClusterName = "cluster-sample-with-users"
 			const withUserSampleFile = "config/samples/v1alpha1_valkeycluster-with-user.yaml"


### PR DESCRIPTION
This PR closes #131

### Summary
A `ValkeyCluster` with 1 shard and 0 replicas gets stuck in an infinite reconciliation loop because `assignSlotsToPendingPrimaries()` skips isolated nodes, and a single-node cluster is permanently isolated with no peer to MEET.
This causes an infinite reconciliation loop 
```
2026-04-09T04:22:11Z    DEBUG   reconcile...    {"controller": "valkeycluster", "controllerGroup": "valkey.io", "controllerKind": "ValkeyCluster", "ValkeyCluster": {"name":"no-exporter","namespace":"default"}, "namespace": "default", "name": "no-exporter", "reconcileID": "21da6899-0e2a-44a3-a233-d0c40bad9f29"}
2026-04-09T04:22:11Z    DEBUG   internal ACLs unchanged {"controller": "valkeycluster", "controllerGroup": "valkey.io", "controllerKind": "ValkeyCluster", "ValkeyCluster": {"name":"no-exporter","namespace":"default"}, "namespace": "default", "name": "no-exporter", "reconcileID": "21da6899-0e2a-44a3-a233-d0c40bad9f29"}
2026-04-09T04:22:11Z    DEBUG   slots are not assigned, requeue..       {"controller": "valkeycluster", "controllerGroup": "valkey.io", "controllerKind": "ValkeyCluster", "ValkeyCluster": {"name":"no-exporter","namespace":"default"}, "namespace": "default", "name": "no-exporter", "reconcileID": "21da6899-0e2a-44a3-a233-d0c40bad9f29", "unassignedSlots": [{"Start":0,"End":16383}]}
2026-04-09T04:22:13Z    DEBUG   reconcile...    {"controller": "valkeycluster", "controllerGroup": "valkey.io", "controllerKind": "ValkeyCluster", "ValkeyCluster": {"name":"no-exporter","namespace":"default"}, "namespace": "default", "name": "no-exporter", "reconcileID": "25ddac3d-2eb1-4032-ae07-8a7767e7a842"}
2026-04-09T04:22:13Z    DEBUG   internal ACLs unchanged {"controller": "valkeycluster", "controllerGroup": "valkey.io", "controllerKind": "ValkeyCluster", "ValkeyCluster": {"name":"no-exporter","namespace":"default"}, "namespace": "default", "name": "no-exporter", "reconcileID": "25ddac3d-2eb1-4032-ae07-8a7767e7a842"}
2026-04-09T04:22:13Z    DEBUG   slots are not assigned, requeue..       {"controller": "valkeycluster", "controllerGroup": "valkey.io", "controllerKind": "ValkeyCluster", "ValkeyCluster": {"name":"no-exporter","namespace":"default"}, "namespace": "default", "name": "no-exporter", "reconcileID": "25ddac3d-2eb1-4032-ae07-8a7767e7a842", "unassignedSlots": [{"Start":0,"End":16383}]}
2026-04-09T04:22:15Z    DEBUG   reconcile...    {"controller": "valkeycluster", "controllerGroup": "valkey.io", "controllerKind": "ValkeyCluster", "ValkeyCluster": {"name":"no-exporter","namespace":"default"}, "namespace": "default", "name": "no-exporter", "reconcileID": "9baa0b13-b2ea-4494-a697-3610196f39de"}
<repeating ad infinitum>
```

It seems there's a deadlock between `meetIsolatedNodes()` and `assignSlotsToPendingPrimaries()`

When a single node starts up with `cluster_known_nodes = 1`, it's considered "isolated".

1. [`meetIsolatedNodes()`](https://github.com/valkey-io/valkey-operator/blob/5b9adec/internal/controller/valkeycluster_controller.go#L611-L613) picks a meet target via `findMeetTarget()`. Since there are no non-isolated nodes, it falls back to `isolated[0]` aka the only
   node. Then because `meetTarget == isolated[0]`, the node is removed from the list. The loop iterates over an empty slice, where no MEET is issued at any point in time.

2. [`assignSlotsToPendingPrimaries()`](https://github.com/valkey-io/valkey-operator/blob/5b9adec/internal/controller/valkeycluster_controller.go#L658-L659) skips isolated nodes (`cluster_known_nodes <= 1`). Since no MEET happened, `cluster_known_nodes` is still 1, the
   node is skipped and no slots are assigned.

3. The reconciler sees unassigned slots and requeues forever.

IIUC the isolation guard exists to prevent a pod in a multi-node cluster from getting slots before it's been introduced to its peers. But in a single-node cluster (1 shard, 0 replicas), isolation is the permanent correct state, there's no other node to MEET.

### Implementation

I considered fixing this in `meetIsolatedNodes()` itself, but that's a dead end.Even if we made the single node attempt to MEET itself, `CLUSTER MEET` with your own address is a no-op so that wouldn't help.

The simpler fix is in `assignSlotsToPendingPrimaries()`. If the whole cluster is one node, isolation is the correct permanent state and there's nothing to protect against.

### Testing

- E2e test added for single-shard zero-replica cluster creation, validating the cluster reaches Ready with all 16384 slots assigned 
- Tested locally (with an E2E as well), reloaded a new image with the fix while having reproduced the initial bug and the single node cluster came up:
```
 ༼ つ ▀_▀ ༽つ  ~  src  valkey-ope  k get valkeycluster                                                                                                                                       fix/single-shard-slot-assignment  3✎  2+  ⎈ kind-valkey-repro  22:19:07
NAME          STATE         REASON        AGE
single-node   Reconciling   Reconciling   10m
 ༼ つ ▀_▀ ༽つ  ~  src  valkey-ope  k get valkeycluster                                                                                                                                       fix/single-shard-slot-assignment  3✎  2+  ⎈ kind-valkey-repro  22:19:30
NAME          STATE   REASON           AGE
single-node   Ready   ClusterHealthy   10m
```
