### PR TITLE
fix: tighten _operator user ACL permissions (#132)

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -47,8 +47,20 @@ var (
 	exporterUser    = "_exporter"
 	systemUsers     = []string{operatorUser, exporterUser}
 	systemUsersAcls = map[string]string{
-		// TODO: tighten the permission for the operator user
-		operatorUser: "+@all",
+		operatorUser: strings.Join([]string{
+			"+@connection",               // client handshake (CLIENT TRACKING, SETINFO, AUTH, PING)
+			"+cluster|myid",              // get node ID
+			"+cluster|myshardid",         // get shard ID
+			"+cluster|info",              // cluster state
+			"+cluster|nodes",             // cluster topology
+			"+cluster|meet",              // introduce nodes
+			"+cluster|addslotsrange",     // assign slots
+			"+cluster|replicate",         // set up replication
+			"+cluster|forget",            // remove stale nodes
+			"+cluster|getslotmigrations", // check migration status
+			"+cluster|migrateslots",      // migrate slots between shards
+			"+info",                      // node info and replication status
+		}, " "),
 		// the ACL rawstring for exporter is taken from the redis_exporter documentation: https://github.com/oliver006/redis_exporter#authenticating-with-redis
 		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
 	}


### PR DESCRIPTION
This PR closes #132

### Summary

The `_operator` system user was created with `+@all` as a placeholder while the operator's command surface was still evolving. Now that the core functionality is stable, this tightens it down to the minimal set of commands.

### Implementation

Grepped all `.B()` client calls in `internal/` to find every command the operator issues, then added `+@connection` for the valkey-go client handshake (`CLIENT TRACKING`, `CLIENT SETINFO`, etc.) which happens under the hood during connection setup.

### Testing

All permissions are exercised by the existing E2E tests:

- Cluster creation covers `CLUSTER MEET`, `CLUSTER ADDSLOTSRANGE`, `CLUSTER REPLICATE`, and the state discovery commands (`CLUSTER MYID`, `CLUSTER MYSHARDID`, `CLUSTER INFO`, `CLUSTER NODES`, `INFO`)
- Scale-out test covers `CLUSTER MIGRATESLOTS` and `CLUSTER GETSLOTMIGRATIONS` (rebalancing slots to new shards)
- Scale-in test covers `CLUSTER FORGET` (removing drained nodes) and the same migration commands
- `+@connection` is exercised on every single test since it's the client handshake

Also tested locally: created a 3-shard cluster, scaled out to 4, scaled back to 2, checked operator logs for NOPERM errors after each step. All clean.

Adding a unit test for this would just maintain another static list that we compare against which doesn't make sense to me.