### PR TITLE
fix: authenticate getValkeyRole with _operator credentials

### DIFF
--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -388,10 +388,23 @@ func (r *ValkeyNodeReconciler) getValkeyRole(ctx context.Context, node *valkeyio
 		}
 	}
 
+	// Use _operator credentials when available (cluster-managed nodes).
+	// Standalone ValkeyNodes have no cluster label and no system password
+	// secret, so we skip the lookup entirely and connect unauthenticated.
+	var username, operatorPassword string
+	if clusterName, ok := node.Labels[LabelCluster]; ok {
+		operatorPassword, _ = fetchSystemUserPassword(ctx, operatorUser, r.Client, clusterName, node.Namespace)
+		if operatorPassword != "" {
+			username = operatorUser
+		}
+	}
+
 	opt := vclient.ClientOption{
 		InitAddress:       []string{fmt.Sprintf("%s:%d", node.Status.PodIP, DefaultPort)},
 		ForceSingleClient: true, // Don't connect to another cluster node.
 		TLSConfig:         tlsConfig,
+		Username:          username,
+		Password:          operatorPassword,
 	}
 
 	c, err := vclient.NewClient(opt)


### PR DESCRIPTION


This PR is a follow-up to #129 which added `_operator` system user authentication to the cluster controller but missed the `getValkeyRole` code path in the ValkeyNode controller.

### Summary

`getValkeyRole` connects to Valkey unauthenticated to check the replication role. Once the default user is restricted or disabled via `spec.users`, the role check fails silently and `ValkeyNode.status.role` is always empty.

### Implementation

Pass `_operator` credentials to `getValkeyRole`, matching how the cluster controller authenticates in `GetClusterState`. If the system password secret doesn't exist yet (fresh cluster before ACLs are set up), the password is empty and the connection falls back to unauthenticated.

### Limitations

None.

### Testing

Existing E2E tests cover this path (role is populated in ValkeyNode status). No behavioral change when the default user is open.

### Checklist
Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [NA] Tests are added or updated.
- [NA] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)