### PR TITLE
fix: surface reconcileUsersAcl errors in cluster status

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -165,8 +165,7 @@ func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster
 		// Get passwords from Secret
 		passwords, err := fetchUserPasswords(ctx, user, r.Client, cluster.Name, cluster.Namespace)
 		if err != nil {
-			log.Error(err, "failed to fetch password", "username", user.Name)
-			continue
+			return fmt.Errorf("user %s: %w", user.Name, err)
 		}
 
 		// Build ACL string for this user with found password(s)
@@ -248,8 +247,8 @@ func fetchUserPasswords(ctx context.Context, user valkeyiov1alpha1.UserAclSpec, 
 
 	log := logf.FromContext(ctx)
 
-	// If this user doesn't have a password, return empty
-	if user.NoPassword {
+	// If this user doesn't have a password or is disabled, return empty
+	if user.NoPassword || !user.Enabled {
 		return []string{}, nil
 	}
 	// Look for a Secret matching the user-provided name, or clusterName-users

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -124,6 +124,7 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err := r.reconcileUsersAcl(ctx, cluster); err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonUsersAclError, err.Error(), metav1.ConditionFalse)
+		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -118,6 +118,42 @@ var _ = Describe("ValkeyCluster Controller", func() {
 
 var _ = Describe("reconcileUsersAcl", func() {
 	Context("When reconciling ACL secrets", func() {
+		It("should return an error when a user references a missing password secret", func() {
+			ctx := context.Background()
+			cluster := &valkeyiov1alpha1.ValkeyCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "acl-missing-secret-test",
+					Namespace: "default",
+				},
+				Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+					Shards:   1,
+					Replicas: 0,
+					Users: []valkeyiov1alpha1.UserAclSpec{
+						{
+							Name:    "testuser",
+							Enabled: true,
+							PasswordSecret: valkeyiov1alpha1.PasswordSecretSpec{
+								Name: "nonexistent-secret",
+								Keys: []string{"password"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, cluster) }()
+
+			reconciler := &ValkeyClusterReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: events.NewFakeRecorder(100),
+			}
+
+			err := reconciler.reconcileUsersAcl(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("testuser"))
+		})
+
 		It("should create the internal ACL secret with the ACL secret type", func() {
 			ctx := context.Background()
 			cluster := &valkeyiov1alpha1.ValkeyCluster{


### PR DESCRIPTION
This PR closes #139

### Summary

When a user in `spec.users` references a password secret that doesn't exist, [`reconcileUsersAcl`](https://github.com/valkey-io/valkey-operator/blob/main/internal/controller/users.go#L169) logs an error but skips the user and returns nil. The ACL file is written without that user, and the cluster reports Ready. I think it makes sense to fail hard.

Additionally, when `reconcileUsersAcl` does return an error (e.g. internal secret creation fails), the condition is set but `updateStatus` is never called here, so the error isn't persisted to the status either.

### Implementation

- `users.go`: replace `continue` with `return fmt.Errorf(...)` when `fetchUserPasswords` fails
- `valkeycluster_controller.go`: add missing `updateStatus` call on the `reconcileUsersAcl` error path

### Testing

Before the fix, a missing password secret is invisible:
```
NAME            STATE   REASON           AGE
acl-fail-test   Ready   ClusterHealthy   10m
```

After the fix:
```
 ༼ つ ▀_▀ ༽つ  ~  src  valkey-ope  k describe valkeycluster acl-fail-test | tail -n 15                        fix/acl-missing-secret-status  2✎  5+  ⎈ kind-valkey-repro  21:55:45
    Last Transition Time:  2026-04-15T19:51:06Z
    Message:               user testuser: no password or reference found
    Observed Generation:   1
    Reason:                UsersACLError
    Status:                False
    Type:                  Ready
  Message:                 user testuser: no password or reference found
  Ready Shards:            0
  Reason:                  UsersACLError
  Shards:                  0
  State:                   Failed
Events:
  Type    Reason          Age    From                      Message
  ----    ------          ----   ----                      -------
  Normal  ServiceCreated  4m46s  valkeycluster-controller  Created headless Service
 ༼ つ ▀_▀ ༽つ  ~  src  valkey-ope  k get valkeycluster                                                        fix/acl-missing-secret-status  2✎  5+  ⎈ kind-valkey-repro  21:55:53
NAME            STATE    REASON          AGE
acl-fail-test   Failed   UsersACLError   4m51s
```

### Limitations

None.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [NA] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)