### PR TITLE
fix: pass cluster arg to getValkeyClusterState in proactive failover

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -442,7 +442,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 		if err != nil {
 			return false, fmt.Errorf("failed to fetch operator password for proactive failover: %w", err)
 		}
-		clusterState = r.getValkeyClusterState(ctx, nodes, operatorUser, operatorPassword)
+		clusterState = r.getValkeyClusterState(ctx, cluster, nodes, operatorUser, operatorPassword)
 		defer clusterState.CloseClients()
 	}
 


### PR DESCRIPTION
## Description

The merge of #128 (proactive failovers) after #133 (TLS) introduced a build-breaking call. #133 added a `cluster` parameter to `getValkeyClusterState`, but #128's new call site at line 445 used the old signature without it. This causes a compile error on current main.

## Testing

`go build ./...` passes.