### PR TITLE
fix: allow MEET against isolated shard primaries during scale-up

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -601,13 +601,14 @@ func (r *ValkeyClusterReconciler) getValkeyClusterState(ctx context.Context, clu
 }
 
 // findMeetTarget picks the best node to MEET all isolated nodes against.
-// Priority: (1) a non-isolated shard primary — already has slots, so gossip
-// will propagate slot info; (2) a non-isolated pending node from a previous
-// MEET batch; (3) the first isolated node as a bootstrap seed when every
-// single node is isolated (fresh bootstrap, first reconcile).
+// Priority: (1) a shard primary, it owns slots and is an established cluster
+// member even if cluster_known_nodes is 1 (e.g. a single-node cluster being
+// scaled up); (2) a non-isolated pending node from a previous MEET batch;
+// (3) the first isolated node as a bootstrap seed when every single node is
+// isolated (fresh bootstrap, first reconcile).
 func findMeetTarget(state *valkey.ClusterState, isolated []*valkey.NodeState) *valkey.NodeState {
 	for _, shard := range state.Shards {
-		if p := shard.GetPrimaryNode(); p != nil && !p.IsIsolated() {
+		if p := shard.GetPrimaryNode(); p != nil {
 			return p
 		}
 	}


### PR DESCRIPTION
**Description:**

Scaling a single-node cluster (1 shard, 0 replicas) to add a replica gets stuck in an infinite reconciliation loop. `findMeetTarget()` skips shard primaries with `cluster_known_nodes <= 1`, so the new replica is never `CLUSTER MEET`'d to the primary. `CLUSTER REPLICATE` fails with "Unknown node" on every reconciliaton.

The same bug also prevents adding a new shard (1 shard -> 2 shards), since the new shard's primary can't MEET the existing isolated primary either.

A shard primary that owns slots is always a valid `MEET` target regardless of `cluster_known_nodes`. This removes the `IsIsolated()` guard for shard primaries.

Discovered while investigating feedback on #135.

**Testing:**
Reproduced both cases on a local kind cluster: create a 1-shard-0-replica cluster, wait for Ready, then scale up.

**Case 1: add replica** (`replicas: 0` -> `replicas: 1`)

Before fix - cluster stuck at Reconciling, replica never `MEET`'d:
```
$ kubectl get valkeycluster
NAME         STATE         REASON
test-scale   Reconciling   Reconciling

$ kubectl get valkeynodes -o custom-columns=NAME:.metadata.name,READY:.status.ready,ROLE:.status.role
NAME             READY   ROLE
test-scale-0-0   true    primary
test-scale-0-1   true    primary

$ kubectl exec statefulset/valkey-test-scale-0-1 -c server -- valkey-cli CLUSTER INFO | grep cluster_known_nodes
cluster_known_nodes:1
```

Operator logs repeating every 2s:
```
DEBUG  replica does not yet know primary (gossip pending); will retry  replica=10.244.0.9 primaryId=3441aa9a...
DEBUG  skipping replica; primary not ready yet
DEBUG  missing replicas, requeue..
```

After fix - MEET succeeds, cluster reaches Ready:
```
$ kubectl get valkeycluster
NAME         STATE   REASON
test-scale   Ready   ClusterHealthy

$ kubectl get valkeynodes -o custom-columns=NAME:.metadata.name,READY:.status.ready,ROLE:.status.role
NAME             READY   ROLE
test-scale-0-0   true    primary
test-scale-0-1   true    replica

$ kubectl exec statefulset/valkey-test-scale-0-0 -c server -- valkey-cli CLUSTER NODES
3441aa9a... 10.244.0.8:6379@16379 myself,master - 0 0 0 connected 0-16383
bd334739... 10.244.0.9:6379@16379 slave 3441aa9a... 0 1776858716401 0 connected
```

Operator logs:
```
DEBUG  meet node  node=10.244.0.9 target=10.244.0.8
DEBUG  events  Introduced 1 isolated node(s) to the cluster
```

**Case 2: add shard** (`shards: 1` -> `shards: 2`)

After fix - new shard joins and slots are rebalanced:
```
$ kubectl get valkeycluster
NAME          STATE   REASON
test-scale2   Ready   ClusterHealthy

$ kubectl get valkeynodes -o custom-columns=NAME:.metadata.name,READY:.status.ready,ROLE:.status.role
NAME              READY   ROLE
test-scale2-0-0   true    primary
test-scale2-1-0   true    primary

$ kubectl exec statefulset/valkey-test-scale2-0-0 -c server -- valkey-cli CLUSTER NODES
a6e1a811... 10.244.0.13:6379@16379 master - 0 1776860233046 1 connected 0-8191
e9dae06c... 10.244.0.12:6379@16379 myself,master - 0 0 0 connected 8192-16383
```