### PR TITLE
fix: retry cert-manager resource apply in TLS e2e test

### DIFF
--- a/test/e2e/valkeycluster_tls_test.go
+++ b/test/e2e/valkeycluster_tls_test.go
@@ -75,7 +75,11 @@ spec:
 		err = os.WriteFile(cmManifestFile, []byte(cmManifest), 0644)
 		Expect(err).NotTo(HaveOccurred())
 
-		utils.Run(exec.Command("kubectl", "apply", "-f", cmManifestFile))
+		By("applying Cert-Manager Issuer and Certificate (retry until webhook is serving)")
+		Eventually(func() error {
+			_, err := utils.Run(exec.Command("kubectl", "apply", "-f", cmManifestFile))
+			return err
+		}).Should(Succeed())
 
 		By("waiting for the certificate secret to be created")
 		Eventually(func() error {


### PR DESCRIPTION
## Description

The TLS e2e test fails intermittently on CI because the cert-manager Issuer and Certificate are never actually created. The `kubectl apply` on [line 78](https://github.com/valkey-io/valkey-operator/blob/main/test/e2e/valkeycluster_tls_test.go#L78) ignores the return value of `utils.Run`, so when the apply fails the test silently moves on to waiting for a secret that will never appear.

From the [CI logs](https://github.com/valkey-io/valkey-operator/pull/148) we can see this: the apply completes in ~90ms with no output at all (a successful apply would print `issuer.cert-manager.io/selfsigned-issuer created`), and the debug info collected after the failure shows no Issuer/Certificate events in the cluster. The test then polls `kubectl get secret valkey-tls-cert` for 2 minutes until it times out.

I think this is a cert-manager webhook readiness race. `InstallCertManager` waits for the webhook Deployment to report Available, but the webhook pod can be Available before it's actually serving admission requests. The Issuer/Certificate apply hits the webhook before it's ready and fails.

## Testing
- Test compiles
- All 4 TLS e2e tests pass locally on a kind cluster