### PR TITLE
feat: add operator-specific Prometheus metrics

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -38,6 +38,15 @@ const (
 	ClusterStateFailed ClusterState = "Failed"
 )
 
+// ClusterStates lists all possible ValkeyCluster states.
+var ClusterStates = []ClusterState{
+	ClusterStateInitializing,
+	ClusterStateReconciling,
+	ClusterStateReady,
+	ClusterStateDegraded,
+	ClusterStateFailed,
+}
+
 // PDBPolicy controls whether the operator manages a PodDisruptionBudget for the cluster.
 // Values may be added in future versions; clients MUST handle unknown values gracefully.
 // +kubebuilder:validation:Enum=Managed;Disabled

--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -104,6 +104,7 @@ func proactiveFailover(ctx context.Context, recorder events.EventRecorder, clust
 			if role == RolePrimary {
 				recorder.Eventf(cluster, nil, corev1.EventTypeNormal, eventReasonFailoverCompleted, eventActionProactiveFailover, "Failover completed: %s is now primary in shard %s", target.Address, shard.Id)
 				log.Info("proactive failover completed", "newPrimary", target.Address, "shard", shard.Id)
+				failoversTotal.WithLabelValues(cluster.Name, cluster.Namespace, "proactive").Inc()
 				return nil
 			}
 		}

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+)
+
+var (
+	clusterInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "valkey_operator_cluster_info",
+			Help: "Information about a ValkeyCluster. Value is always 1, state is in the label.",
+		},
+		[]string{"cluster", "namespace", "state"},
+	)
+
+	clusterShards = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "valkey_operator_cluster_shards",
+			Help: "Total number of shards in a ValkeyCluster.",
+		},
+		[]string{"cluster", "namespace"},
+	)
+
+	clusterShardsReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "valkey_operator_cluster_shards_ready",
+			Help: "Number of ready shards in a ValkeyCluster.",
+		},
+		[]string{"cluster", "namespace"},
+	)
+
+	failoversTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "valkey_operator_failovers_total",
+			Help: "Total number of failover events.",
+		},
+		[]string{"cluster", "namespace", "type"},
+	)
+
+	slotMigrationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "valkey_operator_slot_migrations_total",
+			Help: "Total number of slot migration batches completed.",
+		},
+		[]string{"cluster", "namespace"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		clusterInfo,
+		clusterShards,
+		clusterShardsReady,
+		failoversTotal,
+		slotMigrationsTotal,
+	)
+}
+
+// clusterStates lists all possible ValkeyCluster states for metric cleanup.
+var clusterStates = []string{"Ready", "Reconciling", "Degraded", "Failed"}
+
+// updateClusterMetrics sets the Prometheus gauges for a ValkeyCluster.
+func updateClusterMetrics(cluster *valkeyiov1alpha1.ValkeyCluster) {
+	name := cluster.Name
+	ns := cluster.Namespace
+
+	// Set info gauge: 1 for current state, 0 for all others
+	for _, s := range clusterStates {
+		val := float64(0)
+		if string(cluster.Status.State) == s {
+			val = 1
+		}
+		clusterInfo.WithLabelValues(name, ns, s).Set(val)
+	}
+
+	clusterShards.WithLabelValues(name, ns).Set(float64(cluster.Status.Shards))
+	clusterShardsReady.WithLabelValues(name, ns).Set(float64(cluster.Status.ReadyShards))
+}

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -32,7 +32,7 @@ var (
 			Name: "valkey_operator_cluster_state_info",
 			Help: "Information about a ValkeyCluster. Value is 1 for the current state, 0 for all others.",
 		},
-		[]string{"valkey_cluster", "namespace", "state"},
+		[]string{"valkey_cluster", "target_namespace", "state"},
 	)
 
 	clusterShards = factory.NewGaugeVec(
@@ -40,7 +40,7 @@ var (
 			Name: "valkey_operator_cluster_shards",
 			Help: "Total number of shards in a ValkeyCluster.",
 		},
-		[]string{"valkey_cluster", "namespace"},
+		[]string{"valkey_cluster", "target_namespace"},
 	)
 
 	clusterShardsReady = factory.NewGaugeVec(
@@ -48,7 +48,7 @@ var (
 			Name: "valkey_operator_cluster_shards_ready",
 			Help: "Number of ready shards in a ValkeyCluster.",
 		},
-		[]string{"valkey_cluster", "namespace"},
+		[]string{"valkey_cluster", "target_namespace"},
 	)
 
 	failoversTotal = factory.NewCounterVec(
@@ -56,7 +56,7 @@ var (
 			Name: "valkey_operator_failovers_total",
 			Help: "Total number of failover events.",
 		},
-		[]string{"valkey_cluster", "namespace", "type"},
+		[]string{"valkey_cluster", "target_namespace", "type"},
 	)
 
 	slotMigrationBatchesTotal = factory.NewCounterVec(
@@ -64,7 +64,7 @@ var (
 			Name: "valkey_operator_slot_migration_batches_total",
 			Help: "Total number of slot migration batches completed.",
 		},
-		[]string{"valkey_cluster", "namespace"},
+		[]string{"valkey_cluster", "target_namespace"},
 	)
 )
 
@@ -93,6 +93,6 @@ func deleteClusterMetrics(name, namespace string) {
 	}
 	clusterShards.DeleteLabelValues(name, namespace)
 	clusterShardsReady.DeleteLabelValues(name, namespace)
-	failoversTotal.DeletePartialMatch(prometheus.Labels{"valkey_cluster": name, "namespace": namespace})
+	failoversTotal.DeletePartialMatch(prometheus.Labels{"valkey_cluster": name, "target_namespace": namespace})
 	slotMigrationBatchesTotal.DeleteLabelValues(name, namespace)
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -29,7 +29,7 @@ var (
 			Name: "valkey_operator_cluster_info",
 			Help: "Information about a ValkeyCluster. Value is always 1, state is in the label.",
 		},
-		[]string{"cluster", "namespace", "state"},
+		[]string{"valkey_cluster", "namespace", "state"},
 	)
 
 	clusterShards = prometheus.NewGaugeVec(
@@ -37,7 +37,7 @@ var (
 			Name: "valkey_operator_cluster_shards",
 			Help: "Total number of shards in a ValkeyCluster.",
 		},
-		[]string{"cluster", "namespace"},
+		[]string{"valkey_cluster", "namespace"},
 	)
 
 	clusterShardsReady = prometheus.NewGaugeVec(
@@ -45,7 +45,7 @@ var (
 			Name: "valkey_operator_cluster_shards_ready",
 			Help: "Number of ready shards in a ValkeyCluster.",
 		},
-		[]string{"cluster", "namespace"},
+		[]string{"valkey_cluster", "namespace"},
 	)
 
 	failoversTotal = prometheus.NewCounterVec(
@@ -53,7 +53,7 @@ var (
 			Name: "valkey_operator_failovers_total",
 			Help: "Total number of failover events.",
 		},
-		[]string{"cluster", "namespace", "type"},
+		[]string{"valkey_cluster", "namespace", "type"},
 	)
 
 	slotMigrationsTotal = prometheus.NewCounterVec(
@@ -61,7 +61,7 @@ var (
 			Name: "valkey_operator_slot_migrations_total",
 			Help: "Total number of slot migration batches completed.",
 		},
-		[]string{"cluster", "namespace"},
+		[]string{"valkey_cluster", "namespace"},
 	)
 )
 
@@ -76,7 +76,13 @@ func init() {
 }
 
 // clusterStates lists all possible ValkeyCluster states for metric cleanup.
-var clusterStates = []string{"Ready", "Reconciling", "Degraded", "Failed"}
+var clusterStates = []valkeyiov1alpha1.ClusterState{
+	valkeyiov1alpha1.ClusterStateInitializing,
+	valkeyiov1alpha1.ClusterStateReconciling,
+	valkeyiov1alpha1.ClusterStateReady,
+	valkeyiov1alpha1.ClusterStateDegraded,
+	valkeyiov1alpha1.ClusterStateFailed,
+}
 
 // updateClusterMetrics sets the Prometheus gauges for a ValkeyCluster.
 func updateClusterMetrics(cluster *valkeyiov1alpha1.ValkeyCluster) {
@@ -86,10 +92,10 @@ func updateClusterMetrics(cluster *valkeyiov1alpha1.ValkeyCluster) {
 	// Set info gauge: 1 for current state, 0 for all others
 	for _, s := range clusterStates {
 		val := float64(0)
-		if string(cluster.Status.State) == s {
+		if cluster.Status.State == s {
 			val = 1
 		}
-		clusterInfo.WithLabelValues(name, ns, s).Set(val)
+		clusterInfo.WithLabelValues(name, ns, string(s)).Set(val)
 	}
 
 	clusterShards.WithLabelValues(name, ns).Set(float64(cluster.Status.Shards))

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -27,7 +27,7 @@ var (
 	clusterInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "valkey_operator_cluster_info",
-			Help: "Information about a ValkeyCluster. Value is always 1, state is in the label.",
+			Help: "Information about a ValkeyCluster. Value is 1 for the current state, 0 for all others.",
 		},
 		[]string{"valkey_cluster", "namespace", "state"},
 	)
@@ -100,4 +100,13 @@ func updateClusterMetrics(cluster *valkeyiov1alpha1.ValkeyCluster) {
 
 	clusterShards.WithLabelValues(name, ns).Set(float64(cluster.Status.Shards))
 	clusterShardsReady.WithLabelValues(name, ns).Set(float64(cluster.Status.ReadyShards))
+}
+
+// deleteClusterMetrics removes all gauge metrics for a deleted ValkeyCluster.
+func deleteClusterMetrics(name, namespace string) {
+	for _, s := range clusterStates {
+		clusterInfo.DeleteLabelValues(name, namespace, string(s))
+	}
+	clusterShards.DeleteLabelValues(name, namespace)
+	clusterShardsReady.DeleteLabelValues(name, namespace)
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -26,7 +26,7 @@ import (
 var (
 	clusterInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "valkey_operator_cluster_info",
+			Name: "valkey_operator_cluster_state_info",
 			Help: "Information about a ValkeyCluster. Value is 1 for the current state, 0 for all others.",
 		},
 		[]string{"valkey_cluster", "namespace", "state"},
@@ -56,9 +56,9 @@ var (
 		[]string{"valkey_cluster", "namespace", "type"},
 	)
 
-	slotMigrationsTotal = prometheus.NewCounterVec(
+	slotMigrationBatchesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "valkey_operator_slot_migrations_total",
+			Name: "valkey_operator_slot_migration_batches_total",
 			Help: "Total number of slot migration batches completed.",
 		},
 		[]string{"valkey_cluster", "namespace"},
@@ -71,7 +71,7 @@ func init() {
 		clusterShards,
 		clusterShardsReady,
 		failoversTotal,
-		slotMigrationsTotal,
+		slotMigrationBatchesTotal,
 	)
 }
 

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -18,13 +18,16 @@ package controller
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 )
 
+var factory = promauto.With(metrics.Registry)
+
 var (
-	clusterInfo = prometheus.NewGaugeVec(
+	clusterStateInfo = factory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "valkey_operator_cluster_state_info",
 			Help: "Information about a ValkeyCluster. Value is 1 for the current state, 0 for all others.",
@@ -32,7 +35,7 @@ var (
 		[]string{"valkey_cluster", "namespace", "state"},
 	)
 
-	clusterShards = prometheus.NewGaugeVec(
+	clusterShards = factory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "valkey_operator_cluster_shards",
 			Help: "Total number of shards in a ValkeyCluster.",
@@ -40,7 +43,7 @@ var (
 		[]string{"valkey_cluster", "namespace"},
 	)
 
-	clusterShardsReady = prometheus.NewGaugeVec(
+	clusterShardsReady = factory.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "valkey_operator_cluster_shards_ready",
 			Help: "Number of ready shards in a ValkeyCluster.",
@@ -48,7 +51,7 @@ var (
 		[]string{"valkey_cluster", "namespace"},
 	)
 
-	failoversTotal = prometheus.NewCounterVec(
+	failoversTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "valkey_operator_failovers_total",
 			Help: "Total number of failover events.",
@@ -56,7 +59,7 @@ var (
 		[]string{"valkey_cluster", "namespace", "type"},
 	)
 
-	slotMigrationBatchesTotal = prometheus.NewCounterVec(
+	slotMigrationBatchesTotal = factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "valkey_operator_slot_migration_batches_total",
 			Help: "Total number of slot migration batches completed.",
@@ -65,48 +68,31 @@ var (
 	)
 )
 
-func init() {
-	metrics.Registry.MustRegister(
-		clusterInfo,
-		clusterShards,
-		clusterShardsReady,
-		failoversTotal,
-		slotMigrationBatchesTotal,
-	)
-}
-
-// clusterStates lists all possible ValkeyCluster states for metric cleanup.
-var clusterStates = []valkeyiov1alpha1.ClusterState{
-	valkeyiov1alpha1.ClusterStateInitializing,
-	valkeyiov1alpha1.ClusterStateReconciling,
-	valkeyiov1alpha1.ClusterStateReady,
-	valkeyiov1alpha1.ClusterStateDegraded,
-	valkeyiov1alpha1.ClusterStateFailed,
-}
-
 // updateClusterMetrics sets the Prometheus gauges for a ValkeyCluster.
 func updateClusterMetrics(cluster *valkeyiov1alpha1.ValkeyCluster) {
 	name := cluster.Name
 	ns := cluster.Namespace
 
 	// Set info gauge: 1 for current state, 0 for all others
-	for _, s := range clusterStates {
+	for _, s := range valkeyiov1alpha1.ClusterStates {
 		val := float64(0)
 		if cluster.Status.State == s {
 			val = 1
 		}
-		clusterInfo.WithLabelValues(name, ns, string(s)).Set(val)
+		clusterStateInfo.WithLabelValues(name, ns, string(s)).Set(val)
 	}
 
 	clusterShards.WithLabelValues(name, ns).Set(float64(cluster.Status.Shards))
 	clusterShardsReady.WithLabelValues(name, ns).Set(float64(cluster.Status.ReadyShards))
 }
 
-// deleteClusterMetrics removes all gauge metrics for a deleted ValkeyCluster.
+// deleteClusterMetrics removes all metrics for a deleted ValkeyCluster.
 func deleteClusterMetrics(name, namespace string) {
-	for _, s := range clusterStates {
-		clusterInfo.DeleteLabelValues(name, namespace, string(s))
+	for _, s := range valkeyiov1alpha1.ClusterStates {
+		clusterStateInfo.DeleteLabelValues(name, namespace, string(s))
 	}
 	clusterShards.DeleteLabelValues(name, namespace)
 	clusterShardsReady.DeleteLabelValues(name, namespace)
+	failoversTotal.DeletePartialMatch(prometheus.Labels{"valkey_cluster": name, "namespace": namespace})
+	slotMigrationBatchesTotal.DeleteLabelValues(name, namespace)
 }

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -1018,7 +1018,7 @@ func (r *ValkeyClusterReconciler) rebalanceSlots(ctx context.Context, cluster *v
 		}
 		return false, err
 	}
-	slotMigrationsTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
+	slotMigrationBatchesTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
 	return true, nil
 }
 
@@ -1132,6 +1132,7 @@ func (r *ValkeyClusterReconciler) drainExcessShards(ctx context.Context, cluster
 			}
 			return false, err
 		}
+		slotMigrationBatchesTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
 		return true, nil
 	}
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -929,6 +929,9 @@ func (r *ValkeyClusterReconciler) updateStatus(ctx context.Context, cluster *val
 		current.Status.Message = readyCondition.Message
 	}
 
+	// Update Prometheus metrics
+	updateClusterMetrics(current)
+
 	if !reflect.DeepEqual(patchBase.Status, current.Status) {
 		if err := r.Status().Patch(ctx, current, patch); err != nil {
 			log.Error(err, statusUpdateFailedMsg)
@@ -1011,6 +1014,7 @@ func (r *ValkeyClusterReconciler) rebalanceSlots(ctx context.Context, cluster *v
 		}
 		return false, err
 	}
+	slotMigrationsTotal.WithLabelValues(cluster.Name, cluster.Namespace).Inc()
 	return true, nil
 }
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -113,7 +113,11 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	cluster := &valkeyiov1alpha1.ValkeyCluster{}
 	if err := r.Get(ctx, req.NamespacedName, cluster); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			deleteClusterMetrics(req.Name, req.Namespace)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
 	}
 
 	if err := r.upsertService(ctx, cluster); err != nil {


### PR DESCRIPTION
**Description**

Adds custom Prometheus metrics for ValkeyCluster observability. The default controller-runtime metrics (reconcile counts, workqueue depth) don't expose operator-specific information.

New metrics:

- `valkey_operator_cluster_state_info` - gauge with state label (Initializing, Ready, Reconciling, Degraded, Failed), value 1 for current state, 0 for all others
- `valkey_operator_cluster_shards` - total shard count per cluster
- `valkey_operator_cluster_shards_ready` - ready shard count per cluster
- `valkey_operator_failovers_total` - counter for proactive failover events
- `valkey_operator_slot_migration_batches_total` - counter for completed slot migration batches (scale-out and scale-in)

Gauge metrics are cleaned up when a ValkeyCluster is deleted. All metrics (gauges and counters) are cleaned up when a ValkeyCluster is deleted to prevent cardinality leaks.

Uses `valkey_cluster` label instead of `cluster` to avoid conflicts in multi-cluster Prometheus setups ([context](https://github.com/cloudnative-pg/cloudnative-pg/issues/2501)). Uses `ClusterState` constants from API types to avoid string mismatches.

**Testing**

Unit tests pass. Deployed to a local kind cluster with a 3-shard 1-replica cluster and scraped the metrics endpoint:

```
$ curl -s http://localhost:8443/metrics | grep valkey_operator_cluster

# HELP valkey_operator_cluster_state_info Information about a ValkeyCluster. Value is 1 for the current state, 0 for all others.
# TYPE valkey_operator_cluster_state_info gauge
valkey_operator_cluster_state_info{valkey_cluster="failover-test",namespace="default",state="Degraded"} 0
valkey_operator_cluster_state_info{valkey_cluster="failover-test",namespace="default",state="Failed"} 0
valkey_operator_cluster_state_info{valkey_cluster="failover-test",namespace="default",state="Initializing"} 0
valkey_operator_cluster_state_info{valkey_cluster="failover-test",namespace="default",state="Ready"} 1
valkey_operator_cluster_state_info{valkey_cluster="failover-test",namespace="default",state="Reconciling"} 0
# HELP valkey_operator_cluster_shards Total number of shards in a ValkeyCluster.
# TYPE valkey_operator_cluster_shards gauge
valkey_operator_cluster_shards{valkey_cluster="failover-test",namespace="default"} 3
# HELP valkey_operator_cluster_shards_ready Number of ready shards in a ValkeyCluster.
# TYPE valkey_operator_cluster_shards_ready gauge
valkey_operator_cluster_shards_ready{valkey_cluster="failover-test",namespace="default"} 3
```