### PR TITLE
feat: add shard-aware topology spread constraints

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -79,10 +79,16 @@ type ValkeyClusterSpec struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-	// Affinity to apply to the pods, overrides NodeSelector if set
-	// Some basic anti-affinity rules will be applied by default to spread pods across nodes and zones
+	// Affinity to apply to the pods, overrides NodeSelector if set.
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+
+	// TopologySpreadConstraints defines pod topology spread constraints applied
+	// to the ValkeyNode workloads. The operator augments these constraints with
+	// shard-aware selectors so pods from the same shard can be spread across the
+	// configured topology domain.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
 	// Metrics exporter options
 	// +kubebuilder:default:={enabled:true}
@@ -225,6 +231,7 @@ const (
 	ReasonUpdatingNodes            = "UpdatingNodes"
 	ReasonSystemUsersAclError      = "SystemUsersACLError"
 	ReasonPodDisruptionBudgetError = "PodDisruptionBudgetError"
+	ReasonPodUnschedulable         = "PodUnschedulable"
 )
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -70,6 +70,12 @@ type ValkeyNodeSpec struct {
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	// TopologySpreadConstraints defines pod topology spread constraints applied
+	// to the ValkeyNode workload. The operator augments these constraints with
+	// shard-aware selectors derived from node labels.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
 	// Exporter defines the metrics exporter sidecar configuration.
 	// +optional
 	Exporter ExporterSpec `json:"exporter,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -290,6 +290,13 @@ func (in *ValkeyClusterSpec) DeepCopyInto(out *ValkeyClusterSpec) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Exporter.DeepCopyInto(&out.Exporter)
 	if in.Persistence != nil {
 		in, out := &in.Persistence, &out.Persistence
@@ -439,6 +446,13 @@ func (in *ValkeyNodeSpec) DeepCopyInto(out *ValkeyNodeSpec) {
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -58,9 +58,8 @@ spec:
             description: spec defines the desired state of ValkeyCluster
             properties:
               affinity:
-                description: |-
-                  Affinity to apply to the pods, overrides NodeSelector if set
-                  Some basic anti-affinity rules will be applied by default to spread pods across nodes and zones
+                description: Affinity to apply to the pods, overrides NodeSelector
+                  if set.
                 properties:
                   nodeAffinity:
                     description: Describes node affinity scheduling rules for the
@@ -2742,6 +2741,184 @@ spec:
                         Value is the taint value the toleration matches to.
                         If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
+                  type: object
+                type: array
+              topologySpreadConstraints:
+                description: |-
+                  TopologySpreadConstraints defines pod topology spread constraints applied
+                  to the ValkeyNode workloads. The operator augments these constraints with
+                  shard-aware selectors so pods from the same shard can be spread across the
+                  configured topology domain.
+                items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
+                  properties:
+                    labelSelector:
+                      description: |-
+                        LabelSelector is used to find matching pods.
+                        Pods that match this label selector are counted to determine the number of pods
+                        in their corresponding topology domain.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: |-
+                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                        spreading will be calculated. The keys are used to lookup values from the
+                        incoming pod labels, those key-value labels are ANDed with labelSelector
+                        to select the group of existing pods over which spreading will be calculated
+                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                        MatchLabelKeys cannot be set when LabelSelector isn't set.
+                        Keys that don't exist in the incoming pod labels will
+                        be ignored. A null or empty list means only match against labelSelector.
+
+                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    maxSkew:
+                      description: |-
+                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                        between the number of matching pods in the target topology and the global minimum.
+                        The global minimum is the minimum number of matching pods in an eligible domain
+                        or zero if the number of eligible domains is less than MinDomains.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                        labelSelector spread as 2/2/1:
+                        In this case, the global minimum is 1.
+                        | zone1 | zone2 | zone3 |
+                        |  P P  |  P P  |   P   |
+                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                        violate MaxSkew(1).
+                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                        to topologies that satisfy it.
+                        It's a required field. Default value is 1 and 0 is not allowed.
+                      format: int32
+                      type: integer
+                    minDomains:
+                      description: |-
+                        MinDomains indicates a minimum number of eligible domains.
+                        When the number of eligible domains with matching topology keys is less than minDomains,
+                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                        this value has no effect on scheduling.
+                        As a result, when the number of eligible domains is less than minDomains,
+                        scheduler won't schedule more than maxSkew Pods to those domains.
+                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                        Valid values are integers greater than 0.
+                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                        labelSelector spread as 2/2/2:
+                        | zone1 | zone2 | zone3 |
+                        |  P P  |  P P  |  P P  |
+                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                        In this situation, new pod with the same labelSelector cannot be scheduled,
+                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                        it will violate MaxSkew.
+                      format: int32
+                      type: integer
+                    nodeAffinityPolicy:
+                      description: |-
+                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                        when calculating pod topology spread skew. Options are:
+                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                        If this value is nil, the behavior is equivalent to the Honor policy.
+                      type: string
+                    nodeTaintsPolicy:
+                      description: |-
+                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                        pod topology spread skew. Options are:
+                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                        has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+
+                        If this value is nil, the behavior is equivalent to the Ignore policy.
+                      type: string
+                    topologyKey:
+                      description: |-
+                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                        and identical values are considered to be in the same topology.
+                        We consider each <key, value> as a "bucket", and try to put balanced number
+                        of pods into each bucket.
+                        We define a domain as a particular instance of a topology.
+                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                        nodeAffinityPolicy and nodeTaintsPolicy.
+                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                        It's a required field.
+                      type: string
+                    whenUnsatisfiable:
+                      description: |-
+                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                        the spread constraint.
+                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                          but giving higher precedence to topologies that would help reduce the
+                          skew.
+                        A constraint is considered "Unsatisfiable" for an incoming pod
+                        if and only if every possible node assignment for that pod would violate
+                        "MaxSkew" on some topology.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                        labelSelector spread as 3/1/1:
+                        | zone1 | zone2 | zone3 |
+                        | P P P |   P   |   P   |
+                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                        won't make it *more* imbalanced.
+                        It's a required field.
+                      type: string
+                  required:
+                  - maxSkew
+                  - topologyKey
+                  - whenUnsatisfiable
                   type: object
                 type: array
               users:

--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -2734,6 +2734,183 @@ spec:
                       type: string
                   type: object
                 type: array
+              topologySpreadConstraints:
+                description: |-
+                  TopologySpreadConstraints defines pod topology spread constraints applied
+                  to the ValkeyNode workload. The operator augments these constraints with
+                  shard-aware selectors derived from node labels.
+                items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
+                  properties:
+                    labelSelector:
+                      description: |-
+                        LabelSelector is used to find matching pods.
+                        Pods that match this label selector are counted to determine the number of pods
+                        in their corresponding topology domain.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    matchLabelKeys:
+                      description: |-
+                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                        spreading will be calculated. The keys are used to lookup values from the
+                        incoming pod labels, those key-value labels are ANDed with labelSelector
+                        to select the group of existing pods over which spreading will be calculated
+                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                        MatchLabelKeys cannot be set when LabelSelector isn't set.
+                        Keys that don't exist in the incoming pod labels will
+                        be ignored. A null or empty list means only match against labelSelector.
+
+                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    maxSkew:
+                      description: |-
+                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                        between the number of matching pods in the target topology and the global minimum.
+                        The global minimum is the minimum number of matching pods in an eligible domain
+                        or zero if the number of eligible domains is less than MinDomains.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                        labelSelector spread as 2/2/1:
+                        In this case, the global minimum is 1.
+                        | zone1 | zone2 | zone3 |
+                        |  P P  |  P P  |   P   |
+                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                        violate MaxSkew(1).
+                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                        to topologies that satisfy it.
+                        It's a required field. Default value is 1 and 0 is not allowed.
+                      format: int32
+                      type: integer
+                    minDomains:
+                      description: |-
+                        MinDomains indicates a minimum number of eligible domains.
+                        When the number of eligible domains with matching topology keys is less than minDomains,
+                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                        this value has no effect on scheduling.
+                        As a result, when the number of eligible domains is less than minDomains,
+                        scheduler won't schedule more than maxSkew Pods to those domains.
+                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                        Valid values are integers greater than 0.
+                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                        labelSelector spread as 2/2/2:
+                        | zone1 | zone2 | zone3 |
+                        |  P P  |  P P  |  P P  |
+                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                        In this situation, new pod with the same labelSelector cannot be scheduled,
+                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                        it will violate MaxSkew.
+                      format: int32
+                      type: integer
+                    nodeAffinityPolicy:
+                      description: |-
+                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                        when calculating pod topology spread skew. Options are:
+                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                        If this value is nil, the behavior is equivalent to the Honor policy.
+                      type: string
+                    nodeTaintsPolicy:
+                      description: |-
+                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                        pod topology spread skew. Options are:
+                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                        has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+
+                        If this value is nil, the behavior is equivalent to the Ignore policy.
+                      type: string
+                    topologyKey:
+                      description: |-
+                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                        and identical values are considered to be in the same topology.
+                        We consider each <key, value> as a "bucket", and try to put balanced number
+                        of pods into each bucket.
+                        We define a domain as a particular instance of a topology.
+                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                        nodeAffinityPolicy and nodeTaintsPolicy.
+                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                        It's a required field.
+                      type: string
+                    whenUnsatisfiable:
+                      description: |-
+                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                        the spread constraint.
+                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                          but giving higher precedence to topologies that would help reduce the
+                          skew.
+                        A constraint is considered "Unsatisfiable" for an incoming pod
+                        if and only if every possible node assignment for that pod would violate
+                        "MaxSkew" on some topology.
+                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                        labelSelector spread as 3/1/1:
+                        | zone1 | zone2 | zone3 |
+                        | P P P |   P   |   P   |
+                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                        won't make it *more* imbalanced.
+                        It's a required field.
+                      type: string
+                  required:
+                  - maxSkew
+                  - topologyKey
+                  - whenUnsatisfiable
+                  type: object
+                type: array
               usersACLSecretName:
                 description: |-
                   UsersACLSecretName is the name of the Secret containing the ACL user

--- a/config/samples/v1alpha1_valkeycluster-topology-spread.yaml
+++ b/config/samples/v1alpha1_valkeycluster-topology-spread.yaml
@@ -1,0 +1,14 @@
+apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  labels:
+    app.kubernetes.io/name: valkey-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster-sample-topology-spread
+spec:
+  shards: 3
+  replicas: 1
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -60,6 +60,7 @@ Common reasons when `Ready=False`:
 - `UpdatingNodes` – rolling update of ValkeyNode CRs in progress
 - `MissingShards` – waiting for all shards to be created
 - `MissingReplicas` – waiting for all replicas to be created
+- `PodUnschedulable` – Kubernetes cannot schedule one or more Valkey pods
 
 Common reasons when `Ready=True`:
 - `ClusterHealthy` – Cluster is healthy
@@ -91,6 +92,7 @@ Indicates whether the cluster is impaired but may still be partially functional.
 Common reasons:
 - `NodeAddFailed` – failed to add a node to the cluster
 - `RebalanceFailed` – slot rebalancing failed (scale-out or scale-in)
+- `PodUnschedulable` – Kubernetes scheduler cannot place one or more Valkey pods, for example because strict topology spread constraints cannot be satisfied
 
 ---
 

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -132,6 +132,58 @@ affinity:
 
 `tolerations`, `nodeSelector`, and `affinity` are passed through to every pod in the cluster.
 
+#### Topology spread constraints
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+```
+
+`topologySpreadConstraints` uses Kubernetes' native pod topology spread constraints and applies them to every Valkey pod in the cluster.
+
+By default, the operator does not add any topology spread constraints. If `topologySpreadConstraints` is omitted or empty, pods are scheduled normally using the other scheduling fields such as `nodeSelector`, `affinity`, `tolerations`, and resource requests.
+
+For `ValkeyCluster`, when a topology spread constraint is configured, the operator makes it shard-aware. It scopes the constraint to the current cluster and shard, so pods from the same shard, for example a primary and its replica, are spread across the configured topology domain.
+
+Each constraint must include:
+
+| Field | Meaning |
+|---|---|
+| `maxSkew` | Maximum allowed difference in matching pod count between topology domains. `1` means Kubernetes keeps the matching pods as evenly spread as possible. |
+| `topologyKey` | Node label used as the spread domain. Use `kubernetes.io/hostname` for worker-node spreading, or labels such as `topology.kubernetes.io/zone` for zone spreading. |
+| `whenUnsatisfiable` | What Kubernetes should do when the constraint cannot be satisfied. |
+
+`whenUnsatisfiable` supports:
+
+| Value | Behaviour | Impact |
+|---|---|---|
+| `DoNotSchedule` | Hard rule. Kubernetes will not schedule the pod if placement would violate the constraint. | Stronger HA placement, but pods may remain `Pending` when there are not enough eligible nodes or topology domains. The operator reports `PodUnschedulable` on the ValkeyCluster. |
+| `ScheduleAnyway` | Soft rule. Kubernetes prefers satisfying the constraint, but can still schedule the pod if it cannot. | Better scheduling availability in constrained clusters, but pods from the same shard may still land in the same topology domain. |
+
+Example strict node-level spreading:
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+```
+
+This tries to keep pods from the same shard on different worker nodes. If the cluster does not have enough eligible worker nodes, affected pods stay `Pending`.
+
+Example preferred node-level spreading:
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+```
+
+This still prefers spreading pods from the same shard across worker nodes, but allows scheduling to continue if the constraint cannot be satisfied.
+
 ### TLS
 
 ```yaml

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -31,3 +31,10 @@ func setCondition(cluster *valkeyiov1alpha1.ValkeyCluster, condType, reason, mes
 		ObservedGeneration: cluster.Generation,
 	})
 }
+
+func removeConditionIfReason(conditions *[]metav1.Condition, condType, reason string) {
+	condition := meta.FindStatusCondition(*conditions, condType)
+	if condition != nil && condition.Reason == reason {
+		meta.RemoveStatusCondition(conditions, condType)
+	}
+}

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -389,6 +389,7 @@ func (r *ValkeyClusterReconciler) handlePodSchedulingIssues(ctx context.Context,
 	if issue.message != "" {
 		message = fmt.Sprintf("%s: %s", message, issue.message)
 	}
+	r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "PodUnschedulable", "SchedulePod", "%s", message)
 	setCondition(cluster, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonPodUnschedulable, message, metav1.ConditionTrue)
 	setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonPodUnschedulable, message, metav1.ConditionFalse)
 	setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonReconciling, "Waiting for unschedulable pods to be scheduled", metav1.ConditionTrue)

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -381,6 +381,7 @@ func (r *ValkeyClusterReconciler) handlePodSchedulingIssues(ctx context.Context,
 	}
 	if issue == nil {
 		removeConditionIfReason(&cluster.Status.Conditions, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonPodUnschedulable)
+		removeConditionIfReason(&cluster.Status.Conditions, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonPodUnschedulable)
 		return ctrl.Result{}, false, nil
 	}
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -160,11 +160,26 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
 	} else if requeue {
+		if result, handled, err := r.handlePodSchedulingIssues(ctx, cluster); err != nil {
+			setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeError, err.Error(), metav1.ConditionFalse)
+			_ = r.updateStatus(ctx, cluster, nil)
+			return ctrl.Result{}, err
+		} else if handled {
+			return result, nil
+		}
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonUpdatingNodes, "Updating ValkeyNodes", metav1.ConditionFalse)
 		setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonUpdatingNodes, "Updating ValkeyNodes", metav1.ConditionTrue)
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
+	if result, handled, err := r.handlePodSchedulingIssues(ctx, cluster); err != nil {
+		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeError, err.Error(), metav1.ConditionFalse)
+		_ = r.updateStatus(ctx, cluster, nil)
+		return ctrl.Result{}, err
+	} else if handled {
+		return result, nil
+	}
+
 	operatorPassword, err := fetchSystemUserPassword(ctx, operatorUser, r.Client, cluster.Name, cluster.Namespace)
 	if err != nil {
 		log.Error(err, "failed to retrieve system user password")
@@ -352,6 +367,65 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	log.V(1).Info("reconcile done")
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+type podSchedulingIssue struct {
+	podName string
+	message string
+}
+
+func (r *ValkeyClusterReconciler) handlePodSchedulingIssues(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (ctrl.Result, bool, error) {
+	issue, err := r.findPodSchedulingIssue(ctx, cluster)
+	if err != nil {
+		return ctrl.Result{}, false, err
+	}
+	if issue == nil {
+		removeConditionIfReason(&cluster.Status.Conditions, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonPodUnschedulable)
+		return ctrl.Result{}, false, nil
+	}
+
+	message := fmt.Sprintf("Pod %s is unschedulable", issue.podName)
+	if issue.message != "" {
+		message = fmt.Sprintf("%s: %s", message, issue.message)
+	}
+	setCondition(cluster, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonPodUnschedulable, message, metav1.ConditionTrue)
+	setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonPodUnschedulable, message, metav1.ConditionFalse)
+	setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonReconciling, "Waiting for unschedulable pods to be scheduled", metav1.ConditionTrue)
+	if err := r.updateStatus(ctx, cluster, nil); err != nil {
+		return ctrl.Result{}, false, err
+	}
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, true, nil
+}
+
+func (r *ValkeyClusterReconciler) findPodSchedulingIssue(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (*podSchedulingIssue, error) {
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{LabelCluster: cluster.Name})); err != nil {
+		return nil, fmt.Errorf("list Valkey pods: %w", err)
+	}
+
+	for i := range pods.Items {
+		if issue := podSchedulingIssueForPod(&pods.Items[i]); issue != nil {
+			return issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func podSchedulingIssueForPod(pod *corev1.Pod) *podSchedulingIssue {
+	if pod.DeletionTimestamp != nil {
+		return nil
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == corev1.PodReasonUnschedulable {
+			return &podSchedulingIssue{
+				podName: pod.Name,
+				message: condition.Message,
+			}
+		}
+	}
+	return nil
 }
 
 func headlessServiceName(clusterName string) string {
@@ -547,18 +621,19 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 			Labels:    l,
 		},
 		Spec: valkeyiov1alpha1.ValkeyNodeSpec{
-			Image:               cluster.Spec.Image,
-			WorkloadType:        cluster.Spec.WorkloadType,
-			Persistence:         cluster.Spec.Persistence,
-			Resources:           cluster.Spec.Resources,
-			NodeSelector:        cluster.Spec.NodeSelector,
-			Affinity:            cluster.Spec.Affinity,
-			Tolerations:         cluster.Spec.Tolerations,
-			Exporter:            cluster.Spec.Exporter,
-			Containers:          cluster.Spec.Containers,
-			ServerConfigMapName: GetServerConfigMapName(cluster.Name),
-			UsersACLSecretName:  getInternalSecretName(cluster.Name),
-			TLS:                 cluster.Spec.TLS,
+			Image:                     cluster.Spec.Image,
+			WorkloadType:              cluster.Spec.WorkloadType,
+			Persistence:               cluster.Spec.Persistence,
+			Resources:                 cluster.Spec.Resources,
+			NodeSelector:              cluster.Spec.NodeSelector,
+			Affinity:                  cluster.Spec.Affinity,
+			Tolerations:               cluster.Spec.Tolerations,
+			TopologySpreadConstraints: cluster.Spec.TopologySpreadConstraints,
+			Exporter:                  cluster.Spec.Exporter,
+			Containers:                cluster.Spec.Containers,
+			ServerConfigMapName:       GetServerConfigMapName(cluster.Name),
+			UsersACLSecretName:        getInternalSecretName(cluster.Name),
+			TLS:                       cluster.Spec.TLS,
 		},
 	}
 }

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -272,6 +272,34 @@ var _ = Describe("pod scheduling issue handling", func() {
 		Expect(degraded.Reason).To(Equal(valkeyiov1alpha1.ReasonPodUnschedulable))
 	})
 
+	It("clears stale unschedulable Ready and Degraded conditions when scheduling resolves", func() {
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-scheduling-resolved-test",
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 1,
+			},
+		}
+		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonPodUnschedulable, "Pod is unschedulable", metav1.ConditionFalse)
+		setCondition(cluster, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonPodUnschedulable, "Pod is unschedulable", metav1.ConditionTrue)
+
+		reconciler := &ValkeyClusterReconciler{
+			Client:   k8sClient,
+			Scheme:   k8sClient.Scheme(),
+			Recorder: events.NewFakeRecorder(100),
+		}
+
+		result, handled, err := reconciler.handlePodSchedulingIssues(ctx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(handled).To(BeFalse())
+		Expect(result).To(Equal(reconcile.Result{}))
+		Expect(testutils.FindCondition(cluster.Status.Conditions, valkeyiov1alpha1.ConditionReady)).To(BeNil())
+		Expect(testutils.FindCondition(cluster.Status.Conditions, valkeyiov1alpha1.ConditionDegraded)).To(BeNil())
+	})
+
 	It("ignores pods that are already scheduled", func() {
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "scheduled-pod"},

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -198,6 +199,91 @@ var _ = Describe("ValkeyCluster config hash propagation", func() {
 			Expect(n.Spec.ServerConfigHash).To(Equal(newHash),
 				"ValkeyNode %s ServerConfigHash must be updated to bump Generation and trigger ValkeyNode controller reconciliation", n.Name)
 		}
+	})
+})
+
+var _ = Describe("pod scheduling issue handling", func() {
+	ctx := context.Background()
+
+	It("sets the cluster degraded when a Valkey pod is unschedulable", func() {
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-unschedulable-status-test",
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 1,
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, cluster)
+		})
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-unschedulable-status-test-0",
+				Namespace: "default",
+				Labels: map[string]string{
+					LabelCluster: cluster.Name,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "server",
+					Image: DefaultImage,
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, pod)
+		})
+
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:    corev1.PodScheduled,
+			Status:  corev1.ConditionFalse,
+			Reason:  corev1.PodReasonUnschedulable,
+			Message: "0/1 nodes are available: pod topology spread constraints not satisfied",
+		}}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
+		reconciler := &ValkeyClusterReconciler{
+			Client:   k8sClient,
+			Scheme:   k8sClient.Scheme(),
+			Recorder: events.NewFakeRecorder(100),
+		}
+
+		result, handled, err := reconciler.handlePodSchedulingIssues(ctx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(handled).To(BeTrue())
+		Expect(result.RequeueAfter).To(Equal(10 * time.Second))
+
+		updated := &valkeyiov1alpha1.ValkeyCluster{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), updated)).To(Succeed())
+		Expect(updated.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateDegraded))
+		Expect(updated.Status.Reason).To(Equal(valkeyiov1alpha1.ReasonPodUnschedulable))
+		Expect(updated.Status.Message).To(ContainSubstring("pod topology spread constraints not satisfied"))
+
+		degraded := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionDegraded)
+		Expect(degraded).NotTo(BeNil())
+		Expect(degraded.Status).To(Equal(metav1.ConditionTrue))
+		Expect(degraded.Reason).To(Equal(valkeyiov1alpha1.ReasonPodUnschedulable))
+	})
+
+	It("ignores pods that are already scheduled", func() {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "scheduled-pod"},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		}
+
+		Expect(podSchedulingIssueForPod(pod)).To(BeNil())
 	})
 })
 

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -249,10 +249,11 @@ var _ = Describe("pod scheduling issue handling", func() {
 		}}
 		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 
+		fakeRecorder := events.NewFakeRecorder(100)
 		reconciler := &ValkeyClusterReconciler{
 			Client:   k8sClient,
 			Scheme:   k8sClient.Scheme(),
-			Recorder: events.NewFakeRecorder(100),
+			Recorder: fakeRecorder,
 		}
 
 		result, handled, err := reconciler.handlePodSchedulingIssues(ctx, cluster)
@@ -270,6 +271,11 @@ var _ = Describe("pod scheduling issue handling", func() {
 		Expect(degraded).NotTo(BeNil())
 		Expect(degraded.Status).To(Equal(metav1.ConditionTrue))
 		Expect(degraded.Reason).To(Equal(valkeyiov1alpha1.ReasonPodUnschedulable))
+
+		events := collectEvents(fakeRecorder)
+		Expect(events).To(ContainElement(ContainSubstring("Warning")))
+		Expect(events).To(ContainElement(ContainSubstring(valkeyiov1alpha1.ReasonPodUnschedulable)))
+		Expect(events).To(ContainElement(ContainSubstring("pod topology spread constraints not satisfied")))
 	})
 
 	It("clears stale unschedulable Ready and Degraded conditions when scheduling resolves", func() {

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -273,6 +274,55 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 	return mergePatchContainers(containers, node.Spec.Containers)
 }
 
+func buildShardTopologySpreadConstraints(node *valkeyiov1alpha1.ValkeyNode, labels map[string]string) []corev1.TopologySpreadConstraint {
+	if len(node.Spec.TopologySpreadConstraints) == 0 {
+		return nil
+	}
+
+	constraints := make([]corev1.TopologySpreadConstraint, len(node.Spec.TopologySpreadConstraints))
+	clusterName := labels[LabelCluster]
+	shardIndex := labels[LabelShardIndex]
+
+	for i := range node.Spec.TopologySpreadConstraints {
+		constraint := *node.Spec.TopologySpreadConstraints[i].DeepCopy()
+		if constraint.LabelSelector == nil {
+			constraint.LabelSelector = &metav1.LabelSelector{}
+		}
+		if constraint.LabelSelector.MatchLabels == nil {
+			constraint.LabelSelector.MatchLabels = map[string]string{}
+		}
+		if clusterName != "" && !topologySpreadConstraintUsesKey(constraint, LabelCluster) {
+			constraint.LabelSelector.MatchLabels[LabelCluster] = clusterName
+		}
+		if shardIndex != "" && !topologySpreadConstraintUsesKey(constraint, LabelShardIndex) {
+			constraint.MatchLabelKeys = append(constraint.MatchLabelKeys, LabelShardIndex)
+		}
+		constraints[i] = constraint
+	}
+
+	return constraints
+}
+
+func topologySpreadConstraintUsesKey(constraint corev1.TopologySpreadConstraint, key string) bool {
+	return labelSelectorUsesKey(constraint.LabelSelector, key) ||
+		slices.Contains(constraint.MatchLabelKeys, key)
+}
+
+func labelSelectorUsesKey(selector *metav1.LabelSelector, key string) bool {
+	if selector == nil {
+		return false
+	}
+	if _, exists := selector.MatchLabels[key]; exists {
+		return true
+	}
+	for _, expr := range selector.MatchExpressions {
+		if expr.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
 // buildValkeyNodePodTemplateSpec constructs a PodTemplateSpec for a single
 // Valkey node.
 func buildValkeyNodePodTemplateSpec(node *valkeyiov1alpha1.ValkeyNode, labels map[string]string) (corev1.PodTemplateSpec, error) {
@@ -289,10 +339,11 @@ func buildValkeyNodePodTemplateSpec(node *valkeyiov1alpha1.ValkeyNode, labels ma
 	}
 
 	podSpec := corev1.PodSpec{
-		Containers:   containers,
-		NodeSelector: node.Spec.NodeSelector,
-		Affinity:     node.Spec.Affinity,
-		Tolerations:  node.Spec.Tolerations,
+		Containers:                containers,
+		NodeSelector:              node.Spec.NodeSelector,
+		Affinity:                  node.Spec.Affinity,
+		Tolerations:               node.Spec.Tolerations,
+		TopologySpreadConstraints: buildShardTopologySpreadConstraints(node, labels),
 		Volumes: []corev1.Volume{
 			{
 				Name: "scripts",

--- a/internal/controller/valkeynode_resources_test.go
+++ b/internal/controller/valkeynode_resources_test.go
@@ -274,6 +274,126 @@ func TestBuildValkeyNodePodTemplateSpec_Scheduling(t *testing.T) {
 	assert.Equal(t, tolerations, pts.Spec.Tolerations, "tolerations should pass through")
 }
 
+func TestBuildValkeyNodePodTemplateSpec_TopologySpreadConstraints(t *testing.T) {
+	node := newTestValkeyNode("mycluster-1-0", "test-ns")
+	node.Labels = map[string]string{
+		LabelCluster:    "mycluster",
+		LabelShardIndex: "1",
+		LabelNodeIndex:  "0",
+	}
+	node.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+		},
+	}
+
+	pts, err := buildValkeyNodePodTemplateSpec(node, valkeyNodeLabels(node))
+	require.NoError(t, err)
+	require.Len(t, pts.Spec.TopologySpreadConstraints, 1)
+
+	constraint := pts.Spec.TopologySpreadConstraints[0]
+	require.NotNil(t, constraint.LabelSelector)
+	assert.Equal(t, "mycluster", constraint.LabelSelector.MatchLabels[LabelCluster], "cluster label should be injected")
+	assert.Contains(t, constraint.MatchLabelKeys, LabelShardIndex, "shard label key should scope the spread group")
+}
+
+func TestBuildValkeyNodePodTemplateSpec_TopologySpreadConstraintsPreservesUserSelector(t *testing.T) {
+	node := newTestValkeyNode("mycluster-1-0", "test-ns")
+	node.Labels = map[string]string{
+		LabelCluster:    "mycluster",
+		LabelShardIndex: "1",
+		LabelNodeIndex:  "0",
+	}
+	node.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "topology.kubernetes.io/zone",
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"role":          "server",
+					LabelShardIndex: "1",
+				},
+			},
+		},
+	}
+
+	pts, err := buildValkeyNodePodTemplateSpec(node, valkeyNodeLabels(node))
+	require.NoError(t, err)
+	require.Len(t, pts.Spec.TopologySpreadConstraints, 1)
+
+	constraint := pts.Spec.TopologySpreadConstraints[0]
+	require.NotNil(t, constraint.LabelSelector)
+	assert.Equal(t, "server", constraint.LabelSelector.MatchLabels["role"], "user selector labels should be preserved")
+	assert.Equal(t, "1", constraint.LabelSelector.MatchLabels[LabelShardIndex], "existing shard selector should be preserved")
+	assert.Equal(t, "mycluster", constraint.LabelSelector.MatchLabels[LabelCluster], "cluster label should still be injected")
+	assert.NotContains(t, constraint.MatchLabelKeys, LabelShardIndex, "shard key should not be duplicated when already selected")
+}
+
+func TestBuildValkeyNodePodTemplateSpec_TopologySpreadConstraintsAvoidsDuplicateReservedKeys(t *testing.T) {
+	node := newTestValkeyNode("mycluster-1-0", "test-ns")
+	node.Labels = map[string]string{
+		LabelCluster:    "mycluster",
+		LabelShardIndex: "1",
+		LabelNodeIndex:  "0",
+	}
+	node.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			MatchLabelKeys:    []string{LabelCluster},
+		},
+		{
+			MaxSkew:           1,
+			TopologyKey:       "topology.kubernetes.io/zone",
+			WhenUnsatisfiable: corev1.ScheduleAnyway,
+			MatchLabelKeys:    []string{LabelShardIndex},
+		},
+	}
+
+	pts, err := buildValkeyNodePodTemplateSpec(node, valkeyNodeLabels(node))
+	require.NoError(t, err)
+	require.Len(t, pts.Spec.TopologySpreadConstraints, 2)
+
+	clusterConstraint := pts.Spec.TopologySpreadConstraints[0]
+	require.NotNil(t, clusterConstraint.LabelSelector)
+	assert.NotContains(t, clusterConstraint.LabelSelector.MatchLabels, LabelCluster, "cluster label should not be injected when matchLabelKeys already uses it")
+	assert.Contains(t, clusterConstraint.MatchLabelKeys, LabelCluster, "user-provided cluster matchLabelKey should be preserved")
+	assert.Contains(t, clusterConstraint.MatchLabelKeys, LabelShardIndex, "shard key should still be injected when unused")
+
+	shardConstraint := pts.Spec.TopologySpreadConstraints[1]
+	require.NotNil(t, shardConstraint.LabelSelector)
+	assert.Equal(t, "mycluster", shardConstraint.LabelSelector.MatchLabels[LabelCluster], "cluster label should still be injected when unused")
+	assert.Contains(t, shardConstraint.MatchLabelKeys, LabelShardIndex, "user-provided shard matchLabelKey should be preserved")
+	assert.Len(t, shardConstraint.MatchLabelKeys, 1, "shard matchLabelKey should not be duplicated")
+}
+
+func TestBuildValkeyNodePodTemplateSpec_TopologySpreadConstraintsSkipsShardScopingWithoutShardLabel(t *testing.T) {
+	node := newTestValkeyNode("standalone-node", "test-ns")
+	node.Labels = map[string]string{
+		LabelCluster: "standalone-cluster",
+	}
+	node.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "kubernetes.io/hostname",
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+		},
+	}
+
+	pts, err := buildValkeyNodePodTemplateSpec(node, valkeyNodeLabels(node))
+	require.NoError(t, err)
+	require.Len(t, pts.Spec.TopologySpreadConstraints, 1)
+
+	constraint := pts.Spec.TopologySpreadConstraints[0]
+	require.NotNil(t, constraint.LabelSelector)
+	assert.Equal(t, "standalone-cluster", constraint.LabelSelector.MatchLabels[LabelCluster], "cluster label should still be injected")
+	assert.NotContains(t, constraint.MatchLabelKeys, LabelShardIndex, "shard label key should only be injected when the pod carries a shard label")
+}
+
 func TestBuildValkeyNodePodTemplateSpec_Resources(t *testing.T) {
 	resources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -669,6 +789,13 @@ func TestBuildClusterValkeyNode_PropagatesSpecFields(t *testing.T) {
 			Tolerations: []corev1.Toleration{
 				{Key: "dedicated", Operator: corev1.TolerationOpEqual, Value: "valkey", Effect: corev1.TaintEffectNoSchedule},
 			},
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				{
+					MaxSkew:           1,
+					TopologyKey:       "kubernetes.io/hostname",
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+				},
+			},
 			Exporter: valkeyv1.ExporterSpec{Enabled: true},
 			Containers: []corev1.Container{
 				{Name: "sidecar", Image: "sidecar:latest"},
@@ -685,6 +812,7 @@ func TestBuildClusterValkeyNode_PropagatesSpecFields(t *testing.T) {
 	assert.Equal(t, cluster.Spec.NodeSelector, node.Spec.NodeSelector, "NodeSelector must be propagated")
 	assert.Equal(t, cluster.Spec.Affinity, node.Spec.Affinity, "Affinity must be propagated")
 	assert.Equal(t, cluster.Spec.Tolerations, node.Spec.Tolerations, "Tolerations must be propagated")
+	assert.Equal(t, cluster.Spec.TopologySpreadConstraints, node.Spec.TopologySpreadConstraints, "TopologySpreadConstraints must be propagated")
 	assert.Equal(t, cluster.Spec.Exporter, node.Spec.Exporter, "Exporter must be propagated")
 	assert.Equal(t, cluster.Spec.Containers, node.Spec.Containers, "Containers must be propagated")
 	assert.Equal(t, GetServerConfigMapName(cluster.Name), node.Spec.ServerConfigMapName, "ServerConfigMapName must match configmap name")

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -1003,7 +1003,7 @@ spec:
 				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
 				g.Expect(cr.Status.ReadyShards).To(Equal(int32(3)))
 			}
-			Eventually(verifyCrStatus).Should(Succeed())
+			Eventually(verifyCrStatus, 5*time.Minute, 2*time.Second).Should(Succeed())
 
 			By("validating cluster access")
 			verifyClusterAccess := func(g Gomega) {
@@ -1137,6 +1137,133 @@ spec:
 			Expect(err).To(HaveOccurred(), "patch should be rejected")
 			Expect(output).To(ContainSubstring("persistence.size may only be expanded"),
 				"error should mention that persistence.size may only be expanded")
+		})
+	})
+
+	Context("topology spread constraints", Label("topology-spread"), func() {
+		const clusterName = "valkeycluster-topology-spread-e2e"
+
+		It("spreads pods from the same shard across different nodes", func() {
+			By("creating a ValkeyCluster with host-level topology spread constraints")
+			manifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  shards: 3
+  replicas: 1
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+`, clusterName)
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(manifest)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create ValkeyCluster with topology spread constraints")
+			defer func() {
+				cmd := exec.Command("kubectl", "delete", "valkeycluster", clusterName, "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+			}()
+
+			By("waiting for the ValkeyCluster to become ready")
+			verifyCrStatus := func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(clusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
+				g.Expect(cr.Status.ReadyShards).To(Equal(int32(3)))
+			}
+			Eventually(verifyCrStatus, 5*time.Minute, 2*time.Second).Should(Succeed())
+
+			By("verifying each shard is spread across two different nodes")
+			verifyShardPlacement := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", clusterName),
+					"-o", "go-template={{ range .items }}{{ index .metadata.labels \"valkey.io/shard-index\" }} {{ .spec.nodeName }}{{ \"\\n\" }}{{ end }}")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				shardNodes := map[string]map[string]struct{}{}
+				for _, line := range utils.GetNonEmptyLines(output) {
+					fields := strings.Fields(line)
+					g.Expect(fields).To(HaveLen(2), "expected shard-index and node-name")
+					if _, exists := shardNodes[fields[0]]; !exists {
+						shardNodes[fields[0]] = map[string]struct{}{}
+					}
+					shardNodes[fields[0]][fields[1]] = struct{}{}
+				}
+
+				g.Expect(shardNodes).To(HaveLen(3), "expected placement data for 3 shards")
+				for shardIndex, nodes := range shardNodes {
+					g.Expect(nodes).To(HaveLen(2), "expected shard %s to span two Kubernetes nodes", shardIndex)
+				}
+			}
+			Eventually(verifyShardPlacement).Should(Succeed())
+		})
+
+		It("surfaces scheduler failures when strict topology spread cannot be satisfied", func() {
+			const (
+				unschedulableClusterName = "vkc-tspread-unsched"
+				eligibleNodeLabelKey     = "valkey.io/e2e-topology-spread-node"
+				eligibleNodeLabelValue   = "true"
+			)
+
+			By("labeling one worker node as the only eligible node")
+			cmd := exec.Command("kubectl", "get", "nodes",
+				"--selector=!node-role.kubernetes.io/control-plane",
+				"-o", "jsonpath={.items[0].metadata.name}")
+			eligibleNode, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get worker node: %s", eligibleNode))
+			Expect(eligibleNode).NotTo(BeEmpty(), "expected at least one worker node")
+
+			cmd = exec.Command("kubectl", "label", "node", eligibleNode,
+				fmt.Sprintf("%s=%s", eligibleNodeLabelKey, eligibleNodeLabelValue), "--overwrite=true")
+			output, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to label worker node: %s", output))
+			defer func() {
+				cmd := exec.Command("kubectl", "label", "node", eligibleNode, eligibleNodeLabelKey+"-", "--overwrite=true")
+				_, _ = utils.Run(cmd)
+			}()
+
+			By("creating a ValkeyCluster whose shard requires at least two topology domains")
+			manifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  shards: 1
+  replicas: 1
+  nodeSelector:
+    %s: "%s"
+  topologySpreadConstraints:
+  - maxSkew: 1
+    minDomains: 2
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+`, unschedulableClusterName, eligibleNodeLabelKey, eligibleNodeLabelValue)
+			cmd = exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(manifest)
+			output, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create unschedulable ValkeyCluster: %s", output))
+			defer func() {
+				cmd := exec.Command("kubectl", "delete", "valkeycluster", unschedulableClusterName, "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+			}()
+
+			By("waiting for the ValkeyCluster status to report PodUnschedulable")
+			verifyUnschedulableStatus := func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(unschedulableClusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateDegraded))
+				g.Expect(cr.Status.Reason).To(Equal(valkeyiov1alpha1.ReasonPodUnschedulable))
+				g.Expect(cr.Status.Message).To(ContainSubstring("unschedulable"))
+
+				degradedCond := utils.FindCondition(cr.Status.Conditions, valkeyiov1alpha1.ConditionDegraded)
+				g.Expect(degradedCond).NotTo(BeNil(), "Degraded condition not found")
+				g.Expect(degradedCond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(degradedCond.Reason).To(Equal(valkeyiov1alpha1.ReasonPodUnschedulable))
+			}
+			Eventually(verifyUnschedulableStatus, 5*time.Minute, 2*time.Second).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
## Summary
- expose native `topologySpreadConstraints` on `ValkeyCluster` and propagate them to `ValkeyNode`
- augment pod topology spread rules with shard-aware cluster/shard selectors so same-shard primary/replica placement can be spread across nodes
- surface real scheduler placement failures as `ValkeyCluster.status.reason=PodUnschedulable`
- add unit and e2e coverage, including a strict scheduler-failure scenario

## Context
- follows the native topology spread direction discussed in #146
- supersedes the earlier default anti-affinity approach from #142