### PR TITLE
[feat] Roll ValkeyNodes on changes to ValkeyCluster.Spec.Config

### DIFF
--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -79,6 +79,13 @@ type ValkeyNodeSpec struct {
 	// +optional
 	ServerConfigMapName string `json:"serverConfigMapName,omitempty"`
 
+	// ServerConfigHash is a hash of the server ConfigMap contents. When set by
+	// the ValkeyCluster controller it bumps the spec Generation, which triggers
+	// the ValkeyNode controller to reconcile and update the pod template
+	// annotation — causing a rolling restart when the cluster config changes.
+	// +optional
+	ServerConfigHash string `json:"serverConfigHash,omitempty"`
+
 	// UsersACLSecretName is the name of the Secret containing the ACL user
 	// file. When set, mounts a users-acl volume from this Secret so the
 	// container can load aclfile /config/users/users.acl.

--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -2665,6 +2665,13 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              serverConfigHash:
+                description: |-
+                  ServerConfigHash is a hash of the server ConfigMap contents. When set by
+                  the ValkeyCluster controller it bumps the spec Generation, which triggers
+                  the ValkeyNode controller to reconcile and update the pod template
+                  annotation — causing a rolling restart when the cluster config changes.
+                type: string
               serverConfigMapName:
                 description: |-
                   ServerConfigMapName specifies the name of the ConfigMap that contains the

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -428,6 +428,19 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	return false, nil
 }
 
+// getServerConfigHash returns the config hash annotation from the cluster's
+// ConfigMap. Propagating this to ValkeyNode annotations triggers the ValkeyNode
+// controller to reconcile and update the pod template, causing a rolling restart
+// when the cluster config changes.
+func (r *ValkeyClusterReconciler) getServerConfigHash(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) string {
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(ctx, client.ObjectKey{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm); err != nil {
+		return ""
+	}
+	return cm.Annotations[configHashKey]
+}
+
+
 // reconcileValkeyNode reconciles a single ValkeyNode for (shardIndex, nodeIndex).
 // Returns (requeue, nodeCreated, err). requeue signals the caller should stop
 // iterating and wait before processing the next node.
@@ -465,6 +478,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, clust
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, node, func() error {
 		node.Labels = desired.Labels
 		node.Spec = desired.Spec
+		node.Spec.ServerConfigHash = r.getServerConfigHash(ctx, cluster)
 		return controllerutil.SetControllerReference(cluster, node, r.Scheme)
 	})
 	if err != nil {

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -130,6 +130,13 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
 	}
+	configHash := func() string {
+		cm := &corev1.ConfigMap{}
+		if err := r.Get(ctx, client.ObjectKey{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm); err != nil {
+			return ""
+		}
+		return cm.Annotations[configHashKey]
+	}()
 
 	nodes := &valkeyiov1alpha1.ValkeyNodeList{}
 	if err := r.List(ctx, nodes, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{LabelCluster: cluster.Name})); err != nil {
@@ -139,7 +146,7 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	if requeue, err := r.reconcileValkeyNodes(ctx, cluster, nodes); err != nil {
+	if requeue, err := r.reconcileValkeyNodes(ctx, cluster, nodes, configHash); err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeError, err.Error(), metav1.ConditionFalse)
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
@@ -384,7 +391,7 @@ func (r *ValkeyClusterReconciler) upsertService(ctx context.Context, cluster *va
 //	mycluster-0-0, mycluster-0-1, mycluster-0-2,
 //	mycluster-1-0, mycluster-1-1, mycluster-1-2,
 //	mycluster-2-0, mycluster-2-1, mycluster-2-2.
-func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, nodes *valkeyiov1alpha1.ValkeyNodeList) (bool, error) {
+func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, nodes *valkeyiov1alpha1.ValkeyNodeList, configHash string) (bool, error) {
 	log := logf.FromContext(ctx)
 
 	nodesPerShard := 1 + int(cluster.Spec.Replicas)
@@ -409,7 +416,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	for shardIndex := range int(cluster.Spec.Shards) {
 		// Iterate nodeIndex in reverse order (replicas before primary)
 		for nodeIndex := nodesPerShard - 1; nodeIndex >= 0; nodeIndex-- {
-			requeue, nodeCreated, err := r.reconcileValkeyNode(ctx, cluster, shardIndex, nodeIndex, clusterState)
+			requeue, nodeCreated, err := r.reconcileValkeyNode(ctx, cluster, shardIndex, nodeIndex, clusterState, configHash)
 			if err != nil {
 				return false, err
 			}
@@ -428,26 +435,14 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	return false, nil
 }
 
-// getServerConfigHash returns the config hash annotation from the cluster's
-// ConfigMap. Propagating this to ValkeyNode annotations triggers the ValkeyNode
-// controller to reconcile and update the pod template, causing a rolling restart
-// when the cluster config changes.
-func (r *ValkeyClusterReconciler) getServerConfigHash(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) string {
-	cm := &corev1.ConfigMap{}
-	if err := r.Get(ctx, client.ObjectKey{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm); err != nil {
-		return ""
-	}
-	return cm.Annotations[configHashKey]
-}
-
-
 // reconcileValkeyNode reconciles a single ValkeyNode for (shardIndex, nodeIndex).
 // Returns (requeue, nodeCreated, err). requeue signals the caller should stop
 // iterating and wait before processing the next node.
-func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex, nodeIndex int, clusterState *valkey.ClusterState) (bool, bool, error) {
+func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex, nodeIndex int, clusterState *valkey.ClusterState, configHash string) (bool, bool, error) {
 	log := logf.FromContext(ctx)
 
 	desired := buildClusterValkeyNode(cluster, shardIndex, nodeIndex)
+	desired.Spec.ServerConfigHash = configHash
 	node := &valkeyiov1alpha1.ValkeyNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      desired.Name,
@@ -478,7 +473,6 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, clust
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, node, func() error {
 		node.Labels = desired.Labels
 		node.Spec = desired.Spec
-		node.Spec.ServerConfigHash = r.getServerConfigHash(ctx, cluster)
 		return controllerutil.SetControllerReference(cluster, node, r.Scheme)
 	})
 	if err != nil {

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -618,7 +618,7 @@ var _ = Describe("reconcileValkeyNodes", func() {
 		Expect(k8sClient.List(testCtx, nodeList,
 			client.InNamespace("default"),
 			client.MatchingLabels{LabelCluster: clusterName})).To(Succeed())
-		return r.reconcileValkeyNodes(testCtx, cluster, nodeList)
+		return r.reconcileValkeyNodes(testCtx, cluster, nodeList, "")
 	}
 
 	// createAllNodes runs a single reconcile that creates all 4 ValkeyNode CRs.
@@ -818,7 +818,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 	}
 
 	It("creates the ValkeyNode and emits ValkeyNodeCreated event", func() {
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 		Expect(created).To(BeTrue())
@@ -829,12 +829,12 @@ var _ = Describe("reconcileValkeyNode", func() {
 	})
 
 	It("updates the ValkeyNode spec, emits ValkeyNodeUpdated event, and signals requeue", func() {
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		cluster.Spec.Image = "valkey/valkey:9.1.0"
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue())
 		Expect(created).To(BeFalse())
@@ -844,25 +844,25 @@ var _ = Describe("reconcileValkeyNode", func() {
 	})
 
 	It("signals requeue when node is unchanged but not yet ready", func() {
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		// Status.Ready defaults to false after creation
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue())
 		Expect(created).To(BeFalse())
 	})
 
 	It("does not requeue when node is unchanged and ready", func() {
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		setNodeReady(true)
 
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 		Expect(created).To(BeFalse())
@@ -870,7 +870,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 
 	It("signals requeue when node is unchanged but ObservedGeneration is stale", func() {
 		// Create the node
-		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		_, _, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Mark ready but leave ObservedGeneration at 0
@@ -885,7 +885,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 		// Because ObservedGeneration > 0 guard: newly created node with
 		// ObservedGeneration=0 falls through to the Ready check, which
 		// passes (Ready=true). No requeue.
-		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		requeue, created, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
 		Expect(created).To(BeFalse())
@@ -901,13 +901,13 @@ var _ = Describe("reconcileValkeyNode", func() {
 
 		// Change cluster spec to trigger an update on next reconcile
 		cluster.Spec.Image = "valkey/valkey:9.1.0"
-		requeue, _, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		requeue, _, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue(), "should requeue after updating node")
 
 		// Next reconcile: spec matches (OperationResultNone), but
 		// Generation (2) != ObservedGeneration (1) — must requeue.
-		requeue, created, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil)
+		requeue, created, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeTrue(), "should requeue while ObservedGeneration is stale")
 		Expect(created).To(BeFalse())

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -116,6 +116,91 @@ var _ = Describe("ValkeyCluster Controller", func() {
 	})
 })
 
+var _ = Describe("ValkeyCluster config hash propagation", func() {
+	ctx := context.Background()
+
+	It("should set configHashKey annotation on ValkeyNodes and update it when cluster config changes", func() {
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config-hash-test",
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+				Config:   map[string]string{"maxmemory": "100mb"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		defer func() {
+			nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+			_ = k8sClient.List(ctx, nodeList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: cluster.Name})
+			for i := range nodeList.Items {
+				_ = k8sClient.Delete(ctx, &nodeList.Items[i])
+			}
+			_ = k8sClient.Delete(ctx, cluster)
+			cm := &corev1.ConfigMap{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm); err == nil {
+				_ = k8sClient.Delete(ctx, cm)
+			}
+			secret := &corev1.Secret{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: getInternalSecretName(cluster.Name), Namespace: cluster.Namespace}, secret); err == nil {
+				_ = k8sClient.Delete(ctx, secret)
+			}
+		}()
+
+		r := &ValkeyClusterReconciler{
+			Client:   k8sClient,
+			Scheme:   k8sClient.Scheme(),
+			Recorder: events.NewFakeRecorder(100),
+		}
+
+		By("reconciling to create the ConfigMap and ValkeyNodes")
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("reading the config hash from the cluster ConfigMap")
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm)).To(Succeed())
+		initialHash := cm.Annotations[configHashKey]
+		Expect(initialHash).NotTo(BeEmpty())
+
+		By("verifying each ValkeyNode carries the config hash in its spec")
+		nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+		Expect(k8sClient.List(ctx, nodeList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: cluster.Name})).To(Succeed())
+		Expect(nodeList.Items).NotTo(BeEmpty())
+		for _, n := range nodeList.Items {
+			Expect(n.Spec.ServerConfigHash).To(Equal(initialHash),
+				"ValkeyNode %s must have ServerConfigHash set so a spec change triggers ValkeyNode controller reconciliation", n.Name)
+		}
+
+		By("updating the cluster config")
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+		cluster.Spec.Config["maxmemory"] = "200mb"
+		Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+
+		By("reconciling after the config change")
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying the ConfigMap has a new hash")
+		updatedCM := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, updatedCM)).To(Succeed())
+		newHash := updatedCM.Annotations[configHashKey]
+		Expect(newHash).NotTo(BeEmpty())
+		Expect(newHash).NotTo(Equal(initialHash), "config hash should change when cluster config changes")
+
+		By("verifying each ValkeyNode spec was updated with the new hash")
+		updatedNodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+		Expect(k8sClient.List(ctx, updatedNodeList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: cluster.Name})).To(Succeed())
+		Expect(updatedNodeList.Items).NotTo(BeEmpty())
+		for _, n := range updatedNodeList.Items {
+			Expect(n.Spec.ServerConfigHash).To(Equal(newHash),
+				"ValkeyNode %s ServerConfigHash must be updated to bump Generation and trigger ValkeyNode controller reconciliation", n.Name)
+		}
+	})
+})
+
 var _ = Describe("reconcileUsersAcl", func() {
 	Context("When reconciling ACL secrets", func() {
 		It("should return an error when a user references a missing password secret", func() {

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -115,7 +115,6 @@ func (r *ValkeyNodeReconciler) ensureWorkload(ctx context.Context, node *valkeyi
 	}
 }
 
-// ensureStatefulSet creates or updates the StatefulSet for the ValkeyNode.
 // buildPodTemplateAnnotations assembles the annotations that must be present on
 // the pod template spec to trigger rolling updates when the ACL secret or the
 // server config changes.
@@ -129,6 +128,7 @@ func buildPodTemplateAnnotations(node *valkeyiov1alpha1.ValkeyNode, aclSecret *c
 	return annotations
 }
 
+// ensureStatefulSet creates or updates the StatefulSet for the ValkeyNode.
 func (r *ValkeyNodeReconciler) ensureStatefulSet(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode) error {
 	log := logf.FromContext(ctx)
 	desired, err := buildValkeyNodeStatefulSet(node)

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -116,6 +116,19 @@ func (r *ValkeyNodeReconciler) ensureWorkload(ctx context.Context, node *valkeyi
 }
 
 // ensureStatefulSet creates or updates the StatefulSet for the ValkeyNode.
+// buildPodTemplateAnnotations assembles the annotations that must be present on
+// the pod template spec to trigger rolling updates when the ACL secret or the
+// server config changes.
+func buildPodTemplateAnnotations(node *valkeyiov1alpha1.ValkeyNode, aclSecret *corev1.Secret) map[string]string {
+	annotations := map[string]string{
+		hashAnnotationKey: aclSecret.Annotations[hashAnnotationKey],
+	}
+	if node.Spec.ServerConfigHash != "" {
+		annotations[configHashKey] = node.Spec.ServerConfigHash
+	}
+	return annotations
+}
+
 func (r *ValkeyNodeReconciler) ensureStatefulSet(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode) error {
 	log := logf.FromContext(ctx)
 	desired, err := buildValkeyNodeStatefulSet(node)
@@ -141,9 +154,7 @@ func (r *ValkeyNodeReconciler) ensureStatefulSet(ctx context.Context, node *valk
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, sts, func() error {
 		sts.Labels = desired.Labels
 		sts.Spec = desired.Spec
-		sts.Spec.Template.Annotations = map[string]string{
-			hashAnnotationKey: aclSecret.Annotations[hashAnnotationKey],
-		}
+		sts.Spec.Template.Annotations = buildPodTemplateAnnotations(node, aclSecret)
 		return controllerutil.SetControllerReference(node, sts, r.Scheme)
 	})
 	if err != nil {
@@ -180,9 +191,7 @@ func (r *ValkeyNodeReconciler) ensureDeployment(ctx context.Context, node *valke
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, dep, func() error {
 		dep.Labels = desired.Labels
 		dep.Spec = desired.Spec
-		dep.Spec.Template.Annotations = map[string]string{
-			hashAnnotationKey: aclSecret.Annotations[hashAnnotationKey],
-		}
+		dep.Spec.Template.Annotations = buildPodTemplateAnnotations(node, aclSecret)
 		return controllerutil.SetControllerReference(node, dep, r.Scheme)
 	})
 	if err != nil {

--- a/internal/controller/valkeynode_controller_test.go
+++ b/internal/controller/valkeynode_controller_test.go
@@ -600,6 +600,47 @@ var _ = Describe("ValkeyNode Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("persistence.storageClassName is immutable"))
 		})
+
+		It("should propagate ServerConfigHash spec field to StatefulSet pod template when ServerConfigMapName is set", func() {
+			By("recreating the ValkeyNode with ServerConfigMapName and ServerConfigHash set (simulating a cluster-managed node)")
+			recreateNode(valkeyiov1alpha1.ValkeyNodeSpec{
+				WorkloadType:        valkeyiov1alpha1.WorkloadTypeStatefulSet,
+				ServerConfigMapName: "ext-config",
+				ServerConfigHash:    "hash-v1",
+			})
+
+			r := &ValkeyNodeReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: events.NewFakeRecorder(100),
+			}
+
+			By("reconciling to create the StatefulSet")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the StatefulSet pod template carries the config hash annotation")
+			sts := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, statefulSetName, sts)).To(Succeed())
+			Expect(sts.Spec.Template.Annotations).To(HaveKeyWithValue(configHashKey, "hash-v1"),
+				"pod template must include config hash so Kubernetes triggers a rolling update on config change")
+
+			By("simulating a config change by updating ServerConfigHash in the spec")
+			node := &valkeyiov1alpha1.ValkeyNode{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, node)).To(Succeed())
+			node.Spec.ServerConfigHash = "hash-v2"
+			Expect(k8sClient.Update(ctx, node)).To(Succeed())
+
+			By("reconciling after the config change")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the StatefulSet pod template annotation was updated, causing a rolling update")
+			sts2 := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, statefulSetName, sts2)).To(Succeed())
+			Expect(sts2.Spec.Template.Annotations).To(HaveKeyWithValue(configHashKey, "hash-v2"),
+				"updated config hash must be propagated to trigger pod restart")
+		})
 	})
 
 	Context("When WorkloadType is Deployment", func() {

--- a/internal/controller/valkeynode_controller_test.go
+++ b/internal/controller/valkeynode_controller_test.go
@@ -762,6 +762,66 @@ var _ = Describe("ValkeyNode Controller", func() {
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deploy.Spec.Template.Spec.Containers[0].Image).To(Equal("valkey/valkey:8.0.0"))
 		})
+
+		It("should propagate ServerConfigHash spec field to Deployment pod template when ServerConfigMapName is set", func() {
+			By("recreating the ValkeyNode with ServerConfigMapName and ServerConfigHash set")
+			node := &valkeyiov1alpha1.ValkeyNode{}
+			if err := k8sClient.Get(ctx, typeNamespacedName, node); err == nil {
+				node.Finalizers = nil
+				Expect(k8sClient.Update(ctx, node)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, node)).To(Succeed())
+				Eventually(func() bool {
+					return apierrors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, &valkeyiov1alpha1.ValkeyNode{}))
+				}, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
+			}
+			Expect(k8sClient.Create(ctx, &valkeyiov1alpha1.ValkeyNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+					Labels: map[string]string{
+						LabelCluster: resourceName,
+					},
+				},
+				Spec: valkeyiov1alpha1.ValkeyNodeSpec{
+					WorkloadType:        valkeyiov1alpha1.WorkloadTypeDeployment,
+					ServerConfigMapName: "ext-config",
+					ServerConfigHash:    "hash-v1",
+				},
+			})).To(Succeed())
+
+			r := &ValkeyNodeReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: events.NewFakeRecorder(100),
+			}
+
+			By("reconciling to create the Deployment")
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the Deployment pod template carries the config hash annotation")
+			deploymentName := types.NamespacedName{Name: "valkey-" + resourceName, Namespace: "default"}
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentName, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Annotations).To(HaveKeyWithValue(configHashKey, "hash-v1"),
+				"pod template must include config hash so Kubernetes triggers a rolling update on config change")
+
+			By("simulating a config change by updating ServerConfigHash in the spec")
+			updated := &valkeyiov1alpha1.ValkeyNode{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updated)).To(Succeed())
+			updated.Spec.ServerConfigHash = "hash-v2"
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+
+			By("reconciling after the config change")
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the Deployment pod template annotation was updated, causing a rolling update")
+			dep2 := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, deploymentName, dep2)).To(Succeed())
+			Expect(dep2.Spec.Template.Annotations).To(HaveKeyWithValue(configHashKey, "hash-v2"),
+				"updated config hash must be propagated to trigger pod restart")
+		})
 	})
 
 	Context("When WorkloadType is unsupported", func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

This PR closes #50 

### Summary

Will make ValkeyNodes roll sequentially if ValkeyCluster.Spec.Config is updated.

This avoids the need for the user to manually roll pods for them to pick up config changes.

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

Nodes now pick up config changes made on ValkeyCluster.Spec.Config.

### Implementation

Added a `ServerConfigHash` field to ValkeyNode.Spec. When the valkey cluster controller updates this, it will cause a generation bump and trigger the underlying pod to be rolled.

Note that I fully intend on this being a temporary solution. When we refactor configs as part of #141 - this can be removed. Given we are in alpha we can continue to make these kind of changes.

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

N/A

### Testing

I ran a local test and saw the change trickle down.

As part of #141 we should introduce some e2e tests for configs, but we'll revisit that after its been implemented.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
