### PR TITLE
fixed pre-commit local go version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: make-lint
         name: run golangci-lint
         language: system
-        entry: bash -c "GOTOOLCHAIN=go1.25.0+auto make lint"
+        entry: bash -c 'GOTOOLCHAIN="go$(cat .go-version)+auto" make lint'
         types: [go]
         pass_filenames: false
 


### PR DESCRIPTION
This PR closes https://github.com/valkey-io/valkey-operator/issues/167

### Summary

there are inconsistencies in versions .golangci.yml uses  ` go: "1.26"` while pre-commit yaml uses 1.25

### Testing

```
pre-commit run --all-files
generate code and manifests..............................................Passed
run go mod tidy..........................................................Passed
run golangci-lint........................................................Passed
Check for merge conflicts................................................Passed
```

### Checklist

Before submitting the PR make sure the following are checked:

- [X] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
