### PR TITLE
Delete old events in BeforeSuite to prevent stale event assertions

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -68,7 +68,7 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("purging old events")
-	cmd := exec.Command("kubectl", "delete", "events", "--field-selector", "involvedObject.name=valkeycluster-sample")
+	cmd := exec.Command("kubectl", "delete", "events", "--all")
 	_, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to purge old events")
 


### PR DESCRIPTION
### Summary

Stale events from previous test runs persist on the cluster and intermittently cause event assertions to fail (e.g. StaleNodeForgotten from nodes forgotten after pod IP changes between runs).
The failure depends on whether pods happened to get new IPs on recreation in a previous test run.

Purge all events in BeforeSuite so assertions only see the current run.
The previously targeted resource "valkeycluster-sample" does not exist anyway.

### Features / Behaviour Changes

This PR fixes the flaky e2e-test part `creates a Valkey Cluster deployment` test in valkeycluster_test.go,
in assertion "StaleNodeForgotten event should not be emitted during initial creation"

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
