### PR TITLE
Fix e2e tests - pod already exists intermittent issue

### DIFF
--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -127,6 +127,8 @@ var _ = Describe("Manager", Ordered, func() {
 			// +kubebuilder:scaffold:e2e-metrics-webhooks-readiness
 
 			By("creating the curl-metrics pod to access the metrics endpoint")
+			_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", "curl-metrics",
+				"-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
 				"--namespace", namespace,
 				"--image=curlimages/curl:latest",

--- a/test/e2e/metrics_exporter_test.go
+++ b/test/e2e/metrics_exporter_test.go
@@ -204,8 +204,7 @@ spec:
 
 			By("Creating a curl pod to test metrics")
 			curlPodName := "curl-metrics-" + valkeyName
-			_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName,
-				"-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+			_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd = exec.Command("kubectl", "run", curlPodName, "--image=curlimages/curl:latest", "--restart=Never",
 				"--overrides",
 				`{
@@ -232,6 +231,10 @@ spec:
 				}`)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create curl pod")
+			defer func() {
+				cmd := exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+			}()
 
 			By("Waiting for the curl pod to be running")
 			Eventually(func(g Gomega) {
@@ -276,11 +279,6 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred(), "Health endpoint should be accessible")
 				g.Expect(out).NotTo(BeEmpty(), "Health endpoint should return a response")
 			}).Should(Succeed())
-
-			defer func() {
-				cmd := exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=false")
-				_, _ = utils.Run(cmd)
-			}()
 
 			By("Cleaning up test resources")
 			cmd = exec.Command("kubectl", "delete", "valkeycluster", valkeyName, "--ignore-not-found=true")
@@ -382,8 +380,7 @@ spec:
 			verifyCreatedUsers := func(g Gomega) {
 				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyName)
 				curlPodName := "curl-metrics-" + valkeyName
-				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName,
-					"-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 				cmd := exec.Command("kubectl", "run", curlPodName,
 					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",
 					"valkey-cli", "-c", "-h", clusterFqdn, "ACL", "LIST")

--- a/test/e2e/metrics_exporter_test.go
+++ b/test/e2e/metrics_exporter_test.go
@@ -232,10 +232,6 @@ spec:
 				}`)
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create curl pod")
-			defer func() {
-				cmd := exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=false")
-				_, _ = utils.Run(cmd)
-			}()
 
 			By("Waiting for the curl pod to be running")
 			Eventually(func(g Gomega) {
@@ -280,6 +276,11 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred(), "Health endpoint should be accessible")
 				g.Expect(out).NotTo(BeEmpty(), "Health endpoint should return a response")
 			}).Should(Succeed())
+
+			defer func() {
+				cmd := exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+			}()
 
 			By("Cleaning up test resources")
 			cmd = exec.Command("kubectl", "delete", "valkeycluster", valkeyName, "--ignore-not-found=true")

--- a/test/e2e/metrics_exporter_test.go
+++ b/test/e2e/metrics_exporter_test.go
@@ -204,6 +204,8 @@ spec:
 
 			By("Creating a curl pod to test metrics")
 			curlPodName := "curl-metrics-" + valkeyName
+			_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName,
+				"-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd = exec.Command("kubectl", "run", curlPodName, "--image=curlimages/curl:latest", "--restart=Never",
 				"--overrides",
 				`{
@@ -378,23 +380,25 @@ spec:
 			By("verifying created users")
 			verifyCreatedUsers := func(g Gomega) {
 				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyName)
-
-				cmd := exec.Command("kubectl", "run", "client",
+				curlPodName := "curl-metrics-" + valkeyName
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName,
+					"-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+				cmd := exec.Command("kubectl", "run", curlPodName,
 					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",
 					"valkey-cli", "-c", "-h", clusterFqdn, "ACL", "LIST")
 				_, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				cmd = exec.Command("kubectl", "wait", "pod/client",
+				cmd = exec.Command("kubectl", "wait", "pod/"+curlPodName,
 					"--for=jsonpath={.status.phase}=Succeeded", "--timeout=30s")
 				_, err = utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				cmd = exec.Command("kubectl", "logs", "client")
+				cmd = exec.Command("kubectl", "logs", curlPodName)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				cmd = exec.Command("kubectl", "delete", "pod", "client",
+				cmd = exec.Command("kubectl", "delete", "pod", curlPodName,
 					"--wait=true", "--timeout=30s")
 				_, err = utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -262,8 +262,7 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 				// Start a Valkey client pod to access the cluster and execute commands
 				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyClusterName)
 
-				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", "client",
-					"-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", "client", "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 
 				// Append the client command to the overall kubectl run command
 				cmd := exec.Command("kubectl", append([]string{"run", "client",

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -262,6 +262,9 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 				// Start a Valkey client pod to access the cluster and execute commands
 				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyClusterName)
 
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", "client",
+					"-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+
 				// Append the client command to the overall kubectl run command
 				cmd := exec.Command("kubectl", append([]string{"run", "client",
 					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",

--- a/test/e2e/valkeycluster_tls_test.go
+++ b/test/e2e/valkeycluster_tls_test.go
@@ -146,7 +146,8 @@ spec:
 		It("allows cluster access via TLS", func() {
 			clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyClusterName)
 
-			utils.Run(exec.Command("kubectl", "delete", "pod", "client-tls", "--ignore-not-found=true"))
+			utils.Run(exec.Command("kubectl", "delete", "pod", "client-tls",
+				"--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd := exec.Command("kubectl", "run", "client-tls",
 				fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--overrides",
 				fmt.Sprintf(`{
@@ -227,7 +228,8 @@ spec:
 
 			By("running curl pod to verify metrics endpoint")
 			curlPodName := "curl-tls-metrics"
-			utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true"))
+			utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName,
+				"--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd := exec.Command("kubectl", "run", curlPodName, "--image=curlimages/curl:latest", "--restart=Never", "--overrides", `{
 				"spec": {
 					"containers": [{

--- a/test/e2e/valkeycluster_tls_test.go
+++ b/test/e2e/valkeycluster_tls_test.go
@@ -146,8 +146,7 @@ spec:
 		It("allows cluster access via TLS", func() {
 			clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyClusterName)
 
-			utils.Run(exec.Command("kubectl", "delete", "pod", "client-tls",
-				"--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+			utils.Run(exec.Command("kubectl", "delete", "pod", "client-tls", "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd := exec.Command("kubectl", "run", "client-tls",
 				fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--overrides",
 				fmt.Sprintf(`{
@@ -228,8 +227,7 @@ spec:
 
 			By("running curl pod to verify metrics endpoint")
 			curlPodName := "curl-tls-metrics"
-			utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName,
-				"--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+			utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd := exec.Command("kubectl", "run", curlPodName, "--image=curlimages/curl:latest", "--restart=Never", "--overrides", `{
 				"spec": {
 					"containers": [{


### PR DESCRIPTION
This PR fixes intermittent E2E test failures caused by kubectl run attempting to create a pod with same name (client) that may already exist from previous test runs.
failed job link: https://github.com/valkey-io/valkey-operator/actions/runs/25645368225/job/75273172729
Error:
`[FAILED] Timed out after 120.001s.
  The function passed to Eventually failed at /home/runner/work/valkey-operator/valkey-operator/test/e2e/metrics_exporter_test.go:386 with:
  Unexpected error:
      <*fmt.wrapError | 0x29b7c393800>: 
      "kubectl run client --image=valkey/valkey:9.0.0 --restart=Never -- valkey-cli -c -h valkeycluster-no-exporter.default.svc.cluster.local ACL LIST" failed with error "Error from server (AlreadyExists): pods \"client\" already exists\n": exit status 1
      {
          msg: "\"kubectl run client --image=valkey/valkey:9.0.0 --restart=Never -- valkey-cli -c -h valkeycluster-no-exporter.default.svc.cluster.local ACL LIST\" failed with error \"Error from server (AlreadyExists): pods \\\"client\\\" already exists\\n\": exit status 1",`


### Changes
* Updated E2E tests to use unique client pod names or ensure cleanup before pod creation.
* Prevents failures like:
  `Error from server (AlreadyExists): pods "client" already exists`

### Testing
* Verified tests no longer fail intermittently due to existing `client` pods.

### Checklist

* [x] This Pull Request is related to one issue.
* [x] Commit message explains what changed and why
* [x] Tests are added or updated.
* [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)