### PR TITLE
Fix flaky metrics exporter test by waiting for cluster Ready

### DIFF
--- a/test/e2e/metrics_exporter_test.go
+++ b/test/e2e/metrics_exporter_test.go
@@ -28,6 +28,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 	"valkey.io/valkey-operator/test/utils"
 )
 
@@ -174,28 +176,18 @@ spec:
 				}
 			}).Should(Succeed())
 
-			By("Getting pod name for metrics verification")
-			var podName string
+			By("Waiting for the ValkeyCluster to reach Ready state")
 			Eventually(func(g Gomega) {
-				args := []string{
-					"get", "pods", "-l", "valkey.io/cluster=" + valkeyName,
-					"-o", "jsonpath={.items[0].metadata.name}",
-				}
-				cmd := exec.Command("kubectl", args...)
-				out, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod name")
-				g.Expect(out).NotTo(BeEmpty(), "Pod name should not be empty")
-				podName = out
+				cr, err := utils.GetValkeyClusterStatus(valkeyName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
 			}).Should(Succeed())
 
 			By("Getting pod IP for metrics verification")
 			var podIP string
 			Eventually(func(g Gomega) {
-				args := []string{
-					"get", "pods", podName,
-					"-o", "jsonpath={.status.podIP}",
-				}
-				cmd := exec.Command("kubectl", args...)
+				cmd := exec.Command("kubectl", "get", "pods", "-l", "valkey.io/cluster="+valkeyName,
+					"-o", "jsonpath={.items[0].status.podIP}")
 				out, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred(), "Failed to get pod IP")
 				g.Expect(out).NotTo(BeEmpty(), "Pod IP should not be empty")


### PR DESCRIPTION
### Summary

The metrics exporter test fetched the pod IP before the cluster reached `Ready` state.
During initial formation the pod IP may change before the cluster reaches Ready state. The curl then hits the stale address and times out.

Wait for the ValkeyCluster to reach Ready state before fetching the pod IP, ensuring the pod is stable and no further restarts will occur. Also fetch the IP by label selector instead of requiring the pod name as an intermediate step.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
