### PR TITLE
[fix] Switch to test-e2e context if it exists already

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo '{"kind": "Cluster", "apiVersion": "kind.x-k8s.io/v1alpha4", "nodes": [{"role": "control-plane"}, {"role": "worker"}, {"role": "worker"}]}' | $(KIND) create cluster --name $(KIND_CLUSTER) --config - ;; \
 	esac
 	@echo "Switching kubectl context to kind-$(KIND_CLUSTER)..."
-	@$(KUBECTL) config use-context kind-$(KIND_CLUSTER)
+	@"$(KUBECTL)" config use-context kind-$(KIND_CLUSTER)
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			echo '{"kind": "Cluster", "apiVersion": "kind.x-k8s.io/v1alpha4", "nodes": [{"role": "control-plane"}, {"role": "worker"}, {"role": "worker"}]}' | $(KIND) create cluster --name $(KIND_CLUSTER) --config - ;; \
 	esac
+	@echo "Switching kubectl context to kind-$(KIND_CLUSTER)..."
+	@$(KUBECTL) config use-context kind-$(KIND_CLUSTER)
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

This PR closes <Issue #>

### Summary

Currently, `make test-e2e` will check if it needs to create a kind cluster for e2e tests. If it doesn't exist, it uses kind to create one. Kind create cluster will switch the kubecfg context to this new cluster.

If the cluster exists, the switch does not happen, and so e2e tests are ran against the current context.

This PR will switch contexts to the e2e cluster if it exists.

<!--
Add a summary describing the changes
-->

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->

N/A

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->
N/A

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->
N/A

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

Tested locally and validated it.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
