### PR TITLE
[feat] Add minimal pod disruption budget

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -38,6 +38,16 @@ const (
 	ClusterStateFailed ClusterState = "Failed"
 )
 
+// PDBPolicy controls whether the operator manages a PodDisruptionBudget for the cluster.
+// Values may be added in future versions; clients MUST handle unknown values gracefully.
+// +kubebuilder:validation:Enum=Managed;Disabled
+type PDBPolicy string
+
+const (
+	PDBPolicyManaged  PDBPolicy = "Managed"
+	PDBPolicyDisabled PDBPolicy = "Disabled"
+)
+
 // ValkeyClusterSpec defines the desired state of ValkeyCluster.
 // +kubebuilder:validation:XValidation:rule="!(has(self.persistence) && self.workloadType == 'Deployment')",message="persistence requires workloadType StatefulSet"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.persistence) || has(self.persistence)",message="persistence cannot be removed once set"
@@ -105,6 +115,12 @@ type ValkeyClusterSpec struct {
 	// TLS configuration for the cluster
 	// +optional
 	TLS *TLSConfig `json:"tls,omitempty"`
+
+	// PodDisruptionBudget controls whether the operator manages a PodDisruptionBudget for this cluster.
+	// Set to Disabled when the PDB is managed externally or must be suppressed during maintenance.
+	// +kubebuilder:default=Managed
+	// +optional
+	PodDisruptionBudget PDBPolicy `json:"podDisruptionBudget,omitempty"`
 }
 
 // TLSConfig defines the TLS configuration for ValkeyCluster.
@@ -186,28 +202,29 @@ const (
 
 const (
 	// Common reasons for conditions
-	ReasonInitializing        = "Initializing"
-	ReasonReconciling         = "Reconciling"
-	ReasonClusterHealthy      = "ClusterHealthy"
-	ReasonServiceError        = "ServiceError"
-	ReasonConfigMapError      = "ConfigMapError"
-	ReasonValkeyNodeError     = "ValkeyNodeError"
-	ReasonValkeyNodeListError = "ValkeyNodeListError"
-	ReasonAddingNodes         = "AddingNodes"
-	ReasonNodeAddFailed       = "NodeAddFailed"
-	ReasonMissingShards       = "MissingShards"
-	ReasonMissingReplicas     = "MissingReplicas"
-	ReasonReconcileComplete   = "ReconcileComplete"
-	ReasonTopologyComplete    = "TopologyComplete"
-	ReasonAllSlotsAssigned    = "AllSlotsAssigned"
-	ReasonSlotsUnassigned     = "SlotsUnassigned"
-	ReasonPrimaryLost         = "PrimaryLost"
-	ReasonNoSlots             = "NoSlotsAvailable"
-	ReasonRebalancingSlots    = "RebalancingSlots"
-	ReasonRebalanceFailed     = "RebalanceFailed"
-	ReasonUsersAclError       = "UsersACLError"
-	ReasonUpdatingNodes       = "UpdatingNodes"
-	ReasonSystemUsersAclError = "SystemUsersACLError"
+	ReasonInitializing             = "Initializing"
+	ReasonReconciling              = "Reconciling"
+	ReasonClusterHealthy           = "ClusterHealthy"
+	ReasonServiceError             = "ServiceError"
+	ReasonConfigMapError           = "ConfigMapError"
+	ReasonValkeyNodeError          = "ValkeyNodeError"
+	ReasonValkeyNodeListError      = "ValkeyNodeListError"
+	ReasonAddingNodes              = "AddingNodes"
+	ReasonNodeAddFailed            = "NodeAddFailed"
+	ReasonMissingShards            = "MissingShards"
+	ReasonMissingReplicas          = "MissingReplicas"
+	ReasonReconcileComplete        = "ReconcileComplete"
+	ReasonTopologyComplete         = "TopologyComplete"
+	ReasonAllSlotsAssigned         = "AllSlotsAssigned"
+	ReasonSlotsUnassigned          = "SlotsUnassigned"
+	ReasonPrimaryLost              = "PrimaryLost"
+	ReasonNoSlots                  = "NoSlotsAvailable"
+	ReasonRebalancingSlots         = "RebalancingSlots"
+	ReasonRebalanceFailed          = "RebalanceFailed"
+	ReasonUsersAclError            = "UsersACLError"
+	ReasonUpdatingNodes            = "UpdatingNodes"
+	ReasonSystemUsersAclError      = "SystemUsersACLError"
+	ReasonPodDisruptionBudgetError = "PodDisruptionBudgetError"
 )
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -2607,6 +2607,16 @@ spec:
                 required:
                 - size
                 type: object
+              podDisruptionBudget:
+                default: Managed
+                description: |-
+                  PodDisruptionBudget controls operator management of a PodDisruptionBudget for this cluster.
+                  When Managed (default), the operator creates a PDB with maxUnavailable: 1 selecting all
+                  pods in the cluster. When Disabled, any PDB named valkey-<cluster> is deleted.
+                enum:
+                - Managed
+                - Disabled
+                type: string
               replicas:
                 description: The number of replicas for each shard group.
                 format: int32

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -2610,9 +2610,8 @@ spec:
               podDisruptionBudget:
                 default: Managed
                 description: |-
-                  PodDisruptionBudget controls operator management of a PodDisruptionBudget for this cluster.
-                  When Managed (default), the operator creates a PDB with maxUnavailable: 1 selecting all
-                  pods in the cluster. When Disabled, any PDB named valkey-<cluster> is deleted.
+                  PodDisruptionBudget controls whether the operator manages a PodDisruptionBudget for this cluster.
+                  Set to Disabled when the PDB is managed externally or must be suppressed during maintenance.
                 enum:
                 - Managed
                 - Disabled

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,18 @@ rules:
   - create
   - patch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - valkey.io
   resources:
   - valkeyclusters

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -55,6 +55,7 @@ Common reasons when `Ready=False`:
 - `SystemUsersACLError` – failed to reconcile system/internal ACL users
 - `ValkeyNodeError` – failed to create/update ValkeyNode CRs
 - `ValkeyNodeListError` – failed to list ValkeyNodes
+- `PodDisruptionBudgetError` – failed to create/update/delete the PodDisruptionBudget
 - `Reconciling` – controller is making changes
 - `UpdatingNodes` – rolling update of ValkeyNode CRs in progress
 - `MissingShards` – waiting for all shards to be created
@@ -230,6 +231,9 @@ These events are emitted during the creation and management of Kubernetes resour
 | `ValkeyNodeCreated` | Normal | ValkeyNode CR is created for a shard/replica position |
 | `ValkeyNodeUpdated` | Normal | ValkeyNode CR spec is updated (rolling update) |
 | `ValkeyNodeFailed` | Warning | Failed to create or update a ValkeyNode CR |
+| `PodDisruptionBudgetCreated` | Normal | PodDisruptionBudget is created |
+| `PodDisruptionBudgetUpdated` | Normal | PodDisruptionBudget is updated |
+| `PodDisruptionBudgetDeleted` | Normal | PodDisruptionBudget is deleted (policy set to Disabled) |
 
 ### Cluster topology events
 

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -14,6 +14,7 @@
 - [Containers](#containers)
 - [Metrics](#metrics)
 - [Persistence](#persistence)
+- [Pod disruption budget](#pod-disruption-budget)
 - [Scheduling](#scheduling)
 - [TLS](#tls)
 - [Users](#users)
@@ -96,6 +97,19 @@ When `persistence` is set, the operator manages a PVC for each ValkeyNode. With 
 
 - Live volume expansion
 - Automated volume expansion
+
+### Pod disruption budget
+
+```yaml
+podDisruptionBudget: Managed  # default
+```
+
+The operator creates a `PodDisruptionBudget` with `maxUnavailable: 1` selecting all pods in the cluster. Set to `Disabled` when the PDB is managed externally or is not required.
+
+| Value | Behaviour |
+|---|---|
+| `Managed` | Operator creates and owns the PDB |
+| `Disabled` | Operator deletes the PDB if it exists and does not recreate it |
 
 ### Scheduling
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -107,7 +107,7 @@ type ValkeyClusterReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/reconcile
-func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint:gocyclo
 	log := logf.FromContext(ctx)
 	log.V(1).Info("reconcile...")
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,6 +76,7 @@ type ValkeyClusterReconciler struct {
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is the main reconciliation loop. On each invocation it drives the
 // cluster one step closer to the desired state described by the ValkeyCluster
@@ -116,6 +118,12 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	if err := r.upsertService(ctx, cluster); err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonServiceError, err.Error(), metav1.ConditionFalse)
+		_ = r.updateStatus(ctx, cluster, nil)
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcilePodDisruptionBudget(ctx, cluster); err != nil {
+		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonPodDisruptionBudgetError, err.Error(), metav1.ConditionFalse)
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
 	}
@@ -1183,6 +1191,7 @@ func (r *ValkeyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&valkeyiov1alpha1.ValkeyNode{}).
 		Owns(&corev1.Secret{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findReferencedClusters),

--- a/internal/controller/valkeycluster_pdb.go
+++ b/internal/controller/valkeycluster_pdb.go
@@ -62,6 +62,7 @@ func (r *ValkeyClusterReconciler) reconcilePodDisruptionBudget(ctx context.Conte
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
 		existing.Labels = labels(cluster)
 		existing.Spec.MaxUnavailable = &maxUnavailable
+		existing.Spec.MinAvailable = nil
 		existing.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				LabelCluster: cluster.Name,

--- a/internal/controller/valkeycluster_pdb.go
+++ b/internal/controller/valkeycluster_pdb.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+)
+
+func pdbName(cluster *valkeyiov1alpha1.ValkeyCluster) string {
+	return "valkey-" + cluster.Name
+}
+
+func (r *ValkeyClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
+	if cluster.Spec.PodDisruptionBudget == valkeyiov1alpha1.PDBPolicyDisabled {
+		pdb := &policyv1.PodDisruptionBudget{}
+		err := r.Get(ctx, client.ObjectKey{Name: pdbName(cluster), Namespace: cluster.Namespace}, pdb)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("getting PDB for deletion: %w", err)
+		}
+		if err := r.Delete(ctx, pdb); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting PDB: %w", err)
+		}
+		r.Recorder.Eventf(cluster, pdb, corev1.EventTypeNormal, "PodDisruptionBudgetDeleted", "DeletePodDisruptionBudget", "Deleted PodDisruptionBudget")
+		return nil
+	}
+
+	maxUnavailable := intstr.FromInt32(1)
+	existing := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pdbName(cluster),
+			Namespace: cluster.Namespace,
+		},
+	}
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
+		existing.Labels = labels(cluster)
+		existing.Spec.MaxUnavailable = &maxUnavailable
+		existing.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				LabelCluster: cluster.Name,
+			},
+		}
+		return controllerutil.SetControllerReference(cluster, existing, r.Scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("upserting PDB: %w", err)
+	}
+	switch result {
+	case controllerutil.OperationResultCreated:
+		r.Recorder.Eventf(cluster, existing, corev1.EventTypeNormal, "PodDisruptionBudgetCreated", "CreatePodDisruptionBudget", "Created PodDisruptionBudget")
+	case controllerutil.OperationResultUpdated:
+		r.Recorder.Eventf(cluster, existing, corev1.EventTypeNormal, "PodDisruptionBudgetUpdated", "UpdatePodDisruptionBudget", "Updated PodDisruptionBudget")
+	}
+	return nil
+}

--- a/internal/controller/valkeycluster_pdb_test.go
+++ b/internal/controller/valkeycluster_pdb_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+)
+
+var _ = Describe("reconcilePodDisruptionBudget", func() {
+	var (
+		ctx        context.Context
+		reconciler *ValkeyClusterReconciler
+		cluster    *valkeyiov1alpha1.ValkeyCluster
+		pdbKey     types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		reconciler = &ValkeyClusterReconciler{
+			Client:   k8sClient,
+			Scheme:   k8sClient.Scheme(),
+			Recorder: events.NewFakeRecorder(100),
+		}
+		cluster = &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pdb-test-cluster",
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		pdbKey = types.NamespacedName{Name: pdbName(cluster), Namespace: cluster.Namespace}
+
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, cluster)
+			pdb := &policyv1.PodDisruptionBudget{}
+			if err := k8sClient.Get(ctx, pdbKey, pdb); err == nil {
+				_ = k8sClient.Delete(ctx, pdb)
+			}
+		})
+	})
+
+	Context("when PodDisruptionBudget is Managed (default)", func() {
+		It("creates a PDB with maxUnavailable: 1 and the correct selector", func() {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pdb := &policyv1.PodDisruptionBudget{}
+			Expect(k8sClient.Get(ctx, pdbKey, pdb)).To(Succeed())
+
+			maxUnavailable := intstr.FromInt32(1)
+			Expect(pdb.Spec.MaxUnavailable).To(Equal(&maxUnavailable))
+			Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(LabelCluster, cluster.Name))
+		})
+
+		It("recreates the PDB if it is externally deleted", func() {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pdb := &policyv1.PodDisruptionBudget{}
+			Expect(k8sClient.Get(ctx, pdbKey, pdb)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, pdb)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, pdbKey, pdb)).To(Succeed())
+		})
+	})
+
+	Context("when PodDisruptionBudget is Disabled", func() {
+		It("does not create a PDB", func() {
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, cluster)).To(Succeed())
+			cluster.Spec.PodDisruptionBudget = valkeyiov1alpha1.PDBPolicyDisabled
+			Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pdb := &policyv1.PodDisruptionBudget{}
+			err = k8sClient.Get(ctx, pdbKey, pdb)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("deletes an existing PDB when switched to Disabled", func() {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			pdb := &policyv1.PodDisruptionBudget{}
+			Expect(k8sClient.Get(ctx, pdbKey, pdb)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, cluster)).To(Succeed())
+			cluster.Spec.PodDisruptionBudget = valkeyiov1alpha1.PDBPolicyDisabled
+			Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, pdbKey, pdb)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

### Summary

Adds a pod disruption budget to ensure that voluntary pod cycles are limited to 1 at a time.

<!--
Add a summary describing the changes
-->

### Features / Behaviour Changes

Adds a new field `podDisruptionBudget` which takes an enum, defaulting to `Managed` to indicate that a PDB should be created.

Currently this defaults to `maxUnavailable: 1`, with selectors against `valkey.io/cluster=<CLUSTER_NAME>`

<!--
Outline the feature support or behaviour changes included in this PR
-->

### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

```
podDisruptionBudget: Managed # default

# disable it with:
podDisruptionBudget: Disabled
```


Enum chosen over boolean enabled/disabled in case additional modes are added later on.

For future use, we can switch it to be:

```
podDisruptionBudget:
  policy: Managed
  # ... more fields here
```

### Limitations

<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

No customisation yet, we can add this later on while we're still in alpha.



### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

e2e tests passed locally

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
