### PR TITLE
docs: Remove image.tag=main override in quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ Deploy a Valkey Cluster on Kubernetes in under 5 minutes.
 ```sh
 helm repo add valkey https://valkey.io/valkey-helm
 helm repo update
-helm install valkey-operator valkey/valkey-operator -n valkey-operator-system --create-namespace --set image.tag=main
+helm install valkey-operator valkey/valkey-operator -n valkey-operator-system --create-namespace
 ```
 
 Verify the operator is running:


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->


### Summary

Since we have now released valkey-operator v0.1.0, we can remove the override on image.tag=main in the quick start.

<!--
Add a summary describing the changes
-->

### Features / Behaviour Changes

<!--
Outline the feature support or behaviour changes included in this PR
-->
N/A

### Implementation


N/A
<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

N/A
<!--
Describe any features or use cases that are not implemented or are only partially supported
-->

### Testing

N/A
<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [x] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
