### PR TITLE
chore: Add prefix to headless service resource

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -51,7 +51,7 @@ var scripts embed.FS
 var scriptsHash string
 
 func GetServerConfigMapName(clusterName string) string {
-	return ResourcePrefix + clusterName + "-config"
+	return resourcePrefix + clusterName + "-config"
 }
 
 // buildManagedConfig returns the operator-managed directives shared by the

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -51,7 +51,7 @@ var scripts embed.FS
 var scriptsHash string
 
 func GetServerConfigMapName(clusterName string) string {
-	return "valkey-" + clusterName + "-config"
+	return ResourcePrefix + clusterName + "-config"
 }
 
 // buildManagedConfig returns the operator-managed directives shared by the

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	appName        = "valkey"
-	ResourcePrefix = "valkey-"
+	resourcePrefix = "valkey-"
 )
 
 // Naming and labelling scheme

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -32,7 +32,10 @@ import (
 	"valkey.io/valkey-operator/internal/valkey"
 )
 
-const appName = "valkey"
+const (
+	appName        = "valkey"
+	ResourcePrefix = "valkey-"
+)
 
 // Naming and labelling scheme
 //

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -355,7 +355,7 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 func headlessServiceName(clusterName string) string {
-	return ResourcePrefix + clusterName
+	return resourcePrefix + clusterName
 }
 
 // Create or update a headless service (client connects to pods directly)

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -354,11 +354,15 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 }
 
+func headlessServiceName(clusterName string) string {
+	return ResourcePrefix + clusterName
+}
+
 // Create or update a headless service (client connects to pods directly)
 func (r *ValkeyClusterReconciler) upsertService(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cluster.Name,
+			Name:      headlessServiceName(cluster.Name),
 			Namespace: cluster.Namespace,
 		},
 	}
@@ -569,7 +573,7 @@ func (r *ValkeyClusterReconciler) getValkeyClusterState(ctx context.Context, clu
 	}
 	var tlsConfig *tls.Config
 	if cluster.Spec.TLS != nil && cluster.Spec.TLS.Certificate.SecretName != "" {
-		serverName := fmt.Sprintf("%s.%s.svc.cluster.local", cluster.Name, cluster.Namespace)
+		serverName := fmt.Sprintf("%s.%s.svc.cluster.local", headlessServiceName(cluster.Name), cluster.Namespace)
 		cfg, err := getTLSConfig(ctx, r.Client, cluster.Spec.TLS.Certificate.SecretName, serverName, cluster.Namespace)
 		if err == nil {
 			tlsConfig = cfg

--- a/internal/controller/valkeycluster_pdb.go
+++ b/internal/controller/valkeycluster_pdb.go
@@ -32,7 +32,7 @@ import (
 )
 
 func pdbName(cluster *valkeyiov1alpha1.ValkeyCluster) string {
-	return ResourcePrefix + cluster.Name
+	return resourcePrefix + cluster.Name
 }
 
 func (r *ValkeyClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {

--- a/internal/controller/valkeycluster_pdb.go
+++ b/internal/controller/valkeycluster_pdb.go
@@ -32,7 +32,7 @@ import (
 )
 
 func pdbName(cluster *valkeyiov1alpha1.ValkeyCluster) string {
-	return "valkey-" + cluster.Name
+	return ResourcePrefix + cluster.Name
 }
 
 func (r *ValkeyClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -441,7 +441,7 @@ func (r *ValkeyNodeReconciler) getValkeyRole(ctx context.Context, node *valkeyio
 		secretName := node.Spec.TLS.Certificate.SecretName
 		serverName := ""
 		if clusterName, ok := node.Labels[LabelCluster]; ok {
-			serverName = fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, node.Namespace)
+			serverName = fmt.Sprintf("%s.%s.svc.cluster.local", headlessServiceName(clusterName), node.Namespace)
 		}
 
 		cfg, err := getTLSConfig(ctx, r.Client, secretName, serverName, node.Namespace)

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -30,7 +30,7 @@ import (
 // valkeyNodeResourceName returns the name used for resources
 // owned by the given ValkeyNode.
 func valkeyNodeResourceName(node *valkeyiov1alpha1.ValkeyNode) string {
-	return ResourcePrefix + node.Name
+	return resourcePrefix + node.Name
 }
 
 // valkeyNodeLabels returns the standard Kubernetes recommended labels for

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -30,7 +30,7 @@ import (
 // valkeyNodeResourceName returns the name used for resources
 // owned by the given ValkeyNode.
 func valkeyNodeResourceName(node *valkeyiov1alpha1.ValkeyNode) string {
-	return "valkey-" + node.Name
+	return ResourcePrefix + node.Name
 }
 
 // valkeyNodeLabels returns the standard Kubernetes recommended labels for

--- a/test/e2e/metrics_exporter_test.go
+++ b/test/e2e/metrics_exporter_test.go
@@ -370,7 +370,7 @@ spec:
 
 			By("verifying created users")
 			verifyCreatedUsers := func(g Gomega) {
-				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyName)
+				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", valkeyName)
 				curlPodName := "curl-metrics-" + valkeyName
 				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", curlPodName, "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 				cmd := exec.Command("kubectl", "run", curlPodName,

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 
 			By("validating the Service")
 			verifyServiceExists := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "service", valkeyClusterName)
+				cmd := exec.Command("kubectl", "get", "service", "valkey-"+valkeyClusterName)
 				_, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 			}
@@ -260,7 +260,7 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 			By("validating client commands")
 			verifyClusterAccess := func(g Gomega, expected string, command ...string) {
 				// Start a Valkey client pod to access the cluster and execute commands
-				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyClusterName)
+				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", valkeyClusterName)
 
 				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", "client", "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 
@@ -389,7 +389,7 @@ spec:
 
 			By("validating cluster access")
 			verifyClusterAccess := func(g Gomega) {
-				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", singleNodeClusterName)
+				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", singleNodeClusterName)
 
 				cmd := exec.Command("kubectl", "run", "client",
 					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",
@@ -452,7 +452,7 @@ spec:
 
 			By("verifying created users")
 			verifyCreatedUsers := func(g Gomega) {
-				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", withUserClusterName)
+				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", withUserClusterName)
 
 				cmd := exec.Command("kubectl", "run", "client",
 					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",
@@ -696,7 +696,7 @@ spec:
 
 			By("validating that the Service does not exist")
 			verifyServiceRemoved := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "service", valkeyClusterName)
+				cmd := exec.Command("kubectl", "get", "service", "valkey-"+valkeyClusterName)
 				_, err := utils.Run(cmd)
 				g.Expect(err).To(HaveOccurred())
 			}
@@ -1007,7 +1007,7 @@ spec:
 
 			By("validating cluster access")
 			verifyClusterAccess := func(g Gomega) {
-				clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", deploymentClusterName)
+				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", deploymentClusterName)
 
 				cmd := exec.Command("kubectl", "run", "client",
 					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",

--- a/test/e2e/valkeycluster_tls_test.go
+++ b/test/e2e/valkeycluster_tls_test.go
@@ -62,9 +62,9 @@ metadata:
   name: %s
 spec:
   secretName: %s
-  commonName: %s.default.svc.cluster.local
+  commonName: valkey-%s.default.svc.cluster.local
   dnsNames:
-    - %s.default.svc.cluster.local
+    - valkey-%s.default.svc.cluster.local
     - localhost
   issuerRef:
     name: selfsigned-issuer
@@ -144,7 +144,7 @@ spec:
 		})
 
 		It("allows cluster access via TLS", func() {
-			clusterFqdn := fmt.Sprintf("%s.default.svc.cluster.local", valkeyClusterName)
+			clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", valkeyClusterName)
 
 			utils.Run(exec.Command("kubectl", "delete", "pod", "client-tls", "--ignore-not-found=true", "--wait=true", "--timeout=30s"))
 			cmd := exec.Command("kubectl", "run", "client-tls",


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

This PR closes <Issue #>

### Summary

- Prefixes the created headless service with `valkey-`, so that it becomes `valkey-$CLUSTER_NAME`
  - In line with other managed resources
- Remove magic strings of "valkey-", replace with a constant
### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
