### PR TITLE
chore: remove ConfigMap suffix from managed resource names

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -51,7 +51,7 @@ var scripts embed.FS
 var scriptsHash string
 
 func GetServerConfigMapName(clusterName string) string {
-	return "valkey-" + clusterName + "-config"
+	return "valkey-" + clusterName
 }
 
 // buildManagedConfig returns the operator-managed directives shared by the

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -73,7 +73,7 @@ func TestAnnotations(t *testing.T) {
 }
 
 func TestConfigMapName(t *testing.T) {
-	testMapName := "valkey-test-resource-config"
+	testMapName := "valkey-test-resource"
 	result := GetServerConfigMapName("test-resource")
 	if result != testMapName {
 		t.Errorf("Expected '%v', got '%v'", testMapName, result)

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -704,7 +704,7 @@ spec:
 
 			By("validating that the ConfigMap does not exist")
 			verifyConfigMapRemoved := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "configmap", valkeyClusterName)
+				cmd := exec.Command("kubectl", "get", "configmap", controller.GetServerConfigMapName(valkeyClusterName))
 				_, err := utils.Run(cmd)
 				g.Expect(err).To(HaveOccurred())
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

This PR closes #184

### Summary

Removes the `-config` suffix from operator-managed ConfigMap names so the managed resource name no longer includes the resource kind.

### Features / Behaviour Changes

Operator-managed ConfigMaps are now named `valkey-<name>` instead of `valkey-<name>-config`.

User-provided `serverConfigMapName` values are still respected unchanged.

### Implementation

Updated `GetServerConfigMapName` to return `valkey-<name>`.

Updated the related unit test expectation and adjusted the e2e cleanup check to use the shared name helper instead of a hard-coded ConfigMap name.

### Limitations

Existing installations may leave the previous `valkey-<name>-config` ConfigMap behind after upgrading. The operator will create and use the new `valkey-<name>` ConfigMap going forward.

### Testing

- `make test` passed in Docker/Linux environment
- `git diff --check` passed

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)