### PR TITLE
perf: pipeline getNodeState to save valkey roundtrips

### DIFF
--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -312,36 +312,48 @@ func getNodeState(ctx context.Context, address string, port int, username string
 		Address: address,
 		Port:    port}
 
-	id, err := client.Do(ctx, client.B().ClusterMyid().Build()).ToString()
-	if err != nil {
-		log.Error(err, "command failed: CLUSTER MYID")
-	}
-	node.Id = id
+	results := client.DoMulti(ctx,
+		client.B().ClusterMyid().Build(),
+		client.B().ClusterMyshardid().Build(),
+		client.B().Info().Build(),
+		client.B().ClusterInfo().Build(),
+		client.B().ClusterNodes().Build(),
+	)
 
-	shardid, err := client.Do(ctx, client.B().ClusterMyshardid().Build()).ToString()
-	if err != nil {
-		log.Error(err, "command failed: CLUSTER MYSHARDID")
-	}
-	node.ShardId = shardid
+	if len(results) == 5 {
+		id, err := results[0].ToString()
+		if err != nil {
+			log.Error(err, "command failed: CLUSTER MYID")
+		}
+		node.Id = id
 
-	info, err := client.Do(ctx, client.B().Info().Build()).ToString()
-	if err != nil {
-		log.Error(err, "command failed: INFO")
-	}
-	node.Info = infoStringToMap(info)
+		shardid, err := results[1].ToString()
+		if err != nil {
+			log.Error(err, "command failed: CLUSTER MYSHARDID")
+		}
+		node.ShardId = shardid
 
-	cinfo, err := client.Do(ctx, client.B().ClusterInfo().Build()).ToString()
-	if err != nil {
-		log.Error(err, "command failed: CLUSTER INFO")
-	}
-	node.ClusterInfo = infoStringToMap(cinfo)
+		info, err := results[2].ToString()
+		if err != nil {
+			log.Error(err, "command failed: INFO")
+		}
+		node.Info = infoStringToMap(info)
 
-	cnodes, err := client.Do(ctx, client.B().ClusterNodes().Build()).ToString()
-	if err != nil {
-		log.Error(err, "command failed: CLUSTER NODES")
+		cinfo, err := results[3].ToString()
+		if err != nil {
+			log.Error(err, "command failed: CLUSTER INFO")
+		}
+		node.ClusterInfo = infoStringToMap(cinfo)
+
+		cnodes, err := results[4].ToString()
+		if err != nil {
+			log.Error(err, "command failed: CLUSTER NODES")
+		}
+		// Remove the encoding string included in a verbatim string.
+		node.ClusterNodes = strings.TrimPrefix(cnodes, "txt:")
+	} else {
+		log.Error(fmt.Errorf("expected 5 results from DoMulti, got %d", len(results)), "failed to query node state")
 	}
-	// Remove the encoding string included in a verbatim string.
-	node.ClusterNodes = strings.TrimPrefix(cnodes, "txt:")
 
 	// Extract flags
 	for line := range strings.SplitSeq(node.ClusterNodes, "\n") {


### PR DESCRIPTION
### Features / Behaviour Changes

Hi all, I came across this project and noticed that the current valkey-go usage in the `getNodeState` can be pipelined, so I made this PR. This is purely a performance improvement that saves unnecessary valkey roundtrips.

No functional changes.

### Implementation

Use DoMulti to send these at once:
```go
	results := client.DoMulti(ctx,
		client.B().ClusterMyid().Build(),
		client.B().ClusterMyshardid().Build(),
		client.B().Info().Build(),
		client.B().ClusterInfo().Build(),
		client.B().ClusterNodes().Build(),
	)
```

### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
