### PR TITLE
fix: handle fragmented slot ranges in assignSlotsToPendingPrimaries

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -668,7 +668,6 @@ func (r *ValkeyClusterReconciler) meetIsolatedNodes(ctx context.Context, cluster
 // first in Phase 1.
 func (r *ValkeyClusterReconciler) assignSlotsToPendingPrimaries(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, state *valkey.ClusterState, nodes *valkeyiov1alpha1.ValkeyNodeList) (int, error) {
 	log := logf.FromContext(ctx)
-	shardsRequired := int(cluster.Spec.Shards)
 
 	// Collect primary pending nodes (node index 0 = primary), skipping:
 	//  - isolated nodes (cluster_known_nodes <= 1): they haven't been
@@ -679,7 +678,7 @@ func (r *ValkeyClusterReconciler) assignSlotsToPendingPrimaries(ctx context.Cont
 	//    (1 shard, 0 replicas), isolation is the permanent correct state,
 	//    there is nobody to MEET, so the guard is skipped.
 	//  - post-failover replacements whose shard already has a live primary.
-	isSingleNodeCluster := shardsRequired == 1 && cluster.Spec.Replicas == 0
+	isSingleNodeCluster := cluster.Spec.Shards == 1 && cluster.Spec.Replicas == 0
 	primaries := make([]*valkey.NodeState, 0, len(state.PendingNodes))
 	for _, node := range state.PendingNodes {
 		if node.IsIsolated() && !isSingleNodeCluster {
@@ -709,39 +708,55 @@ func (r *ValkeyClusterReconciler) assignSlotsToPendingPrimaries(ctx context.Cont
 		return 0, nil
 	}
 
+	unassignedSlots := 0
+	for _, s := range slots {
+		unassignedSlots += s.End - s.Start + 1
+	}
+
 	assigned := 0
-	shardsExists := len(state.Shards)
 	for _, node := range primaries {
 		if len(slots) == 0 {
 			break
 		}
 
-		slotStart := slots[0].Start
-		numSlotsPerShard := valkey.TotalSlots / shardsRequired
-		shardIdx := shardsExists + assigned
-		// Distribute the remainder evenly: the first (TotalSlots % shardsRequired)
-		// shards each get one extra slot.
-		if shardIdx < valkey.TotalSlots%shardsRequired {
-			numSlotsPerShard++
-		}
-		slotEnd := slotStart + numSlotsPerShard - 1
+		remainingPrimaries := len(primaries) - assigned
+		// Ceiling division to ensure all slots are distributed without remainder.
+		numSlotsForNode := (unassignedSlots + remainingPrimaries - 1) / remainingPrimaries
 
-		log.V(1).Info("assign slots to primary", "node", node.Address, "slotStart", slotStart, "slotEnd", slotEnd)
-		if err := node.Client.Do(ctx, node.Client.B().ClusterAddslotsrange().StartSlotEndSlot().StartSlotEndSlot(int64(slotStart), int64(slotEnd)).Build()).Error(); err != nil {
-			log.Error(err, "CLUSTER ADDSLOTSRANGE failed", "node", node.Address, "slotStart", slotStart, "slotEnd", slotEnd)
-			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "SlotAssignmentFailed", "AssignSlots", "Failed to assign slots %d-%d to %v: %v", slotStart, slotEnd, node.Address, err)
+		// Collect ranges for this node
+		var nodeRanges []valkey.SlotsRange
+		remaining := numSlotsForNode
+		for remaining > 0 && len(slots) > 0 {
+			slotStart := slots[0].Start
+			take := min(slots[0].End-slots[0].Start+1, remaining)
+			slotEnd := slotStart + take - 1
+
+			nodeRanges = append(nodeRanges, valkey.SlotsRange{Start: slotStart, End: slotEnd})
+			remaining -= take
+			unassignedSlots -= take
+			// Advance the slots list: either consume the entire first range
+			// or trim its start. This avoids rebuilding the slice each iteration.
+			if take == slots[0].End-slots[0].Start+1 {
+				slots = slots[1:]
+			} else {
+				slots[0].Start = slotEnd + 1
+			}
+		}
+
+		// Issue a single CLUSTER ADDSLOTSRANGE with all ranges for this node
+		cmd := node.Client.B().ClusterAddslotsrange().StartSlotEndSlot()
+		for _, sr := range nodeRanges {
+			cmd = cmd.StartSlotEndSlot(int64(sr.Start), int64(sr.End))
+		}
+		log.V(1).Info("assign slots to primary", "node", node.Address, "ranges", nodeRanges)
+		if err := node.Client.Do(ctx, cmd.Build()).Error(); err != nil {
+			log.Error(err, "CLUSTER ADDSLOTSRANGE failed", "node", node.Address, "ranges", nodeRanges)
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "SlotAssignmentFailed", "AssignSlots", "Failed to assign slots %s to %v: %v", valkey.FormatSlotsRanges(nodeRanges), node.Address, err)
 			return assigned, err
 		}
-		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "PrimaryCreated", "CreatePrimary", "Created primary %v with slots %d-%d", node.Address, slotStart, slotEnd)
-		assigned++
 
-		// Update the unassigned slots for the next iteration by removing
-		// the range we just assigned.
-		var remainingSlots []valkey.SlotsRange
-		for _, s := range slots {
-			remainingSlots = append(remainingSlots, valkey.SubtractSlotsRange(s, valkey.SlotsRange{Start: slotStart, End: slotEnd})...)
-		}
-		slots = remainingSlots
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "PrimaryCreated", "CreatePrimary", "Created primary %v with slots %s", node.Address, valkey.FormatSlotsRanges(nodeRanges))
+		assigned++
 	}
 	return assigned, nil
 }

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -64,6 +64,22 @@ type SlotsRange struct {
 	End   int
 }
 
+func (s SlotsRange) String() string {
+	if s.Start == s.End {
+		return fmt.Sprintf("%d", s.Start)
+	}
+	return fmt.Sprintf("%d-%d", s.Start, s.End)
+}
+
+// FormatSlotsRanges formats a slice of SlotsRange as "0-100,500-600".
+func FormatSlotsRanges(ranges []SlotsRange) string {
+	parts := make([]string, len(ranges))
+	for i, r := range ranges {
+		parts[i] = r.String()
+	}
+	return strings.Join(parts, ",")
+}
+
 // GetClusterState connects to Valkey nodes and scrapes the current state.
 func GetClusterState(ctx context.Context, addresses []string, port int, username, password string, tlsCfg *tls.Config) *ClusterState {
 	state := ClusterState{


### PR DESCRIPTION
### Summary

When both primary and replica pods are lost for a shard, the operator must reassign that shard's slots to a new primary. The previous implementation calculated slots-per-node as TotalSlots / total_shards and distributed the remainder based on a global shard index. During recovery the shard index of the replacement didn't qualify for the extra slot, leaving 1 slot permanently unassigned.

Additionally, it assumed unassigned slots formed a single contiguous range, which fails when slots are fragmented after rebalancing.

### Features / Behaviour Changes
- Calculate slots-per-node from actual unassigned count divided by pending primaries (equivalent as for initial creation)
- Consume from multiple fragmented ranges per primary
- Issue a single CLUSTER ADDSLOTSRANGE call per node with all ranges
- Add SlotsRange.String() and FormatSlotsRanges for readable event messages

### Testing

The issue can be reproduced using:
```
# Create a cluster (v0.1.0)
kind create cluster
helm repo update
helm install valkey-operator valkey/valkey-operator -n valkey-operator-system --create-namespace

cat <<EOF | kubectl apply -f -
  apiVersion: valkey.io/v1alpha1
  kind: ValkeyCluster
  metadata:
    name: my-cluster
  spec:
    shards: 3
    replicas: 1
EOF
kubectl get valkeycluster

# Scale out, and in again
kubectl patch valkeycluster my-cluster --type=merge -p '{"spec":{"shards":5}}'
kubectl get valkeycluster
kubectl patch valkeycluster my-cluster --type=merge -p '{"spec":{"shards":3}}'
kubectl get valkeycluster

# Verify that slot ranges are fragmented now
kubectl exec pod/valkey-my-cluster-0-0-0 -c server -- valkey-cli CLUSTER NODES

# Delete both pods of a shard
kubectl delete pod valkey-my-cluster-0-0-0 valkey-my-cluster-0-1-0

# The cluster is now forever degraded.
kubectl logs -n valkey-operator-system deployment.apps/valkey-operator-controller-manager

# Log snippet
..  DEBUG	events	Failed to assign slots 6661-12121 to 10.244.0.17: Slot 7646 is already busy
```
### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
