### PR TITLE
Set config epoch on new nodes before MEET to prevent slot loss

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -59,6 +59,7 @@ var (
 			"+cluster|forget",            // remove stale nodes
 			"+cluster|getslotmigrations", // check migration status
 			"+cluster|migrateslots",      // migrate slots between shards
+			"+cluster|set-config-epoch",  // set epoch on new nodes
 			"+info",                      // node info and replication status
 		}, " "),
 		// the ACL rawstring for exporter is taken from the redis_exporter documentation: https://github.com/oliver006/redis_exporter#authenticating-with-redis

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -607,6 +607,9 @@ func findMeetTarget(state *valkey.ClusterState, isolated []*valkey.NodeState) *v
 // refuses to assign slots to isolated nodes, so every node is guaranteed
 // to pass through this function before receiving slots or replicating.
 //
+// Before issuing MEET, we set each node's config epoch above the cluster's
+// current epoch.
+//
 // MEET is idempotent and has no ordering dependencies, so all isolated nodes
 // can be introduced in a single pass. We pick a single "meet target" node
 // and MEET all others against it:
@@ -636,6 +639,20 @@ func (r *ValkeyClusterReconciler) meetIsolatedNodes(ctx context.Context, cluster
 	// Falls back to an isolated node as a bootstrap seed if every node
 	// is isolated (fresh bootstrap).
 	meetTarget := findMeetTarget(state, isolated)
+
+	// Set config epochs on isolated nodes before MEET. Fresh nodes have
+	// epoch 0; setting a higher epoch ensures they enter the cluster with
+	// authority above any dead nodes they replace, preventing gossip from
+	// overriding their future slot claims.
+	currentEpoch := meetTarget.CurrentEpoch()
+	for i, node := range isolated {
+		epoch := currentEpoch + int64(i) + 1
+		if err := node.Client.Do(ctx, node.Client.B().ClusterSetConfigEpoch().ConfigEpoch(epoch).Build()).Error(); err != nil {
+			log.V(1).Info("CLUSTER SETCONFIGEPOCH skipped", "node", node.Address, "err", err)
+		}
+	}
+
+	// Exclude the meet target from the MEET loop during bootstrap.
 	if meetTarget == isolated[0] {
 		isolated = isolated[1:]
 	}

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -209,8 +209,8 @@ func (n *NodeState) IsPrimary() bool {
 // CurrentEpoch returns the cluster's current epoch as reported by this node's
 // CLUSTER INFO output.
 func (n *NodeState) CurrentEpoch() int64 {
-	if v, err := strconv.ParseInt(n.ClusterInfo["cluster_current_epoch"], 10, 64); err == nil {
-		return v
+	if epoch, err := strconv.ParseInt(n.ClusterInfo["cluster_current_epoch"], 10, 64); err == nil {
+		return epoch
 	}
 	return 0
 }

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -206,6 +206,15 @@ func (n *NodeState) IsPrimary() bool {
 	return slices.Contains(n.Flags, "master")
 }
 
+// CurrentEpoch returns the cluster's current epoch as reported by this node's
+// CLUSTER INFO output.
+func (n *NodeState) CurrentEpoch() int64 {
+	if v, err := strconv.ParseInt(n.ClusterInfo["cluster_current_epoch"], 10, 64); err == nil {
+		return v
+	}
+	return 0
+}
+
 // IsIsolated returns true if the node's cluster_known_nodes is <= 1,
 // meaning it hasn't been introduced to any other cluster member yet.
 func (n *NodeState) IsIsolated() bool {

--- a/internal/valkey/clusterstate_test.go
+++ b/internal/valkey/clusterstate_test.go
@@ -281,3 +281,33 @@ func TestGetUnassignedSlots(t *testing.T) {
 		t.Errorf("Expected %v, got %v", expect, result)
 	}
 }
+
+func TestCurrentEpoch(t *testing.T) {
+	t.Run("parses valid epoch", func(t *testing.T) {
+		n := &NodeState{ClusterInfo: map[string]string{"cluster_current_epoch": "42"}}
+		if n.CurrentEpoch() != 42 {
+			t.Errorf("expected 42, got %d", n.CurrentEpoch())
+		}
+	})
+
+	t.Run("returns 0 for missing key", func(t *testing.T) {
+		n := &NodeState{ClusterInfo: map[string]string{}}
+		if n.CurrentEpoch() != 0 {
+			t.Errorf("expected 0, got %d", n.CurrentEpoch())
+		}
+	})
+
+	t.Run("returns 0 for nil map", func(t *testing.T) {
+		n := &NodeState{}
+		if n.CurrentEpoch() != 0 {
+			t.Errorf("expected 0, got %d", n.CurrentEpoch())
+		}
+	})
+
+	t.Run("returns 0 for non-numeric value", func(t *testing.T) {
+		n := &NodeState{ClusterInfo: map[string]string{"cluster_current_epoch": "abc"}}
+		if n.CurrentEpoch() != 0 {
+			t.Errorf("expected 0, got %d", n.CurrentEpoch())
+		}
+	})
+}


### PR DESCRIPTION
### Summary
When new nodes join a cluster they start with config epoch 0. After `MEET`, gossip from existing members might carry slot ownership from dead nodes at higher epochs. The new node accepts this gossip, overwriting its own `ADDSLOTS` claims. When the operator later forgets the dead node, those slots become permanently unassigned.

This leads to a cluster stuck in Reconciling state.

Call `CLUSTER SETCONFIGEPOCH` on each isolated node before `MEET`, setting it above the cluster's current epoch. This ensures the new node's epoch is higher than any dead node it replaces, so gossip cannot override its slot claims. The command fails gracefully on nodes that already have a non-zero epoch.

### Testing

To reproduce:
1. Deploy a ValkeyCluster (e.g., 3 shards, 1 replica each)
2. Delete both the primary and replica Pods of a shard simultaneously
3. Wait for the operator to replace the nodes
4. Occasionally the cluster gets stuck in Reconciling state with permanently unassigned slots (depends on gossip timing)

The Valkey server log on the new node will show:
```
Processing UPDATE message received from <meet-target> about node <dead-node>. old configEpoch 0, new configEpoch <higher>
Slot range [X, Y] is migrated from node <new-node> to node <dead-node>
```
With this correction the UPDATE message will be ignored because the new node's epoch is already higher than the dead node's.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
