### PR TITLE
fix empty IP in 'CLUSTER SLOTS' for single shard clusters

### DIFF
--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -169,6 +169,18 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 			Command: []string{
 				"valkey-server",
 				"/config/valkey.conf",
+				"--cluster-announce-ip",
+				"$(POD_IP)",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name: "POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
+				},
 			},
 			Ports: []corev1.ContainerPort{
 				{

--- a/internal/controller/valkeynode_resources_test.go
+++ b/internal/controller/valkeynode_resources_test.go
@@ -76,7 +76,12 @@ func TestBuildValkeyNodePodTemplateSpec(t *testing.T) {
 	assert.Equal(t, "valkey/valkey:9.0.0", c.Image)
 
 	// Command
-	assert.Equal(t, []string{"valkey-server", "/config/valkey.conf"}, c.Command)
+	assert.Equal(t, []string{"valkey-server", "/config/valkey.conf", "--cluster-announce-ip", "$(POD_IP)"}, c.Command)
+
+	// Env
+	require.Len(t, c.Env, 1)
+	assert.Equal(t, "POD_IP", c.Env[0].Name)
+	assert.Equal(t, "status.podIP", c.Env[0].ValueFrom.FieldRef.FieldPath)
 
 	// Ports
 	require.Len(t, c.Ports, 2)

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -416,6 +416,28 @@ spec:
 				g.Expect(output).To(ContainSubstring("cluster_size:1"))
 			}
 			Eventually(verifyClusterAccess).Should(Succeed())
+
+			By("validating CLUSTER SLOTS reports the pod IP")
+			verifyClusterSlotsIP := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", singleNodeClusterName),
+					"-o", "jsonpath={.items[0].metadata.name}={.items[0].status.podIP}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to list pods")
+				parts := strings.SplitN(strings.TrimSpace(out), "=", 2)
+				g.Expect(parts).To(HaveLen(2), "expected pod=ip output, got %q", out)
+				podName, podIP := parts[0], parts[1]
+				g.Expect(podIP).NotTo(BeEmpty(), "pod %q has no podIP", podName)
+
+				cmd = exec.Command("kubectl", "exec", podName, "-c", "server", "--",
+					"valkey-cli", "CLUSTER", "SLOTS")
+				slotsOut, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "CLUSTER SLOTS failed")
+				g.Expect(slotsOut).To(ContainSubstring(podIP),
+					"regression: CLUSTER SLOTS did not report podIP %s\noutput:\n%s",
+					podIP, slotsOut)
+			}
+			Eventually(verifyClusterSlotsIP).Should(Succeed())
 		})
 
 		It("creates a cluster with custom users", func() {

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -295,6 +295,28 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 				WithArguments("52428800", "CONFIG", "GET", "maxmemory").
 				Should(Succeed(), "Failed CONFIG GET maxmemory")
 
+			By("validating CLUSTER SLOTS reports the pod IP")
+			verifyClusterSlotsIP := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", valkeyClusterName),
+					"-o", "jsonpath={.items[0].metadata.name}={.items[0].status.podIP}")
+				out, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to list pods")
+				parts := strings.SplitN(strings.TrimSpace(out), "=", 2)
+				g.Expect(parts).To(HaveLen(2), "expected pod=ip output, got %q", out)
+				podName, podIP := parts[0], parts[1]
+				g.Expect(podIP).NotTo(BeEmpty(), "pod %q has no podIP", podName)
+
+				cmd = exec.Command("kubectl", "exec", podName, "-c", "server", "--",
+					"valkey-cli", "CLUSTER", "SLOTS")
+				slotsOut, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred(), "CLUSTER SLOTS failed")
+				g.Expect(slotsOut).To(ContainSubstring(podIP),
+					"regression: CLUSTER SLOTS did not report podIP %s\noutput:\n%s",
+					podIP, slotsOut)
+			}
+			Eventually(verifyClusterSlotsIP).Should(Succeed())
+
 			By("get the original ACL hash")
 			cmd = exec.Command("kubectl", "get", "pod",
 				"-o", "jsonpath={.items[0].metadata.annotations.valkey\\.io/internal-acl-hash}",
@@ -437,7 +459,7 @@ spec:
 					"regression: CLUSTER SLOTS did not report podIP %s\noutput:\n%s",
 					podIP, slotsOut)
 			}
-			Eventually(verifyClusterSlotsIP).Should(Succeed())
+			Eventually(verifyClusterSlotsIP, 1*time.Minute, 2*time.Second).Should(Succeed())
 		})
 
 		It("creates a cluster with custom users", func() {


### PR DESCRIPTION
This PR fixes https://github.com/valkey-io/valkey-operator/issues/201

### Summary

Fixes node IP in single shard scenario. more than 1 shard scenario doesn't have this issue, because we are performing cluster meet in case of greater than 1 shard already between nodes.

### Implementation

- added pod_ip env and passed it to cluster_announce_ip

### Testing

Tested manually deploying with single shard and multiple shards. cluster slots returns IPs as expected in both scenarios.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)

