### PR TITLE
fix: Liveness and readiness probe scripts with sh for supporting alpine images

### DIFF
--- a/internal/controller/scripts/liveness-check.sh
+++ b/internal/controller/scripts/liveness-check.sh
@@ -9,32 +9,31 @@ set -e
 timeout=${1:-"4"}
 port=${2:-"6379"}
 
-# timeout_cmd DURATION COMMAND [ARG]...
+# Run a command with a DURATION (seconds) timeout. Polls every 0.1s; on timeout
+# sends SIGTERM then SIGKILL. Returns the command's exit code, or 124 on timeout.
 timeout_cmd() {
     duration=$1; shift
-
-    # Run command and get its pid.
     "$@" &
     cmdpid=$!
 
-    # Start the timeout supervisor (subshell in parallell).
-    (
-        remaining=$((duration * 1000)) # Use millisec
-        while [ "$remaining" -gt "0" ]; do
-            kill -0 $cmdpid || exit 0 # exit subshell if cmd finished.
-            sleep 0.1
-            remaining=$((remaining - 100))
-        done
+	# Poll every 0.1 seconds
+    count=0
+    max_count=$((duration * 10))
+    while [ $count -lt $max_count ]; do
+        if ! kill -0 $cmdpid 2>/dev/null; then
+            wait $cmdpid
+            return $?
+        fi
+        sleep 0.1
+        count=$((count + 1))
+    done
 
-        echo "Command timed out"
-        # First try SIGTERM, then force terminate using SIGKILL.
-        kill -TERM $cmdpid && sleep 0.1 && kill -0 $cmdpid || exit 0
-        sleep 1
-        kill -KILL $cmdpid
-    ) 2>/dev/null &
-
-    # Wait for jobs (avoiding <defunct>)
-    wait
+    # Timeout reached
+    kill -TERM $cmdpid 2>/dev/null
+    sleep 0.1
+    kill -0 $cmdpid 2>/dev/null && sleep 1 && kill -KILL $cmdpid 2>/dev/null
+    wait $cmdpid 2>/dev/null
+    return 124
 }
 
 # Build TLS args from environment variables if set

--- a/internal/controller/scripts/liveness-check.sh
+++ b/internal/controller/scripts/liveness-check.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 #
-# Liveness check of a Valkey node (Bash only).
+# Liveness check of a Valkey node (POSIX sh, works with bash, dash & busybox ash).
 #
 # Usage: liveness-check.sh [timeout] [port]
 #        Default timeout is 4s, and default Valkey port is 6379.
@@ -9,13 +9,13 @@ set -e
 timeout=${1:-"4"}
 port=${2:-"6379"}
 
-# timeout DURATION COMMAND [ARG]...
-function timeout {
-    local duration=$1; shift
+# timeout_cmd DURATION COMMAND [ARG]...
+timeout_cmd() {
+    duration=$1; shift
 
     # Run command and get its pid.
     "$@" &
-    local cmdpid=$!
+    cmdpid=$!
 
     # Start the timeout supervisor (subshell in parallell).
     (
@@ -27,10 +27,10 @@ function timeout {
         done
 
         echo "Command timed out"
-        # First try a SIGTERM, then force terminate using SIGKILL.
-        kill -s SIGTERM $cmdpid && sleep 0.1 && kill -0 $cmdpid || exit 0
+        # First try SIGTERM, then force terminate using SIGKILL.
+        kill -TERM $cmdpid && sleep 0.1 && kill -0 $cmdpid || exit 0
         sleep 1
-        kill -s SIGKILL $cmdpid
+        kill -KILL $cmdpid
     ) 2>/dev/null &
 
     # Wait for jobs (avoiding <defunct>)
@@ -45,7 +45,7 @@ fi
 
 # Perform check
 response=$(
-    timeout $timeout \
+    timeout_cmd $timeout \
     valkey-cli -h localhost -p $port $tls_args PING)
 
 responseFirstWord=$(echo "$response" | head -n1 | awk '{print $1;}')

--- a/internal/controller/scripts/readiness-check.sh
+++ b/internal/controller/scripts/readiness-check.sh
@@ -9,32 +9,31 @@ set -e
 timeout=${1:-"1"}
 port=${2:-"6379"}
 
-# timeout_cmd DURATION COMMAND [ARG]...
+# Run a command with a DURATION (seconds) timeout. Polls every 0.1s; on timeout
+# sends SIGTERM then SIGKILL. Returns the command's exit code, or 124 on timeout.
 timeout_cmd() {
     duration=$1; shift
-
-    # Run command and get its pid.
     "$@" &
     cmdpid=$!
 
-    # Start the timeout supervisor (subshell in parallell).
-    (
-        remaining=$((duration * 1000)) # Use millisec
-        while [ "$remaining" -gt "0" ]; do
-            kill -0 $cmdpid || exit 0 # exit subshell if cmd finished.
-            sleep 0.1
-            remaining=$((remaining - 100))
-        done
+	# Poll every 0.1 seconds
+    count=0
+    max_count=$((duration * 10))
+    while [ $count -lt $max_count ]; do
+        if ! kill -0 $cmdpid 2>/dev/null; then
+            wait $cmdpid
+            return $?
+        fi
+        sleep 0.1
+        count=$((count + 1))
+    done
 
-        echo "Command timed out"
-        # First try SIGTERM, then force terminate using SIGKILL.
-        kill -TERM $cmdpid && sleep 0.1 && kill -0 $cmdpid || exit 0
-        sleep 1
-        kill -KILL $cmdpid
-    ) 2>/dev/null &
-
-    # Wait for jobs (avoiding <defunct>)
-    wait
+    # Timeout reached
+    kill -TERM $cmdpid 2>/dev/null
+    sleep 0.1
+    kill -0 $cmdpid 2>/dev/null && sleep 1 && kill -KILL $cmdpid 2>/dev/null
+    wait $cmdpid 2>/dev/null
+    return 124
 }
 
 # Build TLS args from environment variables if set

--- a/internal/controller/scripts/readiness-check.sh
+++ b/internal/controller/scripts/readiness-check.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 #
-# Readiness check of a Valkey node (Bash only).
+# Readiness check of a Valkey node (POSIX sh, works with bash, dash & busybox ash).
 #
 # Usage: readiness-check.sh [timeout] [port]
 #        Default timeout is 1s, and default Valkey port is 6379.
@@ -9,13 +9,13 @@ set -e
 timeout=${1:-"1"}
 port=${2:-"6379"}
 
-# timeout DURATION COMMAND [ARG]...
-function timeout {
-    local duration=$1; shift
+# timeout_cmd DURATION COMMAND [ARG]...
+timeout_cmd() {
+    duration=$1; shift
 
     # Run command and get its pid.
     "$@" &
-    local cmdpid=$!
+    cmdpid=$!
 
     # Start the timeout supervisor (subshell in parallell).
     (
@@ -27,10 +27,10 @@ function timeout {
         done
 
         echo "Command timed out"
-        # First try a SIGTERM, then force terminate using SIGKILL.
-        kill -s SIGTERM $cmdpid && sleep 0.1 && kill -0 $cmdpid || exit 0
+        # First try SIGTERM, then force terminate using SIGKILL.
+        kill -TERM $cmdpid && sleep 0.1 && kill -0 $cmdpid || exit 0
         sleep 1
-        kill -s SIGKILL $cmdpid
+        kill -KILL $cmdpid
     ) 2>/dev/null &
 
     # Wait for jobs (avoiding <defunct>)
@@ -45,7 +45,7 @@ fi
 
 # Perform checks
 response=$(
-    timeout $timeout \
+    timeout_cmd $timeout \
     valkey-cli -h localhost -p $port $tls_args PING)
 
 if [ "$response" != "PONG" ]; then

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -189,7 +189,7 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
-							"/bin/bash",
+							"/bin/sh",
 							"-c",
 							"/scripts/liveness-check.sh",
 						},
@@ -205,7 +205,7 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
-							"/bin/bash",
+							"/bin/sh",
 							"-c",
 							"/scripts/liveness-check.sh",
 						},
@@ -221,7 +221,7 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
-							"/bin/bash",
+							"/bin/sh",
 							"-c",
 							"/scripts/readiness-check.sh",
 						},


### PR DESCRIPTION
This PR closes https://github.com/valkey-io/valkey-operator/issues/206

### Summary
This PR addresses the crash loop experienced by Valkey clusters utilizing Alpine-based images(valkey/valkey:9.0.3-alpine) by eliminating bash dependencies from the probe scripts

### Features 

Fixes compatibility with valkey alpine images

### Implementation

Refactor readiness-check.sh and liveness-check.sh to work with alpine images.

### Testing

tested with valkey alpine images and non alpine images. We could change one of the e2e test to alpine to cover this in e2e tests.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
