### PR TITLE
fix: check primary node first when resolving shard index

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -1207,9 +1207,16 @@ func (r *ValkeyClusterReconciler) deleteExcessValkeyNodes(ctx context.Context, c
 	return deleted, nil
 }
 
-// shardIndexFromState determines the pod shard-index for a given Valkey shard
-// by matching any of its nodes' addresses to ValkeyNode labels.
+// shardIndexFromState determines the shard index for a given Valkey Cluster
+// shard by matching its node addresses to ValkeyNode shard-index labels. It checks
+// the primary first, falling back to any node if unavailable.
 func shardIndexFromState(shard *valkey.ShardState, nodes *valkeyiov1alpha1.ValkeyNodeList) int {
+	if primary := shard.GetPrimaryNode(); primary != nil {
+		_, shardIndex := nodeRoleAndShard(primary.Address, nodes)
+		if shardIndex >= 0 {
+			return shardIndex
+		}
+	}
 	for _, node := range shard.Nodes {
 		_, shardIndex := nodeRoleAndShard(node.Address, nodes)
 		if shardIndex >= 0 {


### PR DESCRIPTION
### Summary

During scale-in, `shardIndexFromState` could match a stale replica from a drained shard that temporarily appears in a remaining shard via gossip before `CLUSTER FORGET` propagates. This returns the wrong shard index, causing the controller to drain the wrong shards, e.g. draining 3 shards out of 4 total, instead of just draining 1 shard, leading to an unrecoverable Reconciling state.

Fixed by checking the primary node first. The primary is the authoritative slot owner and its ValkeyNode CR always has the correct shard-index label. Stale replicas from drained shards are never primaries of remaining shards.

### Testing

This has been found using #203 running:
`CHAOS_SCENARIOS=scale-shards CHAOS_MIN_SHARDS=3 CHAOS_MAX_SHARDS=9 make test-chaos`

This repeatedly scales the cluster to a random shard count (between 3–9) and verifies it recovers correctly each time, running until failure.

Previously failed within 3–20 iterations; now passes 1000+ without failure.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
