### PR TITLE
fix: rolling update loses all keys when replicas are not synced

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -57,6 +57,7 @@ var (
 			"+cluster|addslotsrange",     // assign slots
 			"+cluster|replicate",         // set up replication
 			"+cluster|forget",            // remove stale nodes
+			"+cluster|failover",          // proactive failover before rolling primary
 			"+cluster|getslotmigrations", // check migration status
 			"+cluster|migrateslots",      // migrate slots between shards
 			"+cluster|set-config-epoch",  // set epoch on new nodes

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -472,12 +472,28 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, clust
 					"name", node.Name, "err", err)
 			}
 		} else if nodeRequiresRoll(current, desired) {
-			if shard, replicas := findFailoverShard(clusterState, current.Status.PodIP); shard != nil {
+			shard, replicas := findFailoverShard(clusterState, current.Status.PodIP)
+			if shard != nil {
 				log.Info("proactive failover before rolling primary",
-					"name", node.Name, "address", current.Status.PodIP)
+					"name", node.Name, "address", current.Status.PodIP,
+					"syncedReplicas", len(replicas))
 				if err := proactiveFailover(ctx, r.Recorder, cluster, shard, replicas); err != nil {
 					log.Info("proactive failover did not complete, proceeding with roll",
 						"name", node.Name, "err", err)
+				}
+			} else if cluster.Spec.Replicas > 0 {
+				// findFailoverShard returned nil for one of three reasons:
+				// 1. Node is the shard primary but has no synced replicas: skip roll, would lose data
+				// 2. Node is in a shard but is a replica: safe to roll
+				// 3. Node isn't in any shard (isolated): safe to roll
+				// Only case 1 requires skipping; identify it's the actual primary of its shard.
+				shardInState := clusterState.FindShardForAddress(current.Status.PodIP)
+				if shardInState != nil && shardInState.GetPrimaryNode() != nil && shardInState.GetPrimaryNode().Address == current.Status.PodIP {
+					log.Info("primary has no synced replicas, deferring roll",
+						"name", node.Name, "address", current.Status.PodIP,
+						"shardNodes", len(shardInState.Nodes),
+						"shardId", shardInState.Id)
+					return false, false, nil
 				}
 			}
 		}


### PR DESCRIPTION
### Summary

This PR fixes two issues that together make rolling updates safe with and without PVCs.

1. Without persistence: restarting a replica destroys its cluster membership and data. The operator considered it Ready and immediately rolled the primary. With no synced replica to fail over to, all shard data was lost.

3. With persistence: the replica stays synced and proactive failover is attempted, but the `_operator` user ACL was missing `cluster|failover`. Every failover failed with NOPERM and the primary was rolled without a graceful handoff.

### Testing

Found using #203 running the rolling-update scenario. It patches io-threads on the ValkeyCluster to trigger a rolling restart of all pods, then verifies the cluster recovers and all keys are preserved.

```
# Without persistence
CHAOS_SCENARIOS=rolling-update make test-chaos

# With persistence
CHAOS_SCENARIOS=rolling-update CHAOS_PERSISTENCE=true make test-chaos
```



### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
