### PR TITLE
add modules workaround docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,4 +99,4 @@ helm uninstall valkey-operator -n valkey-operator-system
 
 - [ValkeyCluster](./valkeycluster.md) — CRD reference and configuration options
 - [Status conditions](./status-conditions.md) — understanding cluster health
-- [Using modules](./docs/using-modules.md) - workaround to deploy a Valkey Cluster with module
+- [Using modules](./using-modules.md) - workaround to deploy a Valkey Cluster with module

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,3 +99,4 @@ helm uninstall valkey-operator -n valkey-operator-system
 
 - [ValkeyCluster](./valkeycluster.md) — CRD reference and configuration options
 - [Status conditions](./status-conditions.md) — understanding cluster health
+- [Using modules](./docs/using-modules.md) - workaround to deploy a Valkey Cluster with module

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,4 +99,4 @@ helm uninstall valkey-operator -n valkey-operator-system
 
 - [ValkeyCluster](./valkeycluster.md) — CRD reference and configuration options
 - [Status conditions](./status-conditions.md) — understanding cluster health
-- [Using modules](./using-modules.md) - workaround to deploy a Valkey Cluster with module
+- [Using modules](./using-modules.md) - workaround to deploy a Valkey Cluster with modules

--- a/docs/using-modules.md
+++ b/docs/using-modules.md
@@ -49,6 +49,12 @@ docker build . -t valkey-customized:1.0
 
 ## 2. Create a ValkeyCluster using the customized image
 
+Update the `server` container configuration, so that:
+- `image` references the Docker image built in the previous step,
+- `args` include the `loadmodule` setting, as well as other configurations required for the module.
+
+The value provided will be applied using strategic merge patch
+
 ```bash
 cat <<EOF | kubectl apply -f -
 apiVersion: valkey.io/v1alpha1

--- a/docs/using-modules.md
+++ b/docs/using-modules.md
@@ -1,0 +1,92 @@
+# Using modules
+
+Currently, valkey-operator does not natively support using modules, but you can workaround that by using a customized Valkey Docker image.
+
+## 1. Creating a customized Valkey Docker image
+
+Below is an example Dockerfile to build the iamge with [valkey-json](https://github.com/valkey-io/valkey-json) module
+
+```Dockerfile
+FROM docker.io/valkey/valkey:9.1.0-alpine AS build
+
+RUN set -eux; \
+    apk add --no-cache            \
+	        ca-certificates       \
+	        build-base            \
+	        cmake                 \
+	        git                   \
+	        curl                  \
+	        clang                 \
+	        clang19-dev           \
+	        gtest-dev             \
+	        ninja-build           \
+	        ninja-is-really-ninja \
+	        openssl-dev           \
+	        clang19-extra-tools   \
+	        linux-headers         \
+	        bash                  \
+            pkgconfig             \
+	;\
+    update-ca-certificates; \
+    ln -s /usr/lib/ninja-build/bin/ninja /usr/bin/ninja-build;
+
+WORKDIR /opt
+
+# Clone repositories
+RUN set -eux; \
+    git clone --depth 1 --branch 1.0.2 https://github.com/valkey-io/valkey-json.git;
+
+# Build JSON module
+WORKDIR /opt/valkey-json
+RUN set -eux; \
+    ./build.sh --release
+```
+Build the image using the following command
+
+```bash
+docker build . -t valkey-customized:1.0
+```
+
+## 2. Create a ValkeyCluster using the customized image
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+spec:
+  shards: 1
+  replicas: 0
+  containers:
+    - name: server
+      image: valkey-customized:1.0
+      args: 
+        - --loadmodule /opt/valkey-json/build/src/libjson.so
+EOF
+```
+
+## 3. Verify the module is loaded
+
+```bash 
+kubectl exec -ti my-cluster-0-0-0 -- valkey-cli hello 3
+```
+
+Expected output:
+```
+1# "server" => "valkey"
+2# "version" => "9.1.0"
+3# "proto" => (integer) 3
+4# "id" => (integer) 75
+5# "mode" => "cluster"
+6# "role" => "master"
+7# "modules" => 
+   1) 1# "name" => "lua"
+      2# "ver" => (integer) 1
+      3# "path" => "lua"
+      4# "args" => (empty array)
+   2) 1# "name" => "json"
+      2# "ver" => (integer) 10002
+      3# "path" => "/opt/valkey-json/build/src/libjson.so"
+      4# "args" => (empty array)
+```

--- a/docs/using-modules.md
+++ b/docs/using-modules.md
@@ -4,10 +4,10 @@ Currently, valkey-operator does not natively support using modules, but you can 
 
 ## 1. Creating a customized Valkey Docker image
 
-Below is an example Dockerfile to build the iamge with [valkey-json](https://github.com/valkey-io/valkey-json) module
+Below is an example Dockerfile to build the image with [valkey-json](https://github.com/valkey-io/valkey-json) module
 
 ```Dockerfile
-FROM docker.io/valkey/valkey:9.1.0-alpine AS build
+FROM docker.io/valkey/valkey:9.1.0-alpine
 
 RUN set -eux; \
     apk add --no-cache            \

--- a/docs/using-modules.md
+++ b/docs/using-modules.md
@@ -1,6 +1,6 @@
 # Using modules
 
-Currently, valkey-operator does not natively support using modules, but you can workaround that by using a customized Valkey Docker image.
+Currently, valkey-operator does not directly support using modules, but you can workaround that by using a customized Valkey Docker image.
 
 ## 1. Creating a customized Valkey Docker image
 

--- a/docs/using-modules.md
+++ b/docs/using-modules.md
@@ -53,7 +53,7 @@ Update the `server` container configuration, so that:
 - `image` references the Docker image built in the previous step,
 - `args` include the `loadmodule` setting, as well as other configurations required for the module.
 
-The value provided will be applied using strategic merge patch
+The values provided will be applied using strategic merge patch
 
 ```bash
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
This PR closes #213 

### Summary

Add docs/using-module.md describing a workaround to deploy a ValkeyCluster with module.

### Features / Behaviour Changes

- Add `docs/using-module.md`
- Add link to `docs/using-module.md` from `docs/quickstart.md`

### Implementation


### Limitations


### Testing


### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [x] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
