### PR TITLE
fix: shardExistsInTopology only matches shards with a primary

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -194,6 +194,12 @@ func shardExistsInTopology(state *valkey.ClusterState, shardIndex int, nodes *va
 			continue
 		}
 		for _, shard := range state.Shards {
+			// Only consider shards that have a primary with slots.
+			// Orphaned replicas (no primary, no slots) should not block
+			// slot assignment to a replacement primary.
+			if shard.PrimaryId == "" || len(shard.Slots) == 0 {
+				continue
+			}
 			for _, node := range shard.Nodes {
 				if node.Address == n.Status.PodIP {
 					return true


### PR DESCRIPTION
### Summary

When a Deployment rollout replaces a primary pod, the old and new pods briefly coexist (`maxSurge`). If the old primary dies before the replica can failover, the shard has no primary and no slots, just an orphaned replica. The old code matched these orphaned replicas, blocking slot assignment to the replacement primary indefinitely.

Now `shardExistsInTopology` only matches shards that have a primary with slots, allowing the replacement primary to proceed with slot assignment.

This fixes CI issues like [this](https://github.com/valkey-io/valkey-operator/actions/runs/26739020633/job/78798358507?pr=214).

### Testing

Found using https://github.com/valkey-io/valkey-operator/pull/203 running the delete-recreate-cluster scenario. This scenario deletes a ValkeyCluster, using Deployment, and wait for all resource to be gone, and then recreates it again.

`CHAOS_SCENARIOS=delete-recreate-cluster CHAOS_WORKLOAD_TYPE=Deployment make test-chaos`

It needed 3 to 357 iterations before hitting the issue.

--- 
The reason for restarting ValkeyNode pods during cluster creation, according to added debug logs in testruns, are annotation changes: 
```
oldAnnotations: {"valkey.io/internal-acl-hash":"8fc9713c..."}
newAnnotations: {"valkey.io/config-hash":"1b746d50...", "valkey.io/internal-acl-hash":"8fc9713c..."}
```

The `config-hash` annotation was missing when the Deployment was created (because serverConfigHash was empty due to the informer cache race?). When the ValkeyNode controller reconciles again and sees the hash, it adds the annotation to the pod template.
Any change to the pod template spec (including annotations) causes Kubernetes to create a new ReplicaSet and roll the pods.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [ ] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
