### PR TITLE
fix: disable replica migration and validity factor in cluster config

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -103,9 +103,11 @@ func generateValkeyNodeConfig(node *valkeyiov1alpha1.ValkeyNode) string {
 func getBaseConfig(cluster *valkeyiov1alpha1.ValkeyCluster) map[string]string {
 	baseConfig := buildManagedConfig(true, cluster.Spec.Persistence, cluster.Spec.TLS)
 	maps.Copy(baseConfig, map[string]string{
-		"cluster-enabled":      "yes",
-		"protected-mode":       "no",
-		"cluster-node-timeout": "2000",
+		"cluster-enabled":                 "yes",
+		"protected-mode":                  "no",
+		"cluster-node-timeout":            "2000",
+		"cluster-allow-replica-migration": "no",
+		"cluster-replica-validity-factor": "0",
 	})
 
 	return baseConfig

--- a/internal/valkey/cluster_rebalance.go
+++ b/internal/valkey/cluster_rebalance.go
@@ -98,16 +98,16 @@ func PlanDrainMove(src *ShardState, dsts []*ShardState, maxSlots int) (*SlotMove
 	if maxSlots <= 0 || len(dsts) == 0 {
 		return nil, nil
 	}
-	srcPrimary := src.GetPrimaryNode()
-	if srcPrimary == nil {
-		return nil, fmt.Errorf("primary missing for draining shard %s", src.Id)
-	}
 	srcCount := 0
 	for _, slot := range src.Slots {
 		srcCount += slot.End - slot.Start + 1
 	}
 	if srcCount == 0 {
-		return nil, nil
+		return nil, nil // Nothing to drain
+	}
+	srcPrimary := src.GetPrimaryNode()
+	if srcPrimary == nil {
+		return nil, fmt.Errorf("primary missing for draining shard %s", src.Id)
 	}
 
 	var dstPrimary *NodeState

--- a/internal/valkey/cluster_rebalance_test.go
+++ b/internal/valkey/cluster_rebalance_test.go
@@ -161,6 +161,7 @@ func TestPlanDrainMove_PicksFirstDst(t *testing.T) {
 }
 
 func TestPlanDrainMove_EmptySrc(t *testing.T) {
+	// Shard with no slots has nothing to move.
 	src := newPrimaryShard("10.0.0.3", "node-3", nil)
 	dsts := []*ShardState{
 		newPrimaryShard("10.0.0.1", "node-1", []SlotsRange{{Start: 0, End: 16383}}),


### PR DESCRIPTION
This PR closes #216 

### Summary

Add `cluster-allow-replica-migration=no` to prevent Valkey from moving replicas between shards autonomously, which conflicts with the operator's topology management.

Add `cluster-replica-validity-factor=0` so replicas always attempt failover regardless of disconnection time. With cluster-node-timeout at 2s, the default factor of 10 gives only a 30s window before replicas refuse to failover, causing stuck clusters under disruption.

Reorder `PlanDrainMove` to check slot count before primary existence, preventing a spurious error on already-drained shards. Returning an error due to the primary would cause the caller (drainExcessShards) to propagate it up, halting scale-down and leaving stale ValkeyNodes around forever.
This problem solved itself previously when `cluster-allow-replica-migration=yes`.

### Testing

This problem was found by using #203 and running on a machine with moderate load:
`CHAOS_MAX_SHARDS=15 CHAOS_SCENARIOS="scale-shards" make test-chaos`


<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
