### PR TITLE
enhancement: Use Recreate deployment strategy

### DIFF
--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -381,6 +381,9 @@ func buildValkeyNodeDeployment(node *valkeyiov1alpha1.ValkeyNode) (*appsv1.Deplo
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: func(i int32) *int32 { return &i }(1),
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},


### PR DESCRIPTION

### Summary

<!--
Add a summary describing the changes
-->

ValkeyNode is a 1:1 mapping of node to pod. By default the Deployment's updateStrategy is set to RollingUpdate which will add a new pod first before removing the old one. This can create 2 pods for a ValkeyNode at once. Recreate will remove the old pod first before creating the new one.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
