### PR TITLE
[enhancement] Roll replicas first during ValkeyNode updates

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -181,8 +181,8 @@ func nodeRoleAndShard(address string, nodes *valkeyv1.ValkeyNodeList) (string, i
 	if err != nil {
 		return "", -1
 	}
-	nodeIndex := nodeIndexForAddress(address, nodes)
-	if nodeIndex < 0 {
+	nodeIndex, err := strconv.Atoi(node.Labels[LabelNodeIndex])
+	if err != nil || nodeIndex < 0 {
 		return "", -1
 	}
 	if nodeIndex == 0 {

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -147,6 +147,23 @@ func upsertAnnotation(o metav1.Object, key string, val string) bool {
 	return true
 }
 
+// nodeIndexForAddress finds the ValkeyNode whose Status.PodIP matches address
+// and returns its node index from the LabelNodeIndex label.
+// Returns -1 if the node is not found or the label is missing or invalid.
+func nodeIndexForAddress(address string, nodes *valkeyv1.ValkeyNodeList) int {
+	idx := slices.IndexFunc(nodes.Items, func(n valkeyv1.ValkeyNode) bool {
+		return n.Status.PodIP == address
+	})
+	if idx == -1 {
+		return -1
+	}
+	nodeIndex, err := strconv.Atoi(nodes.Items[idx].Labels[LabelNodeIndex])
+	if err != nil {
+		return -1
+	}
+	return nodeIndex
+}
+
 // nodeRoleAndShard finds the ValkeyNode whose Status.PodIP matches address
 // and reads its CR labels to determine the intended role and shard index.
 //
@@ -164,8 +181,8 @@ func nodeRoleAndShard(address string, nodes *valkeyv1.ValkeyNodeList) (string, i
 	if err != nil {
 		return "", -1
 	}
-	nodeIndex, err := strconv.Atoi(node.Labels[LabelNodeIndex])
-	if err != nil {
+	nodeIndex := nodeIndexForAddress(address, nodes)
+	if nodeIndex < 0 {
 		return "", -1
 	}
 	if nodeIndex == 0 {
@@ -227,6 +244,53 @@ func findShardPrimary(state *valkey.ClusterState, shardIndex int, nodes *valkeyv
 		}
 	}
 	return "", ""
+}
+
+// primaryNodeIndexForShard returns the node index of the current slot-bearing
+// primary for the given shard, using clusterState as the source of truth.
+// Returns -1 if clusterState is nil, the shard has no primary in the topology,
+// or the primary's node index cannot be resolved or is out of range.
+func primaryNodeIndexForShard(shardIndex, nodesPerShard int, nodes *valkeyv1.ValkeyNodeList, clusterState *valkey.ClusterState) int {
+	if clusterState == nil {
+		return -1
+	}
+	_, primaryIP := findShardPrimary(clusterState, shardIndex, nodes)
+	if primaryIP == "" {
+		return -1
+	}
+	idx := nodeIndexForAddress(primaryIP, nodes)
+	if idx < 0 || idx >= nodesPerShard {
+		return -1
+	}
+	return idx
+}
+
+// replicaFirstNodeOrder returns the node indices for a shard ordered so that
+// replicas are processed before the primary. The primary is identified via
+// clusterState — the live cluster topology — rather than by node-index convention,
+// which may be stale after a failover.
+//
+// When the primary cannot be identified, indices are returned in descending order
+// (nodesPerShard-1 … 0), keeping node-index=0 (the conventional primary) last.
+func replicaFirstNodeOrder(shardIndex, nodesPerShard int, nodes *valkeyv1.ValkeyNodeList, clusterState *valkey.ClusterState) []int {
+	primaryIdx := primaryNodeIndexForShard(shardIndex, nodesPerShard, nodes, clusterState)
+
+	order := make([]int, 0, nodesPerShard)
+	if primaryIdx < 0 {
+		// No live primary identified — fall back to descending order, keeping
+		// node-index=0 (the conventional primary) last.
+		for i := nodesPerShard - 1; i >= 0; i-- {
+			order = append(order, i)
+		}
+		return order
+	}
+	for i := range nodesPerShard {
+		if i != primaryIdx {
+			order = append(order, i)
+		}
+	}
+	order = append(order, primaryIdx)
+	return order
 }
 
 func countSlots(ranges []valkey.SlotsRange) int {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	valkeyv1 "valkey.io/valkey-operator/api/v1alpha1"
+	"valkey.io/valkey-operator/internal/valkey"
 )
 
 func TestLabels(t *testing.T) {
@@ -115,6 +116,233 @@ func TestNodeRoleAndShard(t *testing.T) {
 	role, shard = nodeRoleAndShard("10.0.0.99", nodes)
 	assert.Equal(t, "", role)
 	assert.Equal(t, -1, shard)
+}
+
+func TestReplicaFirstNodeOrder(t *testing.T) {
+	nodes := &valkeyv1.ValkeyNodeList{
+		Items: []valkeyv1.ValkeyNode{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelShardIndex: "0",
+						LabelNodeIndex:  "0",
+					},
+				},
+				Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.0.0.1"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelShardIndex: "0",
+						LabelNodeIndex:  "1",
+					},
+				},
+				Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.0.0.2"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						LabelShardIndex: "0",
+						LabelNodeIndex:  "2",
+					},
+				},
+				Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.0.0.3"},
+			},
+		},
+	}
+
+	clusterStateWithPrimary := func(primaryID string) *valkey.ClusterState {
+		return &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-0",
+					PrimaryId: primaryID,
+					Slots:     []valkey.SlotsRange{{Start: 0, End: 16383}},
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "node-0"},
+						{Address: "10.0.0.2", Id: "node-1"},
+						{Address: "10.0.0.3", Id: "node-2"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("nil clusterState returns descending order", func(t *testing.T) {
+		order := replicaFirstNodeOrder(0, 3, nodes, nil)
+		assert.Equal(t, []int{2, 1, 0}, order)
+	})
+
+	t.Run("primary at index 0 is placed last", func(t *testing.T) {
+		order := replicaFirstNodeOrder(0, 3, nodes, clusterStateWithPrimary("node-0"))
+		assert.Equal(t, []int{1, 2, 0}, order)
+	})
+
+	t.Run("primary at non-zero index is placed last (post-failover)", func(t *testing.T) {
+		order := replicaFirstNodeOrder(0, 3, nodes, clusterStateWithPrimary("node-1"))
+		assert.Equal(t, []int{0, 2, 1}, order)
+	})
+
+	t.Run("primary IP not in nodes list returns descending order", func(t *testing.T) {
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-0",
+					PrimaryId: "node-x",
+					Slots:     []valkey.SlotsRange{{Start: 0, End: 16383}},
+					Nodes: []*valkey.NodeState{
+						{Address: "10.9.9.9", Id: "node-x"},
+					},
+				},
+			},
+		}
+		order := replicaFirstNodeOrder(0, 3, nodes, state)
+		assert.Equal(t, []int{2, 1, 0}, order)
+	})
+
+	t.Run("correct shard is used when multiple shards present", func(t *testing.T) {
+		multiShardNodes := &valkeyv1.ValkeyNodeList{
+			Items: []valkeyv1.ValkeyNode{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelShardIndex: "0",
+							LabelNodeIndex:  "0",
+						},
+					},
+					Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.0.0.1"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelShardIndex: "0",
+							LabelNodeIndex:  "1",
+						},
+					},
+					Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.0.0.2"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelShardIndex: "1",
+							LabelNodeIndex:  "0",
+						},
+					},
+					Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.1.0.1"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							LabelShardIndex: "1",
+							LabelNodeIndex:  "1",
+						},
+					},
+					Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.1.0.2"},
+				},
+			},
+		}
+		// Shard 1's primary is at node-index 1 (post-failover on shard 1).
+		// Shard 0's primary is at node-index 0 — but we're asking about shard 1,
+		// so shard 0 nodes must not affect the result.
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-0",
+					PrimaryId: "s0-node-0",
+					Slots:     []valkey.SlotsRange{{Start: 0, End: 8191}},
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "s0-node-0"},
+						{Address: "10.0.0.2", Id: "s0-node-1"},
+					},
+				},
+				{
+					Id:        "shard-1",
+					PrimaryId: "s1-node-1",
+					Slots:     []valkey.SlotsRange{{Start: 8192, End: 16383}},
+					Nodes: []*valkey.NodeState{
+						{Address: "10.1.0.1", Id: "s1-node-0"},
+						{Address: "10.1.0.2", Id: "s1-node-1"},
+					},
+				},
+			},
+		}
+		// Querying shard 1 with nodesPerShard=2: node-index 1 is the primary,
+		// so it is placed last → [0, 1].
+		order := replicaFirstNodeOrder(1, 2, multiShardNodes, state)
+		assert.Equal(t, []int{0, 1}, order)
+	})
+}
+
+func TestPrimaryNodeIndexForShard(t *testing.T) {
+	nodes := &valkeyv1.ValkeyNodeList{
+		Items: []valkeyv1.ValkeyNode{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelShardIndex: "0", LabelNodeIndex: "0"},
+				},
+				Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.0.0.1"},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{LabelShardIndex: "0", LabelNodeIndex: "1"},
+				},
+				Status: valkeyv1.ValkeyNodeStatus{PodIP: "10.0.0.2"},
+			},
+		},
+	}
+
+	clusterStateWithPrimary := func(primaryID string) *valkey.ClusterState {
+		return &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-0",
+					PrimaryId: primaryID,
+					Slots:     []valkey.SlotsRange{{Start: 0, End: 16383}},
+					Nodes: []*valkey.NodeState{
+						{Address: "10.0.0.1", Id: "node-0"},
+						{Address: "10.0.0.2", Id: "node-1"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("primary at index 0 returns 0", func(t *testing.T) {
+		assert.Equal(t, 0, primaryNodeIndexForShard(0, 2, nodes, clusterStateWithPrimary("node-0")))
+	})
+
+	t.Run("primary at index 1 returns 1 (post-failover)", func(t *testing.T) {
+		assert.Equal(t, 1, primaryNodeIndexForShard(0, 2, nodes, clusterStateWithPrimary("node-1")))
+	})
+
+	t.Run("nil clusterState returns -1", func(t *testing.T) {
+		assert.Equal(t, -1, primaryNodeIndexForShard(0, 2, nodes, nil))
+	})
+
+	t.Run("shard not in topology returns -1", func(t *testing.T) {
+		// clusterState has no shards with slots, so findShardPrimary returns ""
+		state := &valkey.ClusterState{Shards: []*valkey.ShardState{}}
+		assert.Equal(t, -1, primaryNodeIndexForShard(0, 2, nodes, state))
+	})
+
+	t.Run("primary IP not in nodes list returns -1", func(t *testing.T) {
+		state := &valkey.ClusterState{
+			Shards: []*valkey.ShardState{
+				{
+					Id:        "shard-0",
+					PrimaryId: "node-x",
+					Slots:     []valkey.SlotsRange{{Start: 0, End: 16383}},
+					Nodes:     []*valkey.NodeState{{Address: "10.9.9.9", Id: "node-x"}},
+				},
+			},
+		}
+		assert.Equal(t, -1, primaryNodeIndexForShard(0, 2, nodes, state))
+	})
+
+	t.Run("primary index out of range returns -1", func(t *testing.T) {
+		// nodesPerShard=1 but primary resolves to index 1 — out of range
+		assert.Equal(t, -1, primaryNodeIndexForShard(0, 1, nodes, clusterStateWithPrimary("node-1")))
+	})
 }
 
 func TestBuildClusterValkeyNodeLabels(t *testing.T) {

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -394,8 +394,8 @@ func (r *ValkeyClusterReconciler) upsertService(ctx context.Context, cluster *va
 //	<cluster>-<N>-<M>
 //
 // where N is the shard index and M is the node index (0 = initial primary,
-// 1+ = replicas). It iterates shards in ascending order and nodes in descending order within each
-// shard (replicas before primary). At most one spec update is issued per reconcile.
+// 1+ = replicas). It iterates shards in ascending order and nodes replica-first within each
+// shard, using live cluster state to identify the actual primary. At most one spec update is issued per reconcile.
 // Once a node is updated or found not-ready after a prior update,
 // the function returns (true, nil) so the caller requeues before advancing to the next node.
 //
@@ -413,9 +413,9 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	// Scrape cluster state once for proactive failover decisions, but only
 	// when at least one node actually needs a roll. During initial bootstrap
 	// no nodes exist, so state stays nil. The snapshot is safe to reuse
-	// across the loop because nodes are iterated replicas-first (the primary
-	// is last in each shard), and after an update we requeue immediately,
-	// re-scraping fresh state.
+	// across the loop: replicaFirstNodeOrder uses it to place the actual
+	// primary last within each shard, and after an update we requeue
+	// immediately, re-scraping fresh state before any further rolls.
 	var clusterState *valkey.ClusterState
 	if anyNodeRequiresRoll(cluster, nodes) {
 		operatorPassword, err := fetchSystemUserPassword(ctx, operatorUser, r.Client, cluster.Name, cluster.Namespace)
@@ -427,8 +427,18 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	}
 
 	for shardIndex := range int(cluster.Spec.Shards) {
-		// Iterate nodeIndex in reverse order (replicas before primary)
-		for nodeIndex := nodesPerShard - 1; nodeIndex >= 0; nodeIndex-- {
+		// If rolls are in progress but the primary of an active shard cannot be
+		// identified from cluster state, defer rather than roll in an unknown order.
+		// New shards (not yet in the topology) are exempt — they need creation, not rolling.
+		if clusterState != nil && shardExistsInTopology(clusterState, shardIndex, nodes) &&
+			primaryNodeIndexForShard(shardIndex, nodesPerShard, nodes, clusterState) < 0 {
+			log.Info("cannot identify primary for shard, deferring roll", "shardIndex", shardIndex)
+			return true, nil
+		}
+		// Iterate nodes replica-first: use live cluster state to identify the
+		// actual primary (which may differ from node-index=0 after a failover)
+		// and place it last.
+		for _, nodeIndex := range replicaFirstNodeOrder(shardIndex, nodesPerShard, nodes, clusterState) {
 			requeue, nodeCreated, err := r.reconcileValkeyNode(ctx, cluster, shardIndex, nodeIndex, clusterState, configHash)
 			if err != nil {
 				return false, err


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

This PR closes #123 

### Summary

When nodes in a shard are rolled, they are done so by querying for the replicas first, before picking the primary last.

### Features / Behaviour Changes

Today, the nodes in a shard are rolled in reverse ordinal order:

```
mycluster-0-2
mycluster-0-1
mycluster-0-0
```

Node 0 is always the intended primary, so any node index >0 are intended replicas. If there has been a failover at some point, then there will be a node index >0 that is the primary. Following this static reverse ordinal index ordering could create up to 3 failovers for the shard, should node index 2 failover to 1, then 1 to 0, then 0.

Now, we are polling for the primary of the shard, and when we loop over the nodes to check, we always place it last. As replicas are rolled, they will requeue the reconciliation check. Then another discovery of replicas takes place. If the replicas do not roll, they do not requeue reconciliation. 

When we get round to the primary (which would be last), all the replicas would have rolled. The primary is checked to see if a proactive failover needs to happen, after that happens it is rolled and requeued. On the next reconcile, the old primary is now a replica and it does not need a roll. The reconcile check then continues past the nodes now that they do not need to be rolled.

### Implementation

I described the high level process above.

Not for this PR, but I am considering raising another PR to tidy up some of the primary node discovery pieces, since there are a few places where we're doing primary and replica discoveries, including in failover.go. I don't wanna refactor in this PR though. Once we've got some more features released we can see where we can refactor and optimise.

### Limitations

- If no primary is detected (because the command failed), then it defaults back to reverse ordinal index order
  - Unsure whether to skip this shard for now
  - We probably can introduce retry logic in the client, I would like to propose a client registry that handles this in the future. Let's see how often it happens first
- Does not failback after the failover, this is an issue today
  - Perhaps we could introduce another check at the end of the cluster reconciliation to ensure that node 0 is the primary
- Proactive failover does not select a replica with highest offset (unchanged from status quo)
- There appears to be a "bug" that exists in status quo where ALL the replicas across ALL shards are rolled first, whereas the intention is to roll all replicas in a shard, then the primary, then move onto the next shard
  - When I looked into this, it appears that after the replica is rolled, there isn't a healthy replica to failover to so the shard is skipped
  - Perhaps instead it should wait for the shard to complete before moving on to the next one

### Testing

- Tested locally by deploying a cluster, updating maxmemory-policy, and watching the change go out
- The first change targeted node index 1 first. The second change targeted node index 0.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
