### PR TITLE
fix: New cluster rolls immediately after creation

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -143,20 +143,27 @@ func buildServerConfig(cluster *valkeyiov1alpha1.ValkeyCluster) string {
 
 // Create or update a default valkey.conf
 // If additional config is provided, append to the default map
-func (r *ValkeyClusterReconciler) upsertConfigMap(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
+//
+// Returns the hash of the rendered server config. Callers MUST use this
+// returned hash rather than reading it back from the ConfigMap: the operator's
+// cached client does not observe a freshly created ConfigMap immediately, so a
+// read-back can miss and yield an empty hash. An empty hash propagated to a
+// ValkeyNode omits the config-hash pod-template annotation, and the later
+// non-empty hash then rolls the just-created pods.
+func (r *ValkeyClusterReconciler) upsertConfigMap(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (string, error) {
 
 	log := logf.FromContext(ctx)
 
 	// Embed readiness check script
 	readiness, err := scripts.ReadFile("scripts/readiness-check.sh")
 	if err != nil {
-		return fmt.Errorf("reading embedded readiness-check.sh: %w", err)
+		return "", fmt.Errorf("reading embedded readiness-check.sh: %w", err)
 	}
 
 	// Embed liveness check script
 	liveness, err := scripts.ReadFile("scripts/liveness-check.sh")
 	if err != nil {
-		return fmt.Errorf("reading embedded liveness-check.sh: %w", err)
+		return "", fmt.Errorf("reading embedded liveness-check.sh: %w", err)
 	}
 
 	// Get the new server config
@@ -174,7 +181,7 @@ func (r *ValkeyClusterReconciler) upsertConfigMap(ctx context.Context, cluster *
 	}, serverConfigMap); err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Error(err, "failed to fetch server configmap")
-			return err
+			return "", err
 		}
 
 		// ConfigMap not found; This happens on cluster init
@@ -200,20 +207,20 @@ func (r *ValkeyClusterReconciler) upsertConfigMap(ctx context.Context, cluster *
 		if err := controllerutil.SetControllerReference(cluster, serverConfigMap, r.Scheme); err != nil {
 			log.Error(err, "Failed to grab ownership of server configMap")
 			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "ConfigMapCreationFailed", "UpsertConfigMap", "Failed to grab ownership of server configMap: %v", err)
-			return err
+			return "", err
 		}
 
 		// Create the configMap
 		if err := r.Create(ctx, serverConfigMap); err != nil {
 			log.Error(err, "Failed to create server configMap")
 			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "ConfigMapCreationFailed", "UpsertConfigMap", "Failed to create server configMap: %v", err)
-			return err
+			return "", err
 		}
 
 		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "ConfigMapCreated", "UpsertConfigMap", "Created server configMap")
 
 		// All good; new configMap with contents created
-		return nil
+		return newServerConfigHash, nil
 	}
 
 	// ConfigMap exists
@@ -226,11 +233,16 @@ func (r *ValkeyClusterReconciler) upsertConfigMap(ctx context.Context, cluster *
 		serverConfigMap.Data[livenessScriptKey] = string(liveness)
 	}
 
+	// Evaluate both upsertAnnotation calls unconditionally so the configHashKey
+	// annotation is always updated when the config changes — even when updatedScripts
+	// is true and would otherwise short-circuit the && below.
+	updatedConfig := upsertAnnotation(serverConfigMap, configHashKey, newServerConfigHash)
+
 	// If the generated config contents hash (from above) matches the hash of the current
 	// config contents, and we did not update the scripts contents, exit early
-	if !updatedScripts && !upsertAnnotation(serverConfigMap, configHashKey, newServerConfigHash) {
+	if !updatedScripts && !updatedConfig {
 		log.V(1).Info("server config unchanged")
-		return nil
+		return newServerConfigHash, nil
 	}
 
 	// Update the configMap with the generated config contents
@@ -240,13 +252,13 @@ func (r *ValkeyClusterReconciler) upsertConfigMap(ctx context.Context, cluster *
 	if err := r.Update(ctx, serverConfigMap); err != nil {
 		log.Error(err, "Failed to update server configMap")
 		r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "ConfigMapUpdateFailed", "UpsertConfigMap", "Failed to update server configMap: %v", err)
-		return err
+		return "", err
 	}
 
 	r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "ConfigMapUpdated", "UpsertConfigMap", "Synchronized server configMap")
 
 	// All is good. configMap was updated with new contents.
-	return nil
+	return newServerConfigHash, nil
 }
 
 // Helper function to write a config line in the form of "parameter value\n" to a strings.Builder

--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -119,7 +119,12 @@ func nodeRequiresRoll(current *valkeyiov1alpha1.ValkeyNode, desired *valkeyiov1a
 // anyNodeRequiresRoll returns true if any existing ValkeyNode in the list has
 // a spec diff against what the cluster would build for it. Used as a cheap
 // pre-flight check to avoid opening Valkey connections on steady-state reconciles.
-func anyNodeRequiresRoll(cluster *valkeyiov1alpha1.ValkeyCluster, nodeList *valkeyiov1alpha1.ValkeyNodeList) bool {
+//
+// configHash must be the current server config hash so the desired spec matches
+// what reconcileValkeyNode actually applies; omitting it would make every
+// settled node (which carries the hash) report a spurious diff and defeat the
+// purpose of this pre-flight check.
+func anyNodeRequiresRoll(cluster *valkeyiov1alpha1.ValkeyCluster, nodeList *valkeyiov1alpha1.ValkeyNodeList, configHash string) bool {
 	byName := make(map[string]*valkeyiov1alpha1.ValkeyNode, len(nodeList.Items))
 	for i := range nodeList.Items {
 		byName[nodeList.Items[i].Name] = &nodeList.Items[i]
@@ -128,6 +133,7 @@ func anyNodeRequiresRoll(cluster *valkeyiov1alpha1.ValkeyCluster, nodeList *valk
 	for shardIndex := range int(cluster.Spec.Shards) {
 		for nodeIndex := range nodesPerShard {
 			desired := buildClusterValkeyNode(cluster, shardIndex, nodeIndex)
+			desired.Spec.ServerConfigHash = configHash
 			if current, ok := byName[desired.Name]; ok && nodeRequiresRoll(current, desired) {
 				return true
 			}

--- a/internal/controller/failover_test.go
+++ b/internal/controller/failover_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 	"valkey.io/valkey-operator/internal/valkey"
 )
@@ -139,5 +140,34 @@ func TestNodeRequiresRoll(t *testing.T) {
 		desired := &valkeyiov1alpha1.ValkeyNode{}
 		desired.Spec.Image = "valkey:8.2"
 		assert.False(t, nodeRequiresRoll(current, desired))
+	})
+}
+
+func TestAnyNodeRequiresRoll(t *testing.T) {
+	cluster := &valkeyiov1alpha1.ValkeyCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec:       valkeyiov1alpha1.ValkeyClusterSpec{Shards: 1, Replicas: 0},
+	}
+	const configHash = "abc123"
+
+	// steadyStateNode returns the node the cluster would build for (0,0) in a
+	// settled cluster: matching spec, the current config hash, and a pod IP.
+	steadyStateNode := func() valkeyiov1alpha1.ValkeyNode {
+		n := buildClusterValkeyNode(cluster, 0, 0)
+		n.Spec.ServerConfigHash = configHash
+		n.Status.PodIP = "10.0.0.1"
+		return *n
+	}
+
+	t.Run("settled node with matching config hash does not require roll", func(t *testing.T) {
+		nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{steadyStateNode()}}
+		assert.False(t, anyNodeRequiresRoll(cluster, nodes, configHash))
+	})
+
+	t.Run("node with stale config hash requires roll", func(t *testing.T) {
+		n := steadyStateNode()
+		n.Spec.ServerConfigHash = "stale"
+		nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{n}}
+		assert.True(t, anyNodeRequiresRoll(cluster, nodes, configHash))
 	})
 }

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -134,18 +134,18 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	if err := r.upsertConfigMap(ctx, cluster); err != nil {
+	// Use the hash returned by upsertConfigMap directly. Reading it back from the
+	// ConfigMap via the cached client is unsafe: right after the ConfigMap is
+	// created the informer cache may not have observed it, so the read misses and
+	// yields an empty hash. ValkeyNodes created with an empty hash start without
+	// the config-hash pod-template annotation, and the later non-empty hash rolls
+	// the freshly created pods.
+	configHash, err := r.upsertConfigMap(ctx, cluster)
+	if err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonConfigMapError, err.Error(), metav1.ConditionFalse)
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{}, err
 	}
-	configHash := func() string {
-		cm := &corev1.ConfigMap{}
-		if err := r.Get(ctx, client.ObjectKey{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm); err != nil {
-			return ""
-		}
-		return cm.Annotations[configHashKey]
-	}()
 
 	nodes := &valkeyiov1alpha1.ValkeyNodeList{}
 	if err := r.List(ctx, nodes, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{LabelCluster: cluster.Name})); err != nil {
@@ -417,7 +417,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	// is last in each shard), and after an update we requeue immediately,
 	// re-scraping fresh state.
 	var clusterState *valkey.ClusterState
-	if anyNodeRequiresRoll(cluster, nodes) {
+	if anyNodeRequiresRoll(cluster, nodes, configHash) {
 		operatorPassword, err := fetchSystemUserPassword(ctx, operatorUser, r.Client, cluster.Name, cluster.Namespace)
 		if err != nil {
 			return false, fmt.Errorf("failed to fetch operator password for proactive failover: %w", err)

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -201,6 +201,82 @@ var _ = Describe("ValkeyCluster config hash propagation", func() {
 	})
 })
 
+// staleConfigMapClient wraps a client.Client and always reports ConfigMaps as
+// NotFound on Get, simulating the read-after-write staleness of the cached
+// controller-runtime client used in production (mgr.GetClient()): immediately
+// after a ConfigMap is created, the informer cache has not yet observed it, so
+// a Get returns NotFound. Writes and all non-ConfigMap reads pass through.
+type staleConfigMapClient struct {
+	client.Client
+}
+
+func (c staleConfigMapClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*corev1.ConfigMap); ok {
+		return errors.NewNotFound(corev1.Resource("configmaps"), key.Name)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+var _ = Describe("ValkeyCluster config hash on first reconcile", func() {
+	ctx := context.Background()
+
+	It("creates ValkeyNodes with the config hash even when the ConfigMap is not yet visible to the client cache", func() {
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config-hash-stale-test",
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+				Config:   map[string]string{"maxmemory": "100mb"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		defer func() {
+			nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+			_ = k8sClient.List(ctx, nodeList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: cluster.Name})
+			for i := range nodeList.Items {
+				_ = k8sClient.Delete(ctx, &nodeList.Items[i])
+			}
+			_ = k8sClient.Delete(ctx, cluster)
+			cm := &corev1.ConfigMap{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm); err == nil {
+				_ = k8sClient.Delete(ctx, cm)
+			}
+			secret := &corev1.Secret{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: getInternalSecretName(cluster.Name), Namespace: cluster.Namespace}, secret); err == nil {
+				_ = k8sClient.Delete(ctx, secret)
+			}
+		}()
+
+		r := &ValkeyClusterReconciler{
+			Client:   staleConfigMapClient{Client: k8sClient},
+			Scheme:   k8sClient.Scheme(),
+			Recorder: events.NewFakeRecorder(100),
+		}
+
+		By("reconciling with a client that cannot yet see the freshly created ConfigMap")
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("reading the config hash the operator persisted to the ConfigMap")
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: GetServerConfigMapName(cluster.Name), Namespace: cluster.Namespace}, cm)).To(Succeed())
+		persistedHash := cm.Annotations[configHashKey]
+		Expect(persistedHash).NotTo(BeEmpty())
+
+		By("verifying every ValkeyNode was created with that same hash, not an empty one")
+		nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+		Expect(k8sClient.List(ctx, nodeList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: cluster.Name})).To(Succeed())
+		Expect(nodeList.Items).NotTo(BeEmpty())
+		for _, n := range nodeList.Items {
+			Expect(n.Spec.ServerConfigHash).To(Equal(persistedHash),
+				"ValkeyNode %s must be created with the config hash; an empty hash means the pod starts without the config-hash annotation and rolls as soon as the hash is later populated", n.Name)
+		}
+	})
+})
+
 var _ = Describe("reconcileUsersAcl", func() {
 	Context("When reconciling ACL secrets", func() {
 		It("should return an error when a user references a missing password secret", func() {
@@ -440,8 +516,9 @@ var _ = Describe("EventRecorder", func() {
 			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, cluster) }()
 
-			err := r.upsertConfigMap(ctx, cluster)
+			hash, err := r.upsertConfigMap(ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(hash).NotTo(BeEmpty())
 
 			events := collectEvents(fakeRecorder)
 			Expect(events).To(ContainElement(ContainSubstring("ConfigMapCreated")))


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

This PR closes #229 

### Summary

Stops newly provisioned clusters from rolling immediately after creation and bootstrapping.

### Implementation

The issue is because of ServerConfigHash being empty on bootstrap. It is empty because after the ConfigMap is upserted, it does not exist in the cache for the Hash to be calculated. ServerConfigHash is then set to be empty on bootstrap. After bootstrap, the Hash can be calculated after the ConfigMap is available in the cache, so this diff then causes the pods to be rolled.

The fix here is to have upsertConfigMap return the hash so that it can be immediately used to set in ServerConfigHash.

After we've implemented live config sets in #209 we can revisit the use of ServerConfigHash to see if there is some refactoring that can be done.

### Testing

Tested locally with a roll.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
