### PR TITLE
add dedicated replication system user

### DIFF
--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -49,6 +49,8 @@ var _ = Describe("When creating a cluster", Label("userconfig"), func() {
 
 		// Primary fails over to a replica on SIGTERM (graceful shutdown)
 		Expect(testConfigString).To(ContainSubstring("shutdown-on-sigterm failover"))
+		
+		Expect(testConfigString).To(ContainSubstring("primaryauth sup3rSecr3tP4ssw0rd"))
 	})
 })
 

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -49,7 +49,7 @@ var _ = Describe("When creating a cluster", Label("userconfig"), func() {
 
 		// Primary fails over to a replica on SIGTERM (graceful shutdown)
 		Expect(testConfigString).To(ContainSubstring("shutdown-on-sigterm failover"))
-		
+
 		Expect(testConfigString).To(ContainSubstring("primaryauth sup3rSecr3tP4ssw0rd"))
 	})
 })

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -50,7 +50,6 @@ var _ = Describe("When creating a cluster", Label("userconfig"), func() {
 		// Primary fails over to a replica on SIGTERM (graceful shutdown)
 		Expect(testConfigString).To(ContainSubstring("shutdown-on-sigterm failover"))
 
-		Expect(testConfigString).To(ContainSubstring("primaryauth sup3rSecr3tP4ssw0rd"))
 	})
 })
 

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -49,7 +49,6 @@ var _ = Describe("When creating a cluster", Label("userconfig"), func() {
 
 		// Primary fails over to a replica on SIGTERM (graceful shutdown)
 		Expect(testConfigString).To(ContainSubstring("shutdown-on-sigterm failover"))
-
 	})
 })
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -44,7 +44,8 @@ const (
 var (
 	operatorUser    = "_operator"
 	exporterUser    = "_exporter"
-	systemUsers     = []string{operatorUser, exporterUser}
+	replicationUser = "_replication"
+	systemUsers     = []string{operatorUser, exporterUser, replicationUser}
 	systemUsersAcls = map[string]string{
 		operatorUser: strings.Join([]string{
 			"+@connection",               // client handshake (CLIENT TRACKING, SETINFO, AUTH, PING)
@@ -65,6 +66,8 @@ var (
 		}, " "),
 		// the ACL rawstring for exporter is taken from the redis_exporter documentation: https://github.com/oliver006/redis_exporter#authenticating-with-redis
 		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
+		// the ACL rawstring for replication is taken from Valkey documentation: https://valkey.io/topics/acl/#acl-rules-for-sentinel-and-replicas
+		replicationUser: "-@all +psync +replconf +ping",
 	}
 )
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -136,7 +136,8 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 				return "", err
 			}
 		} else {
-			return "", err
+			// error is unknown system user, either by manual modification, or removal from between valkey-operator versions
+			log.Error(err, "error validating system user secret")
 		}
 	}
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -68,7 +68,7 @@ var (
 		// the ACL rawstring for exporter is taken from the redis_exporter documentation: https://github.com/oliver006/redis_exporter#authenticating-with-redis
 		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
 		// the ACL rawstring for replication is taken from Valkey documentation: https://valkey.io/topics/acl/#acl-rules-for-sentinel-and-replicas
-		replicationUser: "-@all +psync +replconf +ping",
+		replicationUser: "-@all +psync +replconf +ping +cluster|syncslots",
 	}
 )
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -67,8 +67,11 @@ var (
 		}, " "),
 		// the ACL rawstring for exporter is taken from the redis_exporter documentation: https://github.com/oliver006/redis_exporter#authenticating-with-redis
 		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
-		// the ACL rawstring for replication is taken from Valkey documentation: https://valkey.io/topics/acl/#acl-rules-for-sentinel-and-replicas
-		replicationUser: "-@all +psync +replconf +ping +cluster|syncslots",
+
+		replicationUser: strings.Join([]string{
+			"-@all +psync +replconf +ping", // the ACL rawstring for replication is taken from Valkey documentation: https://valkey.io/topics/acl/#acl-rules-for-sentinel-and-replicas
+			"+cluster|syncslots",           // required for atomic slot migration
+		}, " "),
 	}
 )
 
@@ -117,7 +120,7 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 			log.Error(err, "failed to fetch system users secret")
 			return "", err
 		}
-		systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, r.Client, cluster)
+		systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, cluster)
 		if err != nil {
 			log.Error(err, "failed to create system user secret")
 			return "", err
@@ -127,7 +130,7 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 	err = validateSystemUserPasswordSecret(systemUserSecret.Data, cluster)
 	if err != nil {
 		if errors.Is(err, errMissingSystemUser) {
-			systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, r.Client, cluster)
+			systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, cluster)
 			if err != nil {
 				log.Error(err, "failed to update system user secret")
 				return "", err
@@ -350,6 +353,9 @@ func generatePassword(length int) ([]byte, error) {
 	return ret, nil
 }
 
+// validateSystemUserPasswordSecret verifies that the system user password secret
+// contains exactly the expected system user entries. It rejects any unknown users
+// and ensures all required system users are present.
 func validateSystemUserPasswordSecret(data map[string][]byte, cluster *valkeyiov1alpha1.ValkeyCluster) error {
 	// list of users need to exists in the secret (with _exporter being optional)
 	u := make([]string, len(systemUsers))
@@ -370,7 +376,7 @@ func validateSystemUserPasswordSecret(data map[string][]byte, cluster *valkeyiov
 	return nil
 }
 
-func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Context, apiClient client.Client, cluster *valkeyiov1alpha1.ValkeyCluster) (*corev1.Secret, error) {
+func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (*corev1.Secret, error) {
 	log := logf.FromContext(ctx)
 	var createSecret bool
 	secretName := getSystemPasswordSecretName(cluster.Name)
@@ -420,9 +426,9 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 
 	var err error
 	if createSecret {
-		err = apiClient.Create(ctx, systemUsersSecret)
+		err = r.Create(ctx, systemUsersSecret)
 	} else {
-		err = apiClient.Update(ctx, systemUsersSecret)
+		err = r.Update(ctx, systemUsersSecret)
 	}
 	return systemUsersSecret, err
 }

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math/big"
 	"slices"
@@ -71,6 +72,11 @@ var (
 	}
 )
 
+var (
+	errUnknownSystemUser = errors.New("unknown system user")
+	errMissingSystemUser = errors.New("missing system user")
+)
+
 func getInternalSecretName(clusterName string) string {
 	return "internal-" + clusterName + "-acl"
 }
@@ -117,6 +123,20 @@ func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, clus
 			return "", err
 		}
 	}
+
+	err = validateSystemUserPasswordSecret(systemUserSecret.Data, cluster)
+	if err != nil {
+		if errors.Is(err, errMissingSystemUser) {
+			systemUserSecret, err = r.upsertSystemUsersPasswordSecret(ctx, r.Client, cluster)
+			if err != nil {
+				log.Error(err, "failed to update system user secret")
+				return "", err
+			}
+		} else {
+			return "", err
+		}
+	}
+
 	for _, user := range systemUsers {
 		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
 			continue
@@ -330,25 +350,62 @@ func generatePassword(length int) ([]byte, error) {
 	return ret, nil
 }
 
+func validateSystemUserPasswordSecret(data map[string][]byte, cluster *valkeyiov1alpha1.ValkeyCluster) error {
+	// list of users need to exists in the secret (with _exporter being optional)
+	u := make([]string, len(systemUsers))
+	copy(u, systemUsers)
+	for user := range data {
+		i := slices.Index(u, user)
+		if i == -1 {
+			return fmt.Errorf("%w: %s", errUnknownSystemUser, user)
+		}
+		u = append(u[:i], u[i+1:]...)
+	}
+	for _, user := range u {
+		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
+			continue
+		}
+		return fmt.Errorf("%w: %s", errMissingSystemUser, user)
+	}
+	return nil
+}
+
 func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Context, apiClient client.Client, cluster *valkeyiov1alpha1.ValkeyCluster) (*corev1.Secret, error) {
 	log := logf.FromContext(ctx)
+	var createSecret bool
+	secretName := getSystemPasswordSecretName(cluster.Name)
+	systemUsersSecret := &corev1.Secret{}
 
-	systemUsersSecret := corev1.Secret{
-		Type: AclSecretType,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      getSystemPasswordSecretName(cluster.Name),
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      secretName,
+		Namespace: cluster.Namespace,
+	}, systemUsersSecret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to fetch system users secret")
+			return nil, err
+		}
+		log.V(2).Info("creating internal secret", "secretName", systemUsersSecret)
+
+		systemUsersSecret.Type = AclSecretType
+		systemUsersSecret.ObjectMeta = metav1.ObjectMeta{
+			Name:      secretName,
 			Namespace: cluster.Namespace,
 			Labels:    labels(cluster),
-		},
-		Data: map[string][]byte{},
+		}
+		systemUsersSecret.Data = make(map[string][]byte)
+		// Register ownership of the new internal Secret
+		if err := controllerutil.SetControllerReference(cluster, systemUsersSecret, r.Scheme); err != nil {
+			log.Error(err, "Failed to grab ownership of system users secret")
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to grab ownership of system users secret: %v", err)
+			return systemUsersSecret, err
+		}
+		createSecret = true
 	}
-	// Register ownership of the new internal Secret
-	if err := controllerutil.SetControllerReference(cluster, &systemUsersSecret, r.Scheme); err != nil {
-		log.Error(err, "Failed to grab ownership of system users secret")
-		r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to grab ownership of system users secret: %v", err)
-		return &systemUsersSecret, err
-	}
+
 	for _, user := range systemUsers {
+		if _, alreadyExist := systemUsersSecret.Data[user]; alreadyExist {
+			continue
+		}
 		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
 			continue
 		}
@@ -356,13 +413,18 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 		if err != nil {
 			log.Error(err, "Failed to generate random password", "username", user)
 			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "InternalSecretsCreationFailed", "ReconcileUsers", "Failed to generate random password: %v", err)
-			return &systemUsersSecret, err
+			return systemUsersSecret, err
 		}
 		systemUsersSecret.Data[user] = password
 	}
 
-	err := apiClient.Create(ctx, &systemUsersSecret)
-	return &systemUsersSecret, err
+	var err error
+	if createSecret {
+		err = apiClient.Create(ctx, systemUsersSecret)
+	} else {
+		err = apiClient.Update(ctx, systemUsersSecret)
+	}
+	return systemUsersSecret, err
 }
 
 func (r *ValkeyClusterReconciler) upsertInternalAclSecret(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, aclBytes []byte) error {

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -363,16 +363,20 @@ func validateSystemUserPasswordSecret(data map[string][]byte, cluster *valkeyiov
 	copy(u, systemUsers)
 	for user := range data {
 		i := slices.Index(u, user)
-		if i == -1 {
-			return fmt.Errorf("%w: %s", errUnknownSystemUser, user)
+		if i != -1 {
+			u = append(u[:i], u[i+1:]...)
 		}
-		u = append(u[:i], u[i+1:]...)
 	}
 	for _, user := range u {
 		if user == exporterUser && !cluster.Spec.Exporter.Enabled {
 			continue
 		}
 		return fmt.Errorf("%w: %s", errMissingSystemUser, user)
+	}
+	for user := range data {
+		if !slices.Contains(systemUsers, user) {
+			return fmt.Errorf("%w: %s", errUnknownSystemUser, user)
+		}
 	}
 	return nil
 }

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -390,7 +390,7 @@ func (r *ValkeyClusterReconciler) upsertSystemUsersPasswordSecret(ctx context.Co
 			log.Error(err, "failed to fetch system users secret")
 			return nil, err
 		}
-		log.V(2).Info("creating internal secret", "secretName", systemUsersSecret)
+		log.V(2).Info("creating internal secret", "secretName", secretName)
 
 		systemUsersSecret.Type = AclSecretType
 		systemUsersSecret.ObjectMeta = metav1.ObjectMeta{

--- a/internal/controller/users_test.go
+++ b/internal/controller/users_test.go
@@ -20,7 +20,10 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
+
+	//	corev1 "k8s.io/api/core/v1"
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 )
 
@@ -123,4 +126,21 @@ func TestBuildAclFileContents(t *testing.T) {
 			t.Errorf("%s ACL Failed. Expected '%s'; got '%s'", userName, expected, acl)
 		}
 	}
+}
+
+func TestValidateSystemUserPasswordSecret(t *testing.T) {
+	g := NewWithT(t)
+	userSecret := map[string][]byte{
+		operatorUser:    nil,
+		replicationUser: nil,
+	}
+	cluster := &valkeyiov1alpha1.ValkeyCluster{
+		Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+			Exporter: valkeyiov1alpha1.ExporterSpec{
+				Enabled: true,
+			},
+		},
+	}
+	err := validateSystemUserPasswordSecret(userSecret, cluster)
+	g.Expect(err).To(MatchError(errMissingSystemUser))
 }

--- a/internal/controller/users_test.go
+++ b/internal/controller/users_test.go
@@ -145,3 +145,23 @@ func TestValidateSystemUserPasswordSecret(t *testing.T) {
 		t.Errorf("Validate System Users Password Failed. Expected '%s', got: '%s'", errMissingSystemUser.Error(), err.Error())
 	}
 }
+
+func TestValidateSystemUserPasswordSecret_UnknownUser(t *testing.T) {
+	unknownUser := "_randomuser"
+	userSecret := map[string][]byte{
+		operatorUser:    nil,
+		replicationUser: nil,
+		unknownUser:     nil,
+	}
+	cluster := &valkeyiov1alpha1.ValkeyCluster{
+		Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+			Exporter: valkeyiov1alpha1.ExporterSpec{
+				Enabled: false,
+			},
+		},
+	}
+	err := validateSystemUserPasswordSecret(userSecret, cluster)
+	if !errors.Is(err, errUnknownSystemUser) {
+		t.Errorf("Validate System Users Password Failed. Expected '%s', got: '%s'", errMissingSystemUser.Error(), err.Error())
+	}
+}

--- a/internal/controller/users_test.go
+++ b/internal/controller/users_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 
 	//	corev1 "k8s.io/api/core/v1"
@@ -129,7 +129,6 @@ func TestBuildAclFileContents(t *testing.T) {
 }
 
 func TestValidateSystemUserPasswordSecret(t *testing.T) {
-	g := NewWithT(t)
 	userSecret := map[string][]byte{
 		operatorUser:    nil,
 		replicationUser: nil,
@@ -142,5 +141,7 @@ func TestValidateSystemUserPasswordSecret(t *testing.T) {
 		},
 	}
 	err := validateSystemUserPasswordSecret(userSecret, cluster)
-	g.Expect(err).To(MatchError(errMissingSystemUser))
+	if !errors.Is(err, errMissingSystemUser) {
+		t.Errorf("Validate System Users Password Failed. Expected '%s', got: '%s'", errMissingSystemUser.Error(), err.Error())
+	}
 }

--- a/internal/controller/users_test.go
+++ b/internal/controller/users_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	//	corev1 "k8s.io/api/core/v1"
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 )
 

--- a/internal/controller/users_test.go
+++ b/internal/controller/users_test.go
@@ -162,6 +162,24 @@ func TestValidateSystemUserPasswordSecret_UnknownUser(t *testing.T) {
 	}
 	err := validateSystemUserPasswordSecret(userSecret, cluster)
 	if !errors.Is(err, errUnknownSystemUser) {
+		t.Errorf("Validate System Users Password Failed. Expected '%s', got: '%s'", errUnknownSystemUser.Error(), err.Error())
+	}
+}
+
+func TestValidateSystemUserPasswordSecret_UnknownUserAndMissingRequiredUser(t *testing.T) {
+	unknownUser := "_randomuser"
+	userSecret := map[string][]byte{
+		unknownUser: nil,
+	}
+	cluster := &valkeyiov1alpha1.ValkeyCluster{
+		Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+			Exporter: valkeyiov1alpha1.ExporterSpec{
+				Enabled: false,
+			},
+		},
+	}
+	err := validateSystemUserPasswordSecret(userSecret, cluster)
+	if !errors.Is(err, errMissingSystemUser) {
 		t.Errorf("Validate System Users Password Failed. Expected '%s', got: '%s'", errMissingSystemUser.Error(), err.Error())
 	}
 }

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -491,6 +491,50 @@ var _ = Describe("reconcileUsersAcl", func() {
 
 			Expect(internalSecret.Type).To(Equal(AclSecretType))
 		})
+
+		It("should update the system user secret when spec.exporter is enabled after cluster creation", func() {
+			ctx := context.Background()
+			cluster := &valkeyiov1alpha1.ValkeyCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "acl-system-user-reconciliation-test",
+					Namespace: "default",
+				},
+				Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+					Shards:   1,
+					Replicas: 0,
+					Exporter: valkeyiov1alpha1.ExporterSpec{
+						Enabled: false,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, cluster) }()
+
+			reconciler := &ValkeyClusterReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: events.NewFakeRecorder(100),
+			}
+
+			err := reconciler.reconcileUsersAcl(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			systemUsersSecret := &corev1.Secret{}
+			secretName := types.NamespacedName{
+				Name:      getSystemPasswordSecretName(cluster.Name),
+				Namespace: cluster.Namespace,
+			}
+			Expect(k8sClient.Get(ctx, secretName, systemUsersSecret)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, systemUsersSecret) }()
+			Expect(systemUsersSecret.Data).NotTo(HaveKey(exporterUser))
+
+			cluster.Spec.Exporter.Enabled = true
+			Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+			err = reconciler.reconcileUsersAcl(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, secretName, systemUsersSecret)).To(Succeed())
+			Expect(systemUsersSecret.Data).To(HaveKey(exporterUser))
+		})
 	})
 })
 

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"strings"
 	"time"
 
@@ -532,6 +534,16 @@ var _ = Describe("reconcileUsersAcl", func() {
 			err := reconciler.reconcileUsersAcl(ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 
+			systemSecret := &corev1.Secret{}
+			systemSecretName := types.NamespacedName{
+				Name:      getSystemPasswordSecretName(cluster.Name),
+				Namespace: cluster.Namespace,
+			}
+			Expect(k8sClient.Get(ctx, systemSecretName, systemSecret)).To(Succeed())
+			Expect(systemSecret.Data).To(HaveKey(operatorUser))
+			Expect(systemSecret.Data).To(HaveKey(replicationUser))
+			Expect(systemSecret.Data).To(HaveKey(unknownUser))
+
 			aclSecret := &corev1.Secret{}
 			secretName := types.NamespacedName{
 				Name:      getInternalSecretName(cluster.Name),
@@ -540,8 +552,14 @@ var _ = Describe("reconcileUsersAcl", func() {
 			Expect(k8sClient.Get(ctx, secretName, aclSecret)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, aclSecret) }()
 			acl := string(aclSecret.Data[aclFilename])
+			nilPassword := fmt.Sprintf("%x", sha256.Sum256(nil))
+
 			Expect(acl).To(ContainSubstring("user _operator on"))
+			Expect(acl).To(ContainSubstring("user _replication on"))
 			Expect(acl).NotTo(ContainSubstring("user " + unknownUser))
+
+			// assert that the generated password for users are not nil/empty string
+			Expect(acl).NotTo(ContainSubstring(nilPassword))
 		})
 
 		It("should update the system user secret when spec.exporter is enabled after cluster creation", func() {

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -492,6 +492,58 @@ var _ = Describe("reconcileUsersAcl", func() {
 			Expect(internalSecret.Type).To(Equal(AclSecretType))
 		})
 
+		It("should be able to create the internal ACL secret when unknown system user is present", func() {
+			unknownUser := "_unknown"
+			ctx := context.Background()
+			cluster := &valkeyiov1alpha1.ValkeyCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "acl-unknown-system-user-test",
+					Namespace: "default",
+				},
+				Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+					Shards:   1,
+					Replicas: 0,
+					Exporter: valkeyiov1alpha1.ExporterSpec{
+						Enabled: false,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, cluster) }()
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getSystemPasswordSecretName(cluster.Name),
+					Namespace: "default",
+				},
+				Type: AclSecretType,
+				StringData: map[string]string{
+					unknownUser: "",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, secret) }()
+
+			reconciler := &ValkeyClusterReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: events.NewFakeRecorder(100),
+			}
+			err := reconciler.reconcileUsersAcl(ctx, cluster)
+			Expect(err).NotTo(HaveOccurred())
+
+			aclSecret := &corev1.Secret{}
+			secretName := types.NamespacedName{
+				Name:      getInternalSecretName(cluster.Name),
+				Namespace: cluster.Namespace,
+			}
+			Expect(k8sClient.Get(ctx, secretName, aclSecret)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, aclSecret) }()
+			acl := string(aclSecret.Data[aclFilename])
+			Expect(acl).To(ContainSubstring("user _operator on"))
+			Expect(acl).NotTo(ContainSubstring("user " + unknownUser))
+		})
+
 		It("should update the system user secret when spec.exporter is enabled after cluster creation", func() {
 			ctx := context.Background()
 			cluster := &valkeyiov1alpha1.ValkeyCluster{

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -613,14 +613,17 @@ func (r *ValkeyNodeReconciler) buildNodeClientOption(ctx context.Context, node *
 // getValkeyRole connects to a Valkey pod and returns its replication role
 // ("primary" or "replica"). Returns an empty string if the role cannot be determined.
 func (r *ValkeyNodeReconciler) getValkeyRole(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode) string {
+	log := logf.FromContext(ctx)
 	c, err := vclient.NewClient(r.buildNodeClientOption(ctx, node))
 	if err != nil {
+		log.Error(err, "failed to create valkey client")
 		return ""
 	}
 	defer c.Close()
 
 	info, err := c.Do(ctx, c.B().Info().Section("replication").Build()).ToString()
 	if err != nil {
+		log.Error(err, "failed to get replication info")
 		return ""
 	}
 

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -172,6 +172,10 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 				"/config/valkey.conf",
 				"--cluster-announce-ip",
 				"$(POD_IP)",
+				"--primaryuser",
+				replicationUser,
+				"--primaryauth",
+				"$(PRIMARY_AUTH)",
 			},
 			Env: []corev1.EnvVar{
 				{
@@ -179,6 +183,17 @@ func buildContainersDef(node *valkeyiov1alpha1.ValkeyNode) ([]corev1.Container, 
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{
 							FieldPath: "status.podIP",
+						},
+					},
+				},
+				{
+					Name: "PRIMARY_AUTH",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: getSystemPasswordSecretName(node.Labels[LabelCluster]),
+							},
+							Key: replicationUser,
 						},
 					},
 				},

--- a/internal/controller/valkeynode_resources_test.go
+++ b/internal/controller/valkeynode_resources_test.go
@@ -76,12 +76,17 @@ func TestBuildValkeyNodePodTemplateSpec(t *testing.T) {
 	assert.Equal(t, "valkey/valkey:9.0.0", c.Image)
 
 	// Command
-	assert.Equal(t, []string{"valkey-server", "/config/valkey.conf", "--cluster-announce-ip", "$(POD_IP)"}, c.Command)
+	assert.Equal(t, []string{"valkey-server", "/config/valkey.conf",
+		"--cluster-announce-ip", "$(POD_IP)",
+		"--primaryuser", replicationUser,
+		"--primaryauth", "$(PRIMARY_AUTH)"}, c.Command)
 
 	// Env
-	require.Len(t, c.Env, 1)
+	require.Len(t, c.Env, 2)
 	assert.Equal(t, "POD_IP", c.Env[0].Name)
 	assert.Equal(t, "status.podIP", c.Env[0].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "PRIMARY_AUTH", c.Env[1].Name)
+	assert.Equal(t, getSystemPasswordSecretName(node.Labels[LabelCluster]), c.Env[1].ValueFrom.SecretKeyRef.Name)
 
 	// Ports
 	require.Len(t, c.Ports, 2)

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -94,6 +94,7 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 				g.Expect(output).To(SatisfyAll(
 					ContainSubstring("_operator"),
 					ContainSubstring("_exporter"),
+					ContainSubstring("_replication"),
 				))
 			}
 			Eventually(verifySystemUserAcls).Should(Succeed())
@@ -294,6 +295,9 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 			Eventually(verifyClusterAccess).
 				WithArguments("52428800", "CONFIG", "GET", "maxmemory").
 				Should(Succeed(), "Failed CONFIG GET maxmemory")
+			Eventually(verifyClusterAccess).
+				WithArguments("_replication", "CONFIG", "GET", "primaryuser").
+				Should(Succeed(), "Failed CONFIG GET primaryuser")
 
 			By("validating CLUSTER SLOTS reports the pod IP")
 			verifyClusterSlotsIP := func(g Gomega) {

--- a/test/e2e/valkeynode_test.go
+++ b/test/e2e/valkeynode_test.go
@@ -37,9 +37,9 @@ import (
 const (
 	// Credentials the e2e provisions to stand in for the operator-managed
 	// "_operator" system user.
-	e2eOperatorPassword = "e2eOperatorPassw0rd"
+	e2eOperatorPassword    = "e2eOperatorPassw0rd"
 	e2eReplicationPassword = "e2eReplicationPassword"
-	e2eDefaultPassword  = "e2eDefaultPassword"
+	e2eDefaultPassword     = "e2eDefaultPassword"
 )
 
 var _ = Describe("ValkeyNode", func() {

--- a/test/e2e/valkeynode_test.go
+++ b/test/e2e/valkeynode_test.go
@@ -38,6 +38,7 @@ const (
 	// Credentials the e2e provisions to stand in for the operator-managed
 	// "_operator" system user.
 	e2eOperatorPassword = "e2eOperatorPassw0rd"
+	e2eReplicationPassword = "e2eReplicationPassword"
 	e2eDefaultPassword  = "e2eDefaultPassword"
 )
 
@@ -80,7 +81,8 @@ metadata:
     app.kubernetes.io/managed-by: valkey-operator
 stringData:
   _operator: %s
-`, name, e2eOperatorPassword), "system-passwords secret for "+name)
+  _replication: %s
+`, name, e2eOperatorPassword, e2eReplicationPassword), "system-passwords secret for "+name)
 
 		applyManifest(fmt.Sprintf(`apiVersion: v1
 kind: Secret
@@ -93,7 +95,8 @@ stringData:
   users.acl: |
     user default on >%s ~* &* +@all
     user _operator on >%s ~* &* +@all
-`, name, e2eDefaultPassword, e2eOperatorPassword), "ACL secret for "+name)
+	user _replication on >%s ~* &* +@all
+`, name, e2eDefaultPassword, e2eOperatorPassword, e2eReplicationPassword), "ACL secret for "+name)
 	}
 
 	deleteSystemUsersSecrets := func(name string) {
@@ -134,7 +137,7 @@ spec:
 		}).Should(Succeed())
 	}
 
-	Context("standalone StatefulSet", Label("valkeynode"), func() {
+	Context("standalone StatefulSet", Label("valkeynode", "standalone-sts"), func() {
 		const nodeName = "valkeynode-sts-e2e"
 		expectedConfigMapName := controller.GetServerConfigMapName(nodeName)
 
@@ -343,7 +346,28 @@ data:
 			defer deleteResource("configmap", cmName)
 
 			By("creating a ValkeyNode that references the external ConfigMap")
+<<<<<<< HEAD
 			applySystemUsersSecrets(nodeName)
+=======
+			secretManifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+type: valkey.io/acl
+metadata:
+  name: internal-%s-acl
+  labels:
+    app.kubernetes.io/managed-by: valkey-operator
+---
+apiVersion: v1
+kind: Secret
+type: valkey.io/acl
+metadata:
+  name: internal-%s-system-passwords
+data:
+  _exporter: aGVsbG8=
+  _operator: aGVsbG8=
+  _replication: aGVsbG8=
+`, nodeName, nodeName)
+>>>>>>> 477206a (fix valkeynode e2e tests not creating system users secret)
 
 			nodeManifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
 kind: ValkeyNode
@@ -358,8 +382,15 @@ spec:
 
 			applyManifest(nodeManifest, "ValkeyNode with external ConfigMap")
 			defer func() {
+<<<<<<< HEAD
 				deleteResource("valkeynode", nodeName)
 				deleteSystemUsersSecrets(nodeName)
+=======
+				cmd := exec.Command("kubectl", "delete", "valkeynode", nodeName, "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+				cmd = exec.Command("kubectl", "delete", "secret", "internal-"+nodeName+"-acl", "internal-"+nodeName+"-system-passwords", "--ignore-not-found=true", "--wait=false")
+				_, _ = utils.Run(cmd)
+>>>>>>> 477206a (fix valkeynode e2e tests not creating system users secret)
 			}()
 
 			By("verifying the controller did NOT create an owned ConfigMap")

--- a/test/e2e/valkeynode_test.go
+++ b/test/e2e/valkeynode_test.go
@@ -95,7 +95,7 @@ stringData:
   users.acl: |
     user default on >%s ~* &* +@all
     user _operator on >%s ~* &* +@all
-	user _replication on >%s ~* &* +@all
+    user _replication on >%s ~* &* +@all
 `, name, e2eDefaultPassword, e2eOperatorPassword, e2eReplicationPassword), "ACL secret for "+name)
 	}
 
@@ -346,27 +346,7 @@ data:
 			defer deleteResource("configmap", cmName)
 
 			By("creating a ValkeyNode that references the external ConfigMap")
-<<<<<<< HEAD
 			applySystemUsersSecrets(nodeName)
-=======
-			secretManifest := fmt.Sprintf(`apiVersion: v1
-kind: Secret
-type: valkey.io/acl
-metadata:
-  name: internal-%s-acl
-  labels:
-    app.kubernetes.io/managed-by: valkey-operator
----
-apiVersion: v1
-kind: Secret
-type: valkey.io/acl
-metadata:
-  name: internal-%s-system-passwords
-data:
-  _exporter: aGVsbG8=
-  _replication: aGVsbG8=
-`, nodeName, nodeName)
->>>>>>> 477206a (fix valkeynode e2e tests not creating system users secret)
 
 			nodeManifest := fmt.Sprintf(`apiVersion: valkey.io/v1alpha1
 kind: ValkeyNode
@@ -381,15 +361,8 @@ spec:
 
 			applyManifest(nodeManifest, "ValkeyNode with external ConfigMap")
 			defer func() {
-<<<<<<< HEAD
 				deleteResource("valkeynode", nodeName)
 				deleteSystemUsersSecrets(nodeName)
-=======
-				cmd := exec.Command("kubectl", "delete", "valkeynode", nodeName, "--ignore-not-found=true", "--wait=false")
-				_, _ = utils.Run(cmd)
-				cmd = exec.Command("kubectl", "delete", "secret", "internal-"+nodeName+"-acl", "internal-"+nodeName+"-system-passwords", "--ignore-not-found=true", "--wait=false")
-				_, _ = utils.Run(cmd)
->>>>>>> 477206a (fix valkeynode e2e tests not creating system users secret)
 			}()
 
 			By("verifying the controller did NOT create an owned ConfigMap")

--- a/test/e2e/valkeynode_test.go
+++ b/test/e2e/valkeynode_test.go
@@ -364,7 +364,6 @@ metadata:
   name: internal-%s-system-passwords
 data:
   _exporter: aGVsbG8=
-  _operator: aGVsbG8=
   _replication: aGVsbG8=
 `, nodeName, nodeName)
 >>>>>>> 477206a (fix valkeynode e2e tests not creating system users secret)


### PR DESCRIPTION
This PR closes #236 

### Summary

Add a dedicated Valkey user for replication. 

### Features / Behaviour Changes

- Add the system user `_replication`.
- Add `primaryauth`, `primaryuser` to Valkey's pod startup args

### Implementation

### Limitations


### Testing


### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
