### PR TITLE
Filter Secrets by managed-by label to reduce cache memory usage

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -186,8 +186,8 @@ func main() {
 	}
 
 	// Only cache Kubernetes resources managed by this operator to reduce memory
-	// usage in large clusters. Secrets are left unfiltered because the operator
-	// reads user-provided password Secrets that don't carry the managed-by label.
+	// usage in large clusters. User-provided Secrets (passwords, TLS certs) are
+	// fetched directly from the API server via APIReader.
 	managedBySelector := labels.SelectorFromSet(labels.Set{
 		"app.kubernetes.io/managed-by": "valkey-operator",
 	})
@@ -197,6 +197,7 @@ func main() {
 			&appsv1.StatefulSet{}:           {Label: managedBySelector},
 			&appsv1.Deployment{}:            {Label: managedBySelector},
 			&corev1.ConfigMap{}:             {Label: managedBySelector},
+			&corev1.Secret{}:                {Label: managedBySelector},
 			&corev1.PersistentVolumeClaim{}: {Label: managedBySelector},
 			&policyv1.PodDisruptionBudget{}: {Label: managedBySelector},
 			// Pod is not explicitly watched but is cached due to r.List calls

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ For the user-facing API see [valkeycluster.md](valkeycluster.md). For the Valkey
 `internal/controller/valkeycluster_controller.go` — owns top-level orchestration. Each reconcile loop:
 
 1. Upserts a headless Service and PodDisruptionBudget
-2. Reconciles ACL users (Secret with type `valkey.io/acl`)
+2. Reconciles ACL users (creates an internal Secret with type `valkey.io/acl`)
 3. Upserts a ConfigMap containing `valkey.conf` and health-check scripts. A SHA-256 of `valkey.conf` is propagated to each ValkeyNode spec to trigger rolling restarts when config changes
 4. Creates/updates ValkeyNode CRs — one per (shard, node-index) pair, named `<cluster>-<N>-<M>`. Updates are one-at-a-time, replicas-before-primary within each shard
 5. Connects to live pods via `internal/valkey.GetClusterState` (CLUSTER INFO / CLUSTER NODES) to build a `ClusterState`

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 )
 
@@ -79,49 +78,6 @@ func getDefaultSecretName(clusterName string) string {
 
 func getSystemPasswordSecretName(clusterName string) string {
 	return "internal-" + clusterName + "-system-passwords"
-}
-
-// When a Secret is updated, Watch() calls this function to discover
-// which object should be reconciled. Because multiple secrets can be
-// used by the same cluster, and a single secret used by multiple clusters,
-// we grab a list of all Valkey clusters, and iterate through the ACLs
-// looking for the modified secret. We return a list of clusters that
-// need to be reconciled.
-func (r *ValkeyClusterReconciler) findReferencedClusters(ctx context.Context, secret client.Object) []reconcile.Request {
-
-	log := logf.FromContext(ctx)
-	secretName := secret.GetName() // the Secret that was updated
-
-	log.V(1).Info("findReferencedClusters", "modified", secretName)
-
-	// List all ValkeyClusters
-	valkeyClusterList := &valkeyiov1alpha1.ValkeyClusterList{}
-	if err := r.List(ctx, valkeyClusterList,
-		client.InNamespace(secret.GetNamespace()),
-	); err != nil {
-		log.Error(err, "failed to list valkey clusters")
-		return []reconcile.Request{}
-	}
-
-	requests := []reconcile.Request{}
-
-	// Take our list of clusters, and iterate through them, matching against
-	// spec.Users[].PasswordSecret.Name. Return a list of clusters to be reconciled.
-	for _, cluster := range valkeyClusterList.Items {
-		for _, user := range cluster.Spec.Users {
-			if user.PasswordSecret.Name == secretName {
-				log.V(1).Info("adding cluster to reconcile", "name", cluster.Name)
-				requests = append(requests, reconcile.Request{
-					NamespacedName: types.NamespacedName{
-						Name:      cluster.Name,
-						Namespace: cluster.Namespace,
-					},
-				})
-			}
-		}
-	}
-
-	return requests
 }
 
 func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (string, error) {
@@ -178,7 +134,7 @@ func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster
 	for _, user := range cluster.Spec.Users {
 
 		// Get passwords from Secret
-		passwords, err := fetchUserPasswords(ctx, user, r.Client, cluster.Name, cluster.Namespace)
+		passwords, err := fetchUserPasswords(ctx, user, r.APIReader, cluster.Name, cluster.Namespace)
 		if err != nil {
 			return fmt.Errorf("user %s: %w", user.Name, err)
 		}
@@ -261,7 +217,7 @@ func buildUserAcl(user valkeyiov1alpha1.UserAclSpec, passwords []string) string 
 }
 
 // Fetches a Secret, and looks for referenced passwords
-func fetchUserPasswords(ctx context.Context, user valkeyiov1alpha1.UserAclSpec, apiClient client.Client, clusterName, clusterNamespace string) ([]string, error) {
+func fetchUserPasswords(ctx context.Context, user valkeyiov1alpha1.UserAclSpec, apiClient client.Reader, clusterName, clusterNamespace string) ([]string, error) {
 
 	log := logf.FromContext(ctx)
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -313,7 +313,7 @@ func valkeyNodeName(clusterName string, shardIndex int, nodeIndex int) string {
 }
 
 // getTLSConfig returns the TLS configuration for a ValkeyCluster.
-func getTLSConfig(ctx context.Context, c client.Client, secretName, serverName, namespace string) (*tls.Config, error) {
+func getTLSConfig(ctx context.Context, c client.Reader, secretName, serverName, namespace string) (*tls.Config, error) {
 	secret := &corev1.Secret{}
 	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: secretName}, secret)
 	if err != nil {

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -35,12 +35,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 	"valkey.io/valkey-operator/internal/valkey"
 )
@@ -52,7 +49,7 @@ const (
 	DefaultExporterImage  = "oliver006/redis_exporter:v1.80.0"
 	DefaultExporterPort   = 9121
 
-	// AclSecretType is used to filter ACL Secret watch events.
+	// AclSecretType is the Secret type used for operator-managed ACL Secrets.
 	AclSecretType = corev1.SecretType("valkey.io/acl")
 
 	// Error messages
@@ -62,8 +59,9 @@ const (
 // ValkeyClusterReconciler reconciles a ValkeyCluster object
 type ValkeyClusterReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=valkey.io,resources=valkeyclusters,verbs=get;list;watch;create;update;patch;delete
@@ -681,7 +679,7 @@ func (r *ValkeyClusterReconciler) getValkeyClusterState(ctx context.Context, clu
 	var tlsConfig *tls.Config
 	if cluster.Spec.TLS != nil && cluster.Spec.TLS.Certificate.SecretName != "" {
 		serverName := fmt.Sprintf("%s.%s.svc.cluster.local", headlessServiceName(cluster.Name), cluster.Namespace)
-		cfg, err := getTLSConfig(ctx, r.Client, cluster.Spec.TLS.Certificate.SecretName, serverName, cluster.Namespace)
+		cfg, err := getTLSConfig(ctx, r.APIReader, cluster.Spec.TLS.Certificate.SecretName, serverName, cluster.Namespace)
 		if err == nil {
 			tlsConfig = cfg
 		}
@@ -1335,6 +1333,7 @@ func shardIndexFromState(shard *valkey.ShardState, nodes *valkeyiov1alpha1.Valke
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ValkeyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.APIReader = mgr.GetAPIReader()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&valkeyiov1alpha1.ValkeyCluster{}).
 		Owns(&corev1.Service{}).
@@ -1342,14 +1341,6 @@ func (r *ValkeyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&valkeyiov1alpha1.ValkeyNode{}).
 		Owns(&corev1.Secret{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Watches(
-			&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(r.findReferencedClusters),
-			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				secret, ok := obj.(*corev1.Secret)
-				return ok && secret.Type == AclSecretType
-			})),
-		).
 		Named("valkeycluster").
 		Complete(r)
 }

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -80,9 +80,10 @@ var _ = Describe("ValkeyCluster Controller", func() {
 			By("Reconciling the created resource")
 			fakeRecorder := events.NewFakeRecorder(100)
 			controllerReconciler := &ValkeyClusterReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				Recorder: fakeRecorder,
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  fakeRecorder,
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -151,9 +152,10 @@ var _ = Describe("ValkeyCluster config hash propagation", func() {
 		}()
 
 		r := &ValkeyClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: events.NewFakeRecorder(100),
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  events.NewFakeRecorder(100),
 		}
 
 		By("reconciling to create the ConfigMap and ValkeyNodes")
@@ -258,9 +260,10 @@ var _ = Describe("ValkeyCluster config hash on first reconcile", func() {
 		}()
 
 		r := &ValkeyClusterReconciler{
-			Client:   staleConfigMapClient{Client: k8sClient},
-			Scheme:   k8sClient.Scheme(),
-			Recorder: events.NewFakeRecorder(100),
+			Client:    staleConfigMapClient{Client: k8sClient},
+			APIReader: staleConfigMapClient{Client: k8sClient},
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  events.NewFakeRecorder(100),
 		}
 
 		By("reconciling with a client that cannot yet see the freshly created ConfigMap")
@@ -334,9 +337,10 @@ var _ = Describe("pod scheduling issue handling", func() {
 
 		fakeRecorder := events.NewFakeRecorder(100)
 		reconciler := &ValkeyClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: fakeRecorder,
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  fakeRecorder,
 		}
 
 		result, handled, err := reconciler.handlePodSchedulingIssues(ctx, cluster)
@@ -376,9 +380,10 @@ var _ = Describe("pod scheduling issue handling", func() {
 		setCondition(cluster, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonPodUnschedulable, "Pod is unschedulable", metav1.ConditionTrue)
 
 		reconciler := &ValkeyClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: events.NewFakeRecorder(100),
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  events.NewFakeRecorder(100),
 		}
 
 		result, handled, err := reconciler.handlePodSchedulingIssues(ctx, cluster)
@@ -432,9 +437,10 @@ var _ = Describe("reconcileUsersAcl", func() {
 			defer func() { _ = k8sClient.Delete(ctx, cluster) }()
 
 			reconciler := &ValkeyClusterReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				Recorder: events.NewFakeRecorder(100),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  events.NewFakeRecorder(100),
 			}
 
 			err := reconciler.reconcileUsersAcl(ctx, cluster)
@@ -466,9 +472,10 @@ var _ = Describe("reconcileUsersAcl", func() {
 			defer func() { _ = k8sClient.Delete(ctx, cluster) }()
 
 			reconciler := &ValkeyClusterReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				Recorder: events.NewFakeRecorder(100),
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  events.NewFakeRecorder(100),
 			}
 
 			err := reconciler.reconcileUsersAcl(ctx, cluster)
@@ -508,9 +515,10 @@ var _ = Describe("updateStatus", func() {
 		// For updateStatus, we need a client to Get the current object.
 		// The envtest client is used here.
 		r = &ValkeyClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: events.NewFakeRecorder(100),
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  events.NewFakeRecorder(100),
 		}
 
 		// Create the cluster object in the fake client
@@ -599,9 +607,10 @@ var _ = Describe("EventRecorder", func() {
 		ctx = context.Background()
 		fakeRecorder = events.NewFakeRecorder(100)
 		r = &ValkeyClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: fakeRecorder,
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  fakeRecorder,
 		}
 	})
 
@@ -747,9 +756,10 @@ var _ = Describe("reconcileValkeyNodes", func() {
 		testCtx = context.Background()
 		fakeRecorder = events.NewFakeRecorder(100)
 		r = &ValkeyClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: fakeRecorder,
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  fakeRecorder,
 		}
 		cluster = &valkeyiov1alpha1.ValkeyCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -981,9 +991,10 @@ var _ = Describe("reconcileValkeyNode", func() {
 		testCtx = context.Background()
 		fakeRecorder = events.NewFakeRecorder(100)
 		r = &ValkeyClusterReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: fakeRecorder,
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  fakeRecorder,
 		}
 		cluster = &valkeyiov1alpha1.ValkeyCluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -552,7 +552,7 @@ func (r *ValkeyNodeReconciler) buildNodeClientOption(ctx context.Context, node *
 		if clusterName, ok := node.Labels[LabelCluster]; ok {
 			serverName = fmt.Sprintf("%s.%s.svc.cluster.local", headlessServiceName(clusterName), node.Namespace)
 		}
-		if cfg, err := getTLSConfig(ctx, r.Client, secretName, serverName, node.Namespace); err == nil {
+		if cfg, err := getTLSConfig(ctx, r.APIReader, secretName, serverName, node.Namespace); err == nil {
 			tlsConfig = cfg
 		}
 	}

--- a/test/e2e/valkeynode_test.go
+++ b/test/e2e/valkeynode_test.go
@@ -51,6 +51,8 @@ kind: Secret
 type: valkey.io/acl
 metadata:
   name: internal-%s-acl
+  labels:
+    app.kubernetes.io/managed-by: valkey-operator
 `, name)
 		cmd := exec.Command("kubectl", "apply", "-f", "-")
 		cmd.Stdin = strings.NewReader(secretManifest)
@@ -302,6 +304,8 @@ kind: Secret
 type: valkey.io/acl
 metadata:
   name: internal-%s-acl
+  labels:
+    app.kubernetes.io/managed-by: valkey-operator
 `, nodeName)
 
 			cmd = exec.Command("kubectl", "apply", "-f", "-")


### PR DESCRIPTION
This PR closes #187

### Summary

Only cache operator-owned Secrets (those with the`app.kubernetes.io/managed-by=valkey-operator` label).
User-provided Secrets (passwords, TLS certificates) are now read directly from the API server via `APIReader`.

Remove the `Watches()` for user-provided Secrets. The watch predicate filtered on `type=valkey.io/acl` which only matched operator-created Secrets (already covered by `Owns()`), so it had no effect on user-provided Secrets.

Widen `getTLSConfig` and `fetchUserPasswords` to accept `client.Reader` so they can be called with `APIReader` instead of the cached client.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
