### PR TITLE
test: add e2e test for operator permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,12 +185,30 @@ valkey-operator/
 # Run unit tests
 make test
 
-# Run E2E tests (requires cluster)
-make test-e2e
-
 # Run specific tests
 go test ./internal/controller/... -v
 ```
+
+### E2E
+End-to-end tests are executed against pull requests and are required to pass in order for the PR to be mergeable.
+
+To run end-to-end tests locally, you can execute the below command.
+```bash
+# Run E2E tests (requires cluster)
+make test-e2e
+```
+
+To run specific e2e tests locally use the `Focus` decorator of the GinkGo library (see [docs](https://onsi.github.io/ginkgo/#focused-specs)). <br/>
+Select a test case e.g.
+```go
+It("creates a cluster with custom users", func() {...}
+```
+Add the `Focus` decorator
+```go
+It("creates a cluster with custom users", Focus, func() {...}
+```
+Run `make test-e2e`. It'll just run the selected test case.
+
 
 ## Making Changes to the API
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ To run end-to-end tests locally, you can execute the below command.
 make test-e2e
 ```
 
-To run specific e2e tests locally use the `Focus` decorator of the GinkGo library (see [docs](https://onsi.github.io/ginkgo/#focused-specs)). <br/>
+To run specific e2e tests locally use the `Focus` decorator of the Ginkgo library (see [docs](https://onsi.github.io/ginkgo/#focused-specs)). <br/>
 Select a test case e.g.
 ```go
 It("creates a cluster with custom users", func() {...}

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -486,10 +486,14 @@ spec:
 			}
 			Eventually(verifyReady).Should(Succeed())
 
-			By("validating internal secret was created")
+			By("validating internal secrets were created")
 			verifyInternalSecretExists := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "secrets", "internal-"+withUserClusterName+"-acl")
 				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "get", "secrets", "internal-"+withUserClusterName+"-system-passwords")
+				_, err = utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 			}
 			Eventually(verifyInternalSecretExists).Should(Succeed())

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package e2e
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -539,6 +540,121 @@ spec:
 				))
 			}
 			Eventually(verifyCreatedUsers).Should(Succeed())
+
+			By("verifying allowed commands succeed for operator user")
+			verifyAllowedPermissionsOfOperatorUser := func(g Gomega) {
+				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", withUserClusterName)
+
+				cmd = exec.Command("kubectl", "get", "secrets", "internal-"+withUserClusterName+"-system-passwords",
+					"-o", "jsonpath={.data._operator}",
+				)
+
+				b64Password, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				decoded, err := base64.StdEncoding.DecodeString(b64Password)
+				g.Expect(err).NotTo(HaveOccurred())
+				operatorPassword := string(decoded)
+
+				_ = exec.Command("kubectl", "delete", "pod", "client",
+					"--ignore-not-found=true", "--wait=true", "--timeout=30s").Run()
+
+				// Only commands without arguments will be tested
+				cmd = exec.Command("kubectl", "run", "client",
+					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never",
+					"--", "sh", "-c",
+					fmt.Sprintf(
+						`valkey-cli -c -h "%s" --user _operator --pass "%s" <<EOF
+PING
+CLUSTER INFO
+CLUSTER MYID
+CLUSTER MYSHARDID
+CLUSTER NODES
+CLUSTER FAILOVER
+INFO
+ROLE 
+EOF`,
+						clusterFqdn,
+						operatorPassword,
+					),
+				)
+
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "wait", "pod/client",
+					"--for=jsonpath={.status.phase}=Succeeded", "--timeout=30s")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "logs", "client")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "delete", "pod", "client",
+					"--wait=true", "--timeout=30s")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				g.Expect(output).NotTo(ContainSubstring("NOPERM"))
+			}
+			Eventually(verifyAllowedPermissionsOfOperatorUser).Should(Succeed())
+
+			By("verifying denied commands fail for operator user")
+			verifyDeniedPermissionsOfOperatorUser := func(g Gomega) {
+				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", withUserClusterName)
+
+				cmd = exec.Command("kubectl", "get", "secrets", "internal-"+withUserClusterName+"-system-passwords",
+					"-o", "jsonpath={.data._operator}",
+				)
+
+				b64Password, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				decoded, err := base64.StdEncoding.DecodeString(b64Password)
+				g.Expect(err).NotTo(HaveOccurred())
+				operatorPassword := string(decoded)
+
+				disallowedCommands := []string{
+					"SET foo bar",
+					"GET foo",
+					"DEL foo",
+					"KEYS *",
+					"CONFIG GET *",
+					"ACL LIST",
+				}
+
+				_ = exec.Command("kubectl", "delete", "pod", "client",
+					"--ignore-not-found=true", "--wait=true", "--timeout=30s").Run()
+
+				cmd = exec.Command("kubectl", "run", "client",
+					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never",
+					"--", "sh", "-c",
+					fmt.Sprintf(
+						`valkey-cli -c -h "%s" --user _operator --pass "%s" <<EOF
+%s
+EOF`,
+						clusterFqdn, operatorPassword, strings.Join(disallowedCommands, "\n"),
+					))
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "wait", "pod/client",
+					"--for=jsonpath={.status.phase}=Succeeded", "--timeout=30s")
+				_, err = utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cmd = exec.Command("kubectl", "logs", "client")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_ = exec.Command("kubectl", "delete", "pod", "client",
+					"--ignore-not-found=true", "--wait=true", "--timeout=30s").Run()
+
+				g.Expect(strings.Count(output, "NOPERM")).To(Equal(len(disallowedCommands)),
+					"expected all %d disallowed commands to be denied but got: %s",
+					len(disallowedCommands), output)
+			}
+			Eventually(verifyDeniedPermissionsOfOperatorUser).Should(Succeed())
+
 		})
 
 		It("rebalances slots on scale out", func() {


### PR DESCRIPTION
This PR closes #144 

### Summary

The `_operator` user needs specific permissions to operate. The PR #136 tightened the permissions. This PR includes 2 tests which test the permissions of the `_operator` user to ensure that the permissions don't get broken by future changes.

### Features / Behaviour Changes

- Add a test case for permissions which should be allowed.
- Add a test case for permissions which shouldn't be allowed
- Update the e2e test `validating internal secrets were created` to check the secret of the system-passwords got recreated as well. This prevents a race condition because the e2e test will retry until the secret got recreated
- Update the CONTRIBUTING documentation to run specific e2e tests

### Implementation

#### verifying allowed commands succeed for operator user
The test will check the log for the string NOPERM. No executed command should result a NOPERM response.

```go
cmd = exec.Command("kubectl", "run", "client",
					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never",
					"--", "sh", "-c",
					fmt.Sprintf(
						`valkey-cli -c -h "%s" --user _operator --pass "%s" <<EOF
PING
CLUSTER INFO
CLUSTER MYID
INFO
EOF`,
						clusterFqdn,
						operatorPassword,
					),
				)
```
```go
g.Expect(output).NotTo(ContainSubstring("NOPERM"))
```

#### verifying denied commands fail for operator user

This test checks that every command result in a NOPERM response.
```go
disallowedCommands := []string{
					"SET foo bar",
					"GET foo",
					"DEL foo",
					"KEYS *",
					"CONFIG GET *"
					"CONFIG SET hz 15",
					"ACL LIST",
				}

				for _, command := range disallowedCommands {
					By(fmt.Sprintf("verifying operator user cannot run: %s", command))

					_ = exec.Command("kubectl", "delete", "pod", "client",
						"--ignore-not-found=true", "--wait=true", "--timeout=30s").Run()

					cmd = exec.Command("kubectl", "run", "client",
						fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never",
						"--", "sh", "-c",
						fmt.Sprintf(
							`valkey-cli -c -h "%s" --user _operator --pass "%s" %s`,
							clusterFqdn, operatorPassword, command,
						),
					)
					_, err = utils.Run(cmd)
					Expect(err).NotTo(HaveOccurred())

					cmd = exec.Command("kubectl", "wait", "pod/client",
						"--for=jsonpath={.status.phase}=Succeeded", "--timeout=30s")
					_, err = utils.Run(cmd)
					Expect(err).NotTo(HaveOccurred())

					cmd = exec.Command("kubectl", "logs", "client")
					output, err := utils.Run(cmd)
					Expect(err).NotTo(HaveOccurred())

					_ = exec.Command("kubectl", "delete", "pod", "client",
						"--ignore-not-found=true", "--wait=true", "--timeout=30s").Run()

					Expect(output).To(ContainSubstring("NOPERM"),
						"expected command %q to be denied but got: %s", command, output)
				}
```

Happy to discuss!

Cheers,
Tim

### Checklist

Before submitting the PR make sure the following are checked:

- [X] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [X] Tests are added or updated.
- [X] Documentation files are updated.
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
