### PR TITLE
feat: fail over to the highest-offset replica

### DIFF
--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -60,21 +60,6 @@ func findFailoverShard(state *valkey.ClusterState, address string) (*valkey.Shar
 	return shard, replicas
 }
 
-// highestOffsetReplica returns the synced replica with the greatest replication
-// offset, the one most caught up with the primary. Replicas whose offset is
-// unavailable sort last and ties keep discovery order, so the result is stable
-// and never nil for a non-empty slice.
-func highestOffsetReplica(replicas []*valkey.NodeState) *valkey.NodeState {
-	best := replicas[0]
-	bestOffset := best.ReplicationOffset()
-	for _, replica := range replicas[1:] {
-		if offset := replica.ReplicationOffset(); offset > bestOffset {
-			best, bestOffset = replica, offset
-		}
-	}
-	return best
-}
-
 // proactiveFailover issues CLUSTER FAILOVER to the best synced replica in shard,
 // then polls until the replica reports role:master or the timeout is reached.
 // shard must be non-nil; replicas must be non-empty.
@@ -86,7 +71,7 @@ func proactiveFailover(ctx context.Context, recorder events.EventRecorder, clust
 	// graceful CLUSTER FAILOVER holds writes on the primary until the target
 	// replica catches up, so promoting the furthest-ahead one minimises that
 	// write pause and the exposure if the primary dies mid-failover.
-	target := highestOffsetReplica(replicas)
+	target := valkey.HighestOffsetReplica(replicas)
 	log.Info("initiating proactive failover", "shard", shard.Id, "target", target.Address)
 
 	// Emit FailoverInitiated before the command so observers see the event at

--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -60,6 +60,21 @@ func findFailoverShard(state *valkey.ClusterState, address string) (*valkey.Shar
 	return shard, replicas
 }
 
+// highestOffsetReplica returns the synced replica with the greatest replication
+// offset, the one most caught up with the primary. Replicas whose offset is
+// unavailable sort last and ties keep discovery order, so the result is stable
+// and never nil for a non-empty slice.
+func highestOffsetReplica(replicas []*valkey.NodeState) *valkey.NodeState {
+	best := replicas[0]
+	bestOffset := best.ReplicationOffset()
+	for _, replica := range replicas[1:] {
+		if offset := replica.ReplicationOffset(); offset > bestOffset {
+			best, bestOffset = replica, offset
+		}
+	}
+	return best
+}
+
 // proactiveFailover issues CLUSTER FAILOVER to the best synced replica in shard,
 // then polls until the replica reports role:master or the timeout is reached.
 // shard must be non-nil; replicas must be non-empty.
@@ -67,9 +82,11 @@ func proactiveFailover(ctx context.Context, recorder events.EventRecorder, clust
 	log := logf.FromContext(ctx)
 	primaryAddress := shard.GetPrimaryNode().Address
 
-	// Pick the first synced replica as the failover target. The ordering is
-	// determined by node discovery order — no priority scheme is applied yet.
-	target := replicas[0]
+	// Fail over to the most caught-up replica (highest replication offset). A
+	// graceful CLUSTER FAILOVER holds writes on the primary until the target
+	// replica catches up, so promoting the furthest-ahead one minimises that
+	// write pause and the exposure if the primary dies mid-failover.
+	target := highestOffsetReplica(replicas)
 	log.Info("initiating proactive failover", "shard", shard.Id, "target", target.Address)
 
 	// Emit FailoverInitiated before the command so observers see the event at

--- a/internal/controller/failover_test.go
+++ b/internal/controller/failover_test.go
@@ -230,4 +230,9 @@ func TestHighestOffsetReplica(t *testing.T) {
 		replicas := []*valkey.NodeState{replica("only", "42")}
 		assert.Equal(t, "only", highestOffsetReplica(replicas).Address)
 	})
+
+	t.Run("all replicas without an offset keep discovery order", func(t *testing.T) {
+		replicas := []*valkey.NodeState{replica("a", ""), replica("b", "")}
+		assert.Equal(t, "a", highestOffsetReplica(replicas).Address)
+	})
 }

--- a/internal/controller/failover_test.go
+++ b/internal/controller/failover_test.go
@@ -201,3 +201,33 @@ func TestAnyNodeRequiresRoll(t *testing.T) {
 		assert.True(t, anyNodeRequiresRoll(cluster, nodes, configHash))
 	})
 }
+
+func TestHighestOffsetReplica(t *testing.T) {
+	replica := func(addr, offset string) *valkey.NodeState {
+		info := map[string]string{}
+		if offset != "" {
+			info["slave_repl_offset"] = offset
+		}
+		return &valkey.NodeState{Address: addr, Info: info}
+	}
+
+	t.Run("picks the replica with the greatest offset", func(t *testing.T) {
+		replicas := []*valkey.NodeState{replica("a", "100"), replica("b", "300"), replica("c", "200")}
+		assert.Equal(t, "b", highestOffsetReplica(replicas).Address)
+	})
+
+	t.Run("a replica with no offset sorts last", func(t *testing.T) {
+		replicas := []*valkey.NodeState{replica("a", ""), replica("b", "5")}
+		assert.Equal(t, "b", highestOffsetReplica(replicas).Address)
+	})
+
+	t.Run("ties keep discovery order", func(t *testing.T) {
+		replicas := []*valkey.NodeState{replica("a", "10"), replica("b", "10")}
+		assert.Equal(t, "a", highestOffsetReplica(replicas).Address)
+	})
+
+	t.Run("a single replica is returned", func(t *testing.T) {
+		replicas := []*valkey.NodeState{replica("only", "42")}
+		assert.Equal(t, "only", highestOffsetReplica(replicas).Address)
+	})
+}

--- a/internal/controller/failover_test.go
+++ b/internal/controller/failover_test.go
@@ -201,38 +201,3 @@ func TestAnyNodeRequiresRoll(t *testing.T) {
 		assert.True(t, anyNodeRequiresRoll(cluster, nodes, configHash))
 	})
 }
-
-func TestHighestOffsetReplica(t *testing.T) {
-	replica := func(addr, offset string) *valkey.NodeState {
-		info := map[string]string{}
-		if offset != "" {
-			info["slave_repl_offset"] = offset
-		}
-		return &valkey.NodeState{Address: addr, Info: info}
-	}
-
-	t.Run("picks the replica with the greatest offset", func(t *testing.T) {
-		replicas := []*valkey.NodeState{replica("a", "100"), replica("b", "300"), replica("c", "200")}
-		assert.Equal(t, "b", highestOffsetReplica(replicas).Address)
-	})
-
-	t.Run("a replica with no offset sorts last", func(t *testing.T) {
-		replicas := []*valkey.NodeState{replica("a", ""), replica("b", "5")}
-		assert.Equal(t, "b", highestOffsetReplica(replicas).Address)
-	})
-
-	t.Run("ties keep discovery order", func(t *testing.T) {
-		replicas := []*valkey.NodeState{replica("a", "10"), replica("b", "10")}
-		assert.Equal(t, "a", highestOffsetReplica(replicas).Address)
-	})
-
-	t.Run("a single replica is returned", func(t *testing.T) {
-		replicas := []*valkey.NodeState{replica("only", "42")}
-		assert.Equal(t, "only", highestOffsetReplica(replicas).Address)
-	})
-
-	t.Run("all replicas without an offset keep discovery order", func(t *testing.T) {
-		replicas := []*valkey.NodeState{replica("a", ""), replica("b", "")}
-		assert.Equal(t, "a", highestOffsetReplica(replicas).Address)
-	})
-}

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -41,6 +41,21 @@ type NodeState struct {
 	ClusterNodes string
 }
 
+// ReplicationOffset returns this node's processed replication offset from
+// INFO replication (slave_repl_offset), or -1 when it is unavailable. A higher
+// value means the replica is more caught up with its primary.
+func (n *NodeState) ReplicationOffset() int64 {
+	v, ok := n.Info["slave_repl_offset"]
+	if !ok {
+		return -1
+	}
+	offset, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return offset
+}
+
 // ShardState represents the current state of a shard.
 type ShardState struct {
 	Id        string

--- a/internal/valkey/clusterstate.go
+++ b/internal/valkey/clusterstate.go
@@ -56,6 +56,20 @@ func (n *NodeState) ReplicationOffset() int64 {
 	return offset
 }
 
+// HighestOffsetReplica returns the replica with the greatest replication offset,
+// the one most caught up with its primary. Replicas whose offset is unavailable
+// sort last and ties keep slice order. Returns nil for an empty slice.
+func HighestOffsetReplica(replicas []*NodeState) *NodeState {
+	var best *NodeState
+	var bestOffset int64
+	for _, replica := range replicas {
+		if offset := replica.ReplicationOffset(); best == nil || offset > bestOffset {
+			best, bestOffset = replica, offset
+		}
+	}
+	return best
+}
+
 // ShardState represents the current state of a shard.
 type ShardState struct {
 	Id        string
@@ -334,21 +348,15 @@ func (s *ClusterState) IsNodeFailed(nodeId string) bool {
 // BestReplicaOf returns the replica with the highest replication offset
 // that references the given primary ID, or nil if none found.
 func (s *ClusterState) BestReplicaOf(primaryId string) *NodeState {
-	var best *NodeState
-	var bestOffset int64
+	var replicas []*NodeState
 	for _, shard := range s.Shards {
 		for _, node := range shard.Nodes {
-			if node.PrimaryIdFromSelf() != primaryId {
-				continue
-			}
-			offset, _ := strconv.ParseInt(node.Info["slave_repl_offset"], 10, 64)
-			if best == nil || offset > bestOffset {
-				best = node
-				bestOffset = offset
+			if node.PrimaryIdFromSelf() == primaryId {
+				replicas = append(replicas, node)
 			}
 		}
 	}
-	return best
+	return HighestOffsetReplica(replicas)
 }
 
 // PrimaryIdFromSelf returns the primary node ID that this node reports as its

--- a/internal/valkey/clusterstate_test.go
+++ b/internal/valkey/clusterstate_test.go
@@ -460,3 +460,47 @@ func TestClusterState_BestReplicaOf(t *testing.T) {
 		}
 	})
 }
+
+func TestHighestOffsetReplica(t *testing.T) {
+	replica := func(id, offset string) *NodeState {
+		info := map[string]string{}
+		if offset != "" {
+			info["slave_repl_offset"] = offset
+		}
+		return &NodeState{Id: id, Info: info}
+	}
+
+	t.Run("nil for no replicas", func(t *testing.T) {
+		if got := HighestOffsetReplica(nil); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("picks the greatest offset", func(t *testing.T) {
+		got := HighestOffsetReplica([]*NodeState{replica("a", "100"), replica("b", "300"), replica("c", "200")})
+		if got == nil || got.Id != "b" {
+			t.Errorf("expected b, got %v", got)
+		}
+	})
+
+	t.Run("a replica with no offset sorts last", func(t *testing.T) {
+		got := HighestOffsetReplica([]*NodeState{replica("a", ""), replica("b", "5")})
+		if got == nil || got.Id != "b" {
+			t.Errorf("expected b, got %v", got)
+		}
+	})
+
+	t.Run("ties keep slice order", func(t *testing.T) {
+		got := HighestOffsetReplica([]*NodeState{replica("a", "10"), replica("b", "10")})
+		if got == nil || got.Id != "a" {
+			t.Errorf("expected a, got %v", got)
+		}
+	})
+
+	t.Run("all without an offset keep slice order", func(t *testing.T) {
+		got := HighestOffsetReplica([]*NodeState{replica("a", ""), replica("b", "")})
+		if got == nil || got.Id != "a" {
+			t.Errorf("expected a, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
### Summary

When the operator proactively fails a primary over before rolling it, it currently promotes the first synced replica in discovery order, which can be the one furthest behind.

A graceful `CLUSTER FAILOVER` holds writes on the primary until the target replica catches up, so promoting the most caught-up replica shortens that write pause and narrows the exposure if the primary dies mid-failover. This is improvement #1 from the discussion in #231.

### Features / Behaviour Changes

- Proactive failover picks the synced replica with the highest replication offset instead of the first one in discovery order.

### Implementation

- `(*NodeState).ReplicationOffset()` reads `slave_repl_offset` from the node's `INFO replication`, which `getNodeState` already collects into `node.Info`, so there are no extra queries.
- `highestOffsetReplica` chooses the furthest-ahead replica. Replicas with no available offset sort last and ties keep discovery order, so the result is stable and never nil for a non-empty input.

### Limitations

- It does not yet assert that the chosen replica is on the latest ValkeyNode spec (improvement #2 in #231). The sequential roll already promotes replicas before the primary, so in practice the target is on the new spec, but an explicit check would turn that ordering invariant into a hard guarantee. Happy to follow up with it.

### Testing

- Unit tests for `highestOffsetReplica`: greatest offset wins, a missing offset sorts last, ties keep discovery order, single replica.
- `make test` and `make lint` pass locally.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (ran `make test` and `make lint` instead)
