### PR TITLE
fix: surface ValkeyNode reconcile errors in status conditions

### DIFF
--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -122,13 +122,23 @@ func (r *ValkeyNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 	if err := r.ensureConfigMap(ctx, node); err != nil {
+		r.setReadyCondition(ctx, node, "ConfigMapError", err.Error())
 		return ctrl.Result{}, err
 	}
 	if err := r.ensurePersistentVolumeClaim(ctx, node); err != nil {
+		r.setReadyCondition(ctx, node, "PersistentVolumeClaimError", err.Error())
 		return ctrl.Result{}, err
 	}
 
 	if err := r.ensureWorkload(ctx, node); err != nil {
+		workloadReason := "WorkloadError"
+		switch node.Spec.WorkloadType {
+		case valkeyiov1alpha1.WorkloadTypeStatefulSet:
+			workloadReason = "StatefulSetError"
+		case valkeyiov1alpha1.WorkloadTypeDeployment:
+			workloadReason = "DeploymentError"
+		}
+		r.setReadyCondition(ctx, node, workloadReason, err.Error())
 		return ctrl.Result{}, err
 	}
 
@@ -210,6 +220,32 @@ func (r *ValkeyNodeReconciler) clearLiveConfigCondition(ctx context.Context, nod
 		return fmt.Errorf("patch LiveConfigApplied condition: %w", err)
 	}
 	return nil
+}
+
+// setReadyCondition sets the Ready condition to False on the ValkeyNode status
+// so that errors from early reconcile stages (ConfigMap, PVC, workload creation)
+// are visible on the resource.
+func (r *ValkeyNodeReconciler) setReadyCondition(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode, reason, message string) {
+	log := logf.FromContext(ctx)
+	current := &valkeyiov1alpha1.ValkeyNode{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(node), current); err != nil {
+		log.Error(err, "failed to get ValkeyNode for status update")
+		return
+	}
+	patchBase := current.DeepCopy()
+	if !meta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+		Type:               valkeyiov1alpha1.ValkeyNodeConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: current.Generation,
+	}) {
+		return
+	}
+	current.Status.Ready = false
+	if err := r.Status().Patch(ctx, current, client.MergeFrom(patchBase)); err != nil {
+		log.Error(err, "failed to patch ValkeyNode Ready condition")
+	}
 }
 
 func (r *ValkeyNodeReconciler) ensureWorkload(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode) error {


### PR DESCRIPTION
## Summary

When `ensureConfigMap`, `ensurePersistentVolumeClaim`, or `ensureWorkload` fails during ValkeyNode reconciliation, the controller returns the error to controller-runtime without updating the ValkeyNode status. This leaves the resource with no visible indication of why it is stuck other than the operator logs.

Found during testing where a PVC quota exceeded error left a ValkeyNode with a completely empty status section.

## Implementation
Add a `setReadyCondition` helper that patches the ValkeyNode Ready condition to False with the error reason before returning. Reasons are specific to the failing stage: `ConfigMapError`, `PersistentVolumeClaimError`, `StatefulSetError`, or `DeploymentError`. The condition is self-clearing: once the error resolves, the existing `updateStatus` path overwrites it with the healthy state.

## Limitations
Does not cover the `reconcilePersistenceFinalizer` early-return path, ok to me for now.

## Testing
Unit tests pass. Verified manually by triggering a PVC quota error on an ENG cluster:
```
 ༼ つ ▀_▀ ༽つ  ~  src  valkey-ope  kubectl describe valkeynode eng-test-3-0 -n valkey-operator | tail -15
  Tolerations:
    Effect:               NoSchedule
    Key:                  dedicated
    Value:                openebs
  Users ACL Secret Name:  internal-eng-test-acl
  Workload Type:          StatefulSet
Status:
  Conditions:
    Last Transition Time:  2026-06-17T13:21:49Z
    Message:               persistentvolumeclaims "valkey-eng-test-3-0-data" is forbidden: exceeded quota: fuze-quota, requested: persistentvolumeclaims=1, used: persistentvolumeclaims=12, limited: persistentvolumeclaims=12
    Observed Generation:   1
    Reason:                PersistentVolumeClaimError
    Status:                False
    Type:                  Ready
```