### PR TITLE
fix: scale-down blocked when excess shard pod is unschedulable

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -176,14 +176,6 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
-	if result, handled, err := r.handlePodSchedulingIssues(ctx, cluster); err != nil {
-		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeError, err.Error(), metav1.ConditionFalse)
-		_ = r.updateStatus(ctx, cluster, nil)
-		return ctrl.Result{}, err
-	} else if handled {
-		return result, nil
-	}
-
 	operatorPassword, err := fetchSystemUserPassword(ctx, operatorUser, r.Client, cluster.Name, cluster.Namespace)
 	if err != nil {
 		log.Error(err, "failed to retrieve system user password")
@@ -277,7 +269,17 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	allShards := effectiveShards(state, nodes)
 
 	// Handle scale-in: drain excess shards and clean up leftover ValkeyNodes.
+	// This runs before pod scheduling checks so that excess shard pods from a
+	// prior scale-up don't block scale-down when they can't be scheduled.
 	if result, requeue := r.handleScaleIn(ctx, cluster, state, nodes); requeue {
+		return result, nil
+	}
+
+	if result, handled, err := r.handlePodSchedulingIssues(ctx, cluster); err != nil {
+		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonValkeyNodeError, err.Error(), metav1.ConditionFalse)
+		_ = r.updateStatus(ctx, cluster, state)
+		return ctrl.Result{}, err
+	} else if handled {
 		return result, nil
 	}
 


### PR DESCRIPTION
## Summary

When scaling from 4 shards back to 3, if a shard 4 pod could not be scheduled (e.g. insufficient CPU resourcequota), `handlePodSchedulingIssues` detected the unschedulable pod and returned early before `handleScaleIn` could clean up the excess shard. This left the cluster stuck in `Reconciling` indefinitely with no way to complete the scale-down without manual deletion of the ValkeyNodes.

The root cause is that `findPodSchedulingIssue` lists all pods matching the cluster label, including pods from excess shards that are pending removal. When it finds an unschedulable pod, it returns `handled=true`, which causes the reconciler to exit before reaching the scale-in logic.

## Implementation

Move `handlePodSchedulingIssues` after `handleScaleIn` in the reconcile pipeline. This lets scale-in clean up excess shard resources first, then checks for scheduling issues on the remaining (desired) pods.

Options considered:

||Option||Tradeoff||
|Move `handleScaleIn` before state fetch|Scale-in needs cluster topology state which is fetched after the scheduling check. Would require restructuring state fetching.|
|Filter excess shard pods in `findPodSchedulingIssue`|Complex label parsing. Hard to distinguish "excess shard being removed" from "new shard being added" where scheduling issues are real.|
|Move `handlePodSchedulingIssues` after `handleScaleIn` (chosen)|Brief delay surfacing scheduling issues for desired shards. During normal operation (no scale-in), flow is identical.|
|Make `handlePodSchedulingIssues` advisory-only|Downstream steps (MEET, slot assignment) could target unreachable pods.|

## Limitations

During a scale-in where desired shard pods also have scheduling issues, those issues are surfaced one reconcile pass later than before. This is negligible since scale-in generlaly completes in the same pass.

## Testing
Unit tests pass. Found during ENG testing where a 4-shard cluster was scaled back to 3 shards while one shard 4 pod was stuck in Pending due to insufficient CPU available on a node.

I tested the same scenario with my fix in place and it comes back healthy.