### PR TITLE
feat: inject shutdown-on-sigterm failover by default

### DIFF
--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -120,6 +120,12 @@ The operator creates a `PodDisruptionBudget` with `maxUnavailable: 1` selecting 
 | `Managed` | Operator creates and owns the PDB |
 | `Disabled` | Operator deletes the PDB if it exists and does not recreate it |
 
+### Graceful shutdown
+
+On `SIGTERM` (a node drain, eviction, or preemption), a cluster primary fails its slots over to a replica before exiting, so descheduling a primary the operator did not initiate does not leave the shard without a writer. This is enabled by default through the `shutdown-on-sigterm failover` server config and requires Valkey 9.0+.
+
+The handoff runs inside the pod's termination grace period, so set `terminationGracePeriodSeconds` at least as high as `cluster-manual-failover-timeout`; otherwise `SIGKILL` can cut the failover short.
+
 ### Private image registries
 
 ```yaml

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -124,7 +124,7 @@ The operator creates a `PodDisruptionBudget` with `maxUnavailable: 1` selecting 
 
 On `SIGTERM` (a node drain, eviction, or preemption), a cluster primary fails its slots over to a replica before exiting, so descheduling a primary the operator did not initiate does not leave the shard without a writer. This is enabled by default through the `shutdown-on-sigterm failover` server config and requires Valkey 9.0+.
 
-The handoff runs inside the pod's termination grace period, so set `terminationGracePeriodSeconds` at least as high as `cluster-manual-failover-timeout`; otherwise `SIGKILL` can cut the failover short.
+The handoff runs inside the pod's termination grace period. With defaults there is comfortable margin: the Kubernetes default `terminationGracePeriodSeconds` is 30s and the Valkey default `cluster-manual-failover-timeout` is 5s, so the failover completes well before `SIGKILL`. If you raise `cluster-manual-failover-timeout`, raise `terminationGracePeriodSeconds` to keep it above the timeout, otherwise `SIGKILL` can cut the failover short.
 
 ### Private image registries
 

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -112,6 +112,11 @@ func getBaseConfig(cluster *valkeyiov1alpha1.ValkeyCluster) map[string]string {
 		"cluster-node-timeout":            "2000",
 		"cluster-allow-replica-migration": "no",
 		"cluster-replica-validity-factor": "0",
+		// On SIGTERM (graceful pod shutdown from a node drain, eviction, or
+		// preemption), a cluster primary hands its slots off to a replica as
+		// part of shutdown. This covers out-of-band descheduling that the
+		// operator's own rolling failover never observes. Requires Valkey 9.0+.
+		"shutdown-on-sigterm": "failover",
 	})
 
 	return baseConfig

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -46,6 +46,9 @@ var _ = Describe("When creating a cluster", Label("userconfig"), func() {
 
 		// Base, non-overridable parameter
 		Expect(testConfigString).To(ContainSubstring("cluster-enabled"))
+
+		// Primary fails over to a replica on SIGTERM (graceful shutdown)
+		Expect(testConfigString).To(ContainSubstring("shutdown-on-sigterm failover"))
 	})
 })
 


### PR DESCRIPTION
Closes #248

### Summary

Inject `shutdown-on-sigterm failover` into the managed Valkey config by default for every ValkeyCluster. On SIGTERM (node drain, eviction, preemption, or `kubectl delete pod`), a primary fails its slots over to a replica during graceful shutdown, which covers the unplanned termination that the operator's own proactive failover never sees.

### Implementation

- Added the directive to `getBaseConfig`, alongside the other operator-managed defaults.
- It is a Valkey 9.0+ directive, which matches the operator's documented baseline, so it renders unconditionally with no version gate.
- No double-failover risk: it only fires if the node is still primary at SIGTERM, and it is a no-op on replicas.

### Acceptance criteria

- [x] `shutdown-on-sigterm failover` injected into valkey.conf by default
- [x] Works alongside the operator's proactive failover without double-firing (no-op on replicas)
- [ ] E2E test (drain the primary's node, verify a replica is promoted before the pod exits)

I left the E2E test out for now since it needs node-drain orchestration in the e2e harness. Happy to add it here or as a follow-up, whichever you prefer. The unit test asserts the directive is rendered.

The `terminationGracePeriodSeconds` constraint is tracked separately in #260; the docs note the relationship.

### Testing

- Unit test asserts `shutdown-on-sigterm failover` is in the rendered config.
- `make test` and `make lint` pass locally.

### References

- Discussion #231 (shutdown-on-sigterm section)
- #120 (out-of-band termination discussion)
- valkey/valkey#1091

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [ ] I have run pre-commit locally (ran `make test` and `make lint` instead)
