### PR TITLE
feat: configurable terminationGracePeriodSeconds for graceful failover

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -147,6 +147,7 @@ type ValkeyClusterSpec struct {
 	// replica before SIGKILL. When unset, the operator derives a safe default
 	// from cluster-manual-failover-timeout. A value below that derived minimum
 	// is honoured but reported as a warning.
+	// +kubebuilder:validation:Minimum=1
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 
@@ -245,6 +246,10 @@ const (
 	ConditionDegraded      = "Degraded"
 	ConditionClusterFormed = "ClusterFormed"
 	ConditionSlotsAssigned = "SlotsAssigned"
+	// ConditionConfigurationWarning flags a spec value the operator accepted but
+	// considers risky, for example a terminationGracePeriodSeconds too short for
+	// graceful failover.
+	ConditionConfigurationWarning = "ConfigurationWarning"
 )
 
 const (
@@ -264,6 +269,8 @@ const (
 	ReasonTopologyComplete         = "TopologyComplete"
 	ReasonAllSlotsAssigned         = "AllSlotsAssigned"
 	ReasonSlotsUnassigned          = "SlotsUnassigned"
+	ReasonGracePeriodTooShort      = "GracePeriodTooShort"
+	ReasonConfigurationValid       = "ConfigurationValid"
 	ReasonPrimaryLost              = "PrimaryLost"
 	ReasonNoSlots                  = "NoSlotsAvailable"
 	ReasonRebalancingSlots         = "RebalancingSlots"

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -141,6 +141,15 @@ type ValkeyClusterSpec struct {
 	// +optional
 	Config map[string]string `json:"config,omitempty"`
 
+	// TerminationGracePeriodSeconds is the pod termination grace period for the
+	// Valkey nodes. It must give the graceful CLUSTER FAILOVER triggered on
+	// SIGTERM (shutdown-on-sigterm) enough time to hand the shard off to a
+	// replica before SIGKILL. When unset, the operator derives a safe default
+	// from cluster-manual-failover-timeout. A value below that derived minimum
+	// is honoured but reported as a warning.
+	// +optional
+	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
 	// TLS configuration for the cluster
 	// +optional
 	TLS *TLSConfig `json:"tls,omitempty"`

--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -270,7 +270,6 @@ const (
 	ReasonAllSlotsAssigned         = "AllSlotsAssigned"
 	ReasonSlotsUnassigned          = "SlotsUnassigned"
 	ReasonGracePeriodTooShort      = "GracePeriodTooShort"
-	ReasonConfigurationValid       = "ConfigurationValid"
 	ReasonPrimaryLost              = "PrimaryLost"
 	ReasonNoSlots                  = "NoSlotsAvailable"
 	ReasonRebalancingSlots         = "RebalancingSlots"

--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -130,6 +130,12 @@ type ValkeyNodeSpec struct {
 	// When set, this overrides the default PodSecurityContext.
 	// +optional
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
+
+	// TerminationGracePeriodSeconds is the pod termination grace period, set by
+	// the ValkeyCluster controller so the graceful CLUSTER FAILOVER on SIGTERM
+	// can complete before SIGKILL.
+	// +optional
+	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 }
 
 // ValkeyNodeStatus defines the observed state of ValkeyNode.

--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -134,6 +134,7 @@ type ValkeyNodeSpec struct {
 	// TerminationGracePeriodSeconds is the pod termination grace period, set by
 	// the ValkeyCluster controller so the graceful CLUSTER FAILOVER on SIGTERM
 	// can complete before SIGKILL.
+	// +kubebuilder:validation:Minimum=1
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -334,6 +334,11 @@ func (in *ValkeyClusterSpec) DeepCopyInto(out *ValkeyClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
 		*out = new(TLSConfig)
@@ -501,6 +506,11 @@ func (in *ValkeyNodeSpec) DeepCopyInto(out *ValkeyNodeSpec) {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.TerminationGracePeriodSeconds != nil {
+		in, out := &in.TerminationGracePeriodSeconds, &out.TerminationGracePeriodSeconds
+		*out = new(int64)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3141,6 +3141,16 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              terminationGracePeriodSeconds:
+                description: |-
+                  TerminationGracePeriodSeconds is the pod termination grace period for the
+                  Valkey nodes. It must give the graceful CLUSTER FAILOVER triggered on
+                  SIGTERM (shutdown-on-sigterm) enough time to hand the shard off to a
+                  replica before SIGKILL. When unset, the operator derives a safe default
+                  from cluster-manual-failover-timeout. A value below that derived minimum
+                  is honoured but reported as a warning.
+                format: int64
+                type: integer
               tls:
                 description: TLS configuration for the cluster
                 properties:

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3150,6 +3150,7 @@ spec:
                   from cluster-manual-failover-timeout. A value below that derived minimum
                   is honoured but reported as a warning.
                 format: int64
+                minimum: 1
                 type: integer
               tls:
                 description: TLS configuration for the cluster

--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -3139,6 +3139,13 @@ spec:
                   ServerConfigMapName specifies the name of the ConfigMap that contains the
                   scripts, and Valkey config for the ValkeyNode.
                 type: string
+              terminationGracePeriodSeconds:
+                description: |-
+                  TerminationGracePeriodSeconds is the pod termination grace period, set by
+                  the ValkeyCluster controller so the graceful CLUSTER FAILOVER on SIGTERM
+                  can complete before SIGKILL.
+                format: int64
+                type: integer
               tls:
                 description: TLS configuration for the node
                 properties:

--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -3145,6 +3145,7 @@ spec:
                   the ValkeyCluster controller so the graceful CLUSTER FAILOVER on SIGTERM
                   can complete before SIGKILL.
                 format: int64
+                minimum: 1
                 type: integer
               tls:
                 description: TLS configuration for the node

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -123,6 +123,17 @@ Common reasons:
 - `AllSlotsAssigned` – all 16384 slots are assigned
 - `SlotsUnassigned` – waiting for slots to be assigned
 
+#### `ConfigurationWarning`
+Indicates the operator accepted a spec value it considers risky, rather than rejecting or overriding it.
+
+| Status | Meaning |
+|---|---|
+| `True` | A risky value is in effect; see the reason and message. |
+| `False` (or absent) | No configuration warning. |
+
+Common reasons:
+- `GracePeriodTooShort` – `spec.terminationGracePeriodSeconds` is below the recommended minimum for the graceful failover on shutdown (`cluster-manual-failover-timeout` plus a buffer). The value is still applied.
+
 ---
 
 ### ValkeyNode conditions

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -136,7 +136,7 @@ terminationGracePeriodSeconds: 60
 
 When omitted, the operator picks a safe value: the larger of the Kubernetes default (30s) and `cluster-manual-failover-timeout` (default 5s) plus a 10s buffer. With defaults that stays at 30s. Raising `cluster-manual-failover-timeout` pulls the derived grace period up with it.
 
-An explicit value is honoured as-is, even if it is below the recommended minimum. In that case the operator emits a `GracePeriodTooShort` warning event on the `ValkeyCluster` rather than silently overriding it.
+An explicit value is honoured as-is, even if it is below the recommended minimum. In that case the operator sets a `ConfigurationWarning` condition (reason `GracePeriodTooShort`) on the `ValkeyCluster` and emits an event when the cluster first enters that state, rather than silently overriding the value. The value must be a positive integer; the CRD rejects zero or negative values.
 
 ### Private image registries
 

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -124,7 +124,19 @@ The operator creates a `PodDisruptionBudget` with `maxUnavailable: 1` selecting 
 
 On `SIGTERM` (a node drain, eviction, or preemption), a cluster primary fails its slots over to a replica before exiting, so descheduling a primary the operator did not initiate does not leave the shard without a writer. This is enabled by default through the `shutdown-on-sigterm failover` server config and requires Valkey 9.0+.
 
-The handoff runs inside the pod's termination grace period. With defaults there is comfortable margin: the Kubernetes default `terminationGracePeriodSeconds` is 30s and the Valkey default `cluster-manual-failover-timeout` is 5s, so the failover completes well before `SIGKILL`. If you raise `cluster-manual-failover-timeout`, raise `terminationGracePeriodSeconds` to keep it above the timeout, otherwise `SIGKILL` can cut the failover short.
+The handoff runs inside the pod's termination grace period. With defaults there is comfortable margin: the Kubernetes default `terminationGracePeriodSeconds` is 30s and the Valkey default `cluster-manual-failover-timeout` is 5s, so the failover completes well before `SIGKILL`. If you raise `cluster-manual-failover-timeout`, the operator raises the derived `terminationGracePeriodSeconds` to match; see [Termination grace period](#termination-grace-period).
+
+### Termination grace period
+
+```yaml
+terminationGracePeriodSeconds: 60
+```
+
+`terminationGracePeriodSeconds` sets the pod termination grace period for the Valkey nodes. On `SIGTERM` a primary gracefully fails its slots over to a replica, and that handover has to finish before Kubernetes sends `SIGKILL`, so the grace period must be at least `cluster-manual-failover-timeout` plus some headroom.
+
+When omitted, the operator picks a safe value: the larger of the Kubernetes default (30s) and `cluster-manual-failover-timeout` (default 5s) plus a 10s buffer. With defaults that stays at 30s. Raising `cluster-manual-failover-timeout` pulls the derived grace period up with it.
+
+An explicit value is honoured as-is, even if it is below the recommended minimum. In that case the operator emits a `GracePeriodTooShort` warning event on the `ValkeyCluster` rather than silently overriding it.
 
 ### Private image registries
 

--- a/internal/controller/grace_period_test.go
+++ b/internal/controller/grace_period_test.go
@@ -85,6 +85,12 @@ func TestBuildClusterValkeyNodeGracePeriod(t *testing.T) {
 		assert.Nil(t, node.Spec.TerminationGracePeriodSeconds)
 	})
 
+	t.Run("an explicit value equal to the default is still stored verbatim", func(t *testing.T) {
+		node := buildClusterValkeyNode(cluster(ptr(30), nil), 0, 0)
+		require.NotNil(t, node.Spec.TerminationGracePeriodSeconds)
+		assert.Equal(t, int64(30), *node.Spec.TerminationGracePeriodSeconds)
+	})
+
 	t.Run("an explicit value is propagated to the node", func(t *testing.T) {
 		node := buildClusterValkeyNode(cluster(ptr(60), nil), 0, 0)
 		require.NotNil(t, node.Spec.TerminationGracePeriodSeconds)

--- a/internal/controller/grace_period_test.go
+++ b/internal/controller/grace_period_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 )
 
@@ -66,5 +68,32 @@ func TestEffectiveGracePeriodSeconds(t *testing.T) {
 
 	t.Run("an explicit value below the recommended minimum is still honoured", func(t *testing.T) {
 		assert.Equal(t, int64(5), effectiveGracePeriodSeconds(clusterWith(ptr(5), nil)))
+	})
+}
+
+func TestBuildClusterValkeyNodeGracePeriod(t *testing.T) {
+	ptr := func(v int64) *int64 { return &v }
+	cluster := func(grace *int64, cfg map[string]string) *valkeyiov1alpha1.ValkeyCluster {
+		return &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+			Spec:       valkeyiov1alpha1.ValkeyClusterSpec{TerminationGracePeriodSeconds: grace, Config: cfg},
+		}
+	}
+
+	t.Run("the resolved default leaves the node field nil so upgrades do not roll", func(t *testing.T) {
+		node := buildClusterValkeyNode(cluster(nil, nil), 0, 0)
+		assert.Nil(t, node.Spec.TerminationGracePeriodSeconds)
+	})
+
+	t.Run("an explicit value is propagated to the node", func(t *testing.T) {
+		node := buildClusterValkeyNode(cluster(ptr(60), nil), 0, 0)
+		require.NotNil(t, node.Spec.TerminationGracePeriodSeconds)
+		assert.Equal(t, int64(60), *node.Spec.TerminationGracePeriodSeconds)
+	})
+
+	t.Run("a long failover timeout pulls the derived value above the default", func(t *testing.T) {
+		node := buildClusterValkeyNode(cluster(nil, map[string]string{"cluster-manual-failover-timeout": "60000"}), 0, 0)
+		require.NotNil(t, node.Spec.TerminationGracePeriodSeconds)
+		assert.Equal(t, int64(70), *node.Spec.TerminationGracePeriodSeconds)
 	})
 }

--- a/internal/controller/grace_period_test.go
+++ b/internal/controller/grace_period_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+)
+
+func TestFailoverTimeoutSeconds(t *testing.T) {
+	cfg := func(v string) map[string]string {
+		return map[string]string{"cluster-manual-failover-timeout": v}
+	}
+	assert.Equal(t, int64(5), failoverTimeoutSeconds(nil))           // unset map
+	assert.Equal(t, int64(5), failoverTimeoutSeconds(cfg("")))       // empty value
+	assert.Equal(t, int64(30), failoverTimeoutSeconds(cfg("30000"))) // 30s
+	assert.Equal(t, int64(6), failoverTimeoutSeconds(cfg("5500")))   // rounds up
+	assert.Equal(t, int64(5), failoverTimeoutSeconds(cfg("abc")))    // unparseable falls back
+	assert.Equal(t, int64(5), failoverTimeoutSeconds(cfg("0")))      // non-positive falls back
+}
+
+func TestRecommendedGracePeriodSeconds(t *testing.T) {
+	c := &valkeyiov1alpha1.ValkeyCluster{}
+	assert.Equal(t, int64(15), recommendedGracePeriodSeconds(c)) // 5s default + 10s buffer
+
+	c.Spec.Config = map[string]string{"cluster-manual-failover-timeout": "60000"}
+	assert.Equal(t, int64(70), recommendedGracePeriodSeconds(c)) // 60s + 10s buffer
+}
+
+func TestEffectiveGracePeriodSeconds(t *testing.T) {
+	clusterWith := func(grace *int64, cfg map[string]string) *valkeyiov1alpha1.ValkeyCluster {
+		return &valkeyiov1alpha1.ValkeyCluster{
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{TerminationGracePeriodSeconds: grace, Config: cfg},
+		}
+	}
+	ptr := func(v int64) *int64 { return &v }
+
+	t.Run("unset with the default timeout keeps the kubernetes default", func(t *testing.T) {
+		assert.Equal(t, int64(30), effectiveGracePeriodSeconds(clusterWith(nil, nil)))
+	})
+
+	t.Run("unset with a long timeout pulls the grace period up", func(t *testing.T) {
+		c := clusterWith(nil, map[string]string{"cluster-manual-failover-timeout": "60000"})
+		assert.Equal(t, int64(70), effectiveGracePeriodSeconds(c))
+	})
+
+	t.Run("an explicit value is honoured", func(t *testing.T) {
+		assert.Equal(t, int64(45), effectiveGracePeriodSeconds(clusterWith(ptr(45), nil)))
+	})
+
+	t.Run("an explicit value below the recommended minimum is still honoured", func(t *testing.T) {
+		assert.Equal(t, int64(5), effectiveGracePeriodSeconds(clusterWith(ptr(5), nil)))
+	})
+}

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -153,6 +153,18 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// ConfigMap to avoid a race condition where the cache does not have the ConfigMap
 	configHash := serverConfigRollHash(cluster)
 
+	// Warn when an explicit terminationGracePeriodSeconds is too short for the
+	// graceful failover on SIGTERM to finish before SIGKILL. The value is still
+	// honoured; the operator does not silently override it.
+	if g := cluster.Spec.TerminationGracePeriodSeconds; g != nil {
+		if rec := recommendedGracePeriodSeconds(cluster); *g < rec {
+			log.Info("terminationGracePeriodSeconds is below the recommended minimum for graceful failover",
+				"requested", *g, "recommended", rec)
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "GracePeriodTooShort", "ReconcileValkeyCluster",
+				"spec.terminationGracePeriodSeconds (%ds) is below the recommended %ds for cluster-manual-failover-timeout; SIGKILL may interrupt the graceful failover on shutdown", *g, rec)
+		}
+	}
+
 	nodes := &valkeyiov1alpha1.ValkeyNodeList{}
 	if err := r.List(ctx, nodes, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{LabelCluster: cluster.Name})); err != nil {
 		log.Error(err, "failed to list ValkeyNodes")
@@ -671,6 +683,51 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, clust
 	return nodeUnchanged, nil
 }
 
+const (
+	// gracePeriodBufferSeconds is added on top of cluster-manual-failover-timeout
+	// so the SIGTERM-triggered failover has headroom to finish before SIGKILL.
+	gracePeriodBufferSeconds = 10
+	// defaultFailoverTimeoutSeconds mirrors the Valkey default for
+	// cluster-manual-failover-timeout (5000ms).
+	defaultFailoverTimeoutSeconds = 5
+	// defaultGracePeriodSeconds mirrors the Kubernetes default
+	// terminationGracePeriodSeconds.
+	defaultGracePeriodSeconds = 30
+)
+
+// failoverTimeoutSeconds returns cluster-manual-failover-timeout in whole
+// seconds (rounded up), or the Valkey default when unset or unparseable.
+func failoverTimeoutSeconds(config map[string]string) int64 {
+	v, ok := config["cluster-manual-failover-timeout"]
+	if !ok {
+		return defaultFailoverTimeoutSeconds
+	}
+	ms, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	if err != nil || ms <= 0 {
+		return defaultFailoverTimeoutSeconds
+	}
+	return (ms + 999) / 1000
+}
+
+// recommendedGracePeriodSeconds is the smallest terminationGracePeriodSeconds
+// that lets a SIGTERM-triggered failover finish before SIGKILL.
+func recommendedGracePeriodSeconds(cluster *valkeyiov1alpha1.ValkeyCluster) int64 {
+	return failoverTimeoutSeconds(cluster.Spec.Config) + gracePeriodBufferSeconds
+}
+
+// effectiveGracePeriodSeconds is the grace period the operator applies to the
+// Valkey pods: the user's value when set, otherwise a safe default that is at
+// least the Kubernetes default and the recommended minimum.
+func effectiveGracePeriodSeconds(cluster *valkeyiov1alpha1.ValkeyCluster) int64 {
+	if cluster.Spec.TerminationGracePeriodSeconds != nil {
+		return *cluster.Spec.TerminationGracePeriodSeconds
+	}
+	if rec := recommendedGracePeriodSeconds(cluster); rec > defaultGracePeriodSeconds {
+		return rec
+	}
+	return defaultGracePeriodSeconds
+}
+
 // buildClusterValkeyNode constructs the ValkeyNode CR for a given (shard, node) position.
 func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex int, nodeIndex int) *valkeyiov1alpha1.ValkeyNode {
 	// Start with recommended k8s labels; instance is the cluster name and component is "valkey-node".
@@ -686,6 +743,8 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 	l[LabelShardIndex] = strconv.Itoa(shardIndex)
 	l[LabelNodeIndex] = strconv.Itoa(nodeIndex)
 
+	gracePeriod := effectiveGracePeriodSeconds(cluster)
+
 	return &valkeyiov1alpha1.ValkeyNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      valkeyNodeName(cluster.Name, shardIndex, nodeIndex),
@@ -693,23 +752,24 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 			Labels:    l,
 		},
 		Spec: valkeyiov1alpha1.ValkeyNodeSpec{
-			Image:                     cluster.Spec.Image,
-			ImagePullSecrets:          cluster.Spec.ImagePullSecrets,
-			WorkloadType:              cluster.Spec.WorkloadType,
-			Persistence:               cluster.Spec.Persistence,
-			Resources:                 cluster.Spec.Resources,
-			NodeSelector:              cluster.Spec.NodeSelector,
-			Affinity:                  cluster.Spec.Affinity,
-			Tolerations:               cluster.Spec.Tolerations,
-			PriorityClassName:         cluster.Spec.PriorityClassName,
-			TopologySpreadConstraints: cluster.Spec.TopologySpreadConstraints,
-			Exporter:                  cluster.Spec.Exporter,
-			Containers:                cluster.Spec.Containers,
-			ServerConfigMapName:       GetServerConfigMapName(cluster.Name),
-			UsersACLSecretName:        getInternalSecretName(cluster.Name),
-			TLS:                       cluster.Spec.TLS,
-			Config:                    cluster.Spec.Config,
-			PodSecurityContext:        cluster.Spec.PodSecurityContext,
+			Image:                         cluster.Spec.Image,
+			ImagePullSecrets:              cluster.Spec.ImagePullSecrets,
+			WorkloadType:                  cluster.Spec.WorkloadType,
+			Persistence:                   cluster.Spec.Persistence,
+			Resources:                     cluster.Spec.Resources,
+			NodeSelector:                  cluster.Spec.NodeSelector,
+			Affinity:                      cluster.Spec.Affinity,
+			Tolerations:                   cluster.Spec.Tolerations,
+			PriorityClassName:             cluster.Spec.PriorityClassName,
+			TopologySpreadConstraints:     cluster.Spec.TopologySpreadConstraints,
+			Exporter:                      cluster.Spec.Exporter,
+			Containers:                    cluster.Spec.Containers,
+			ServerConfigMapName:           GetServerConfigMapName(cluster.Name),
+			UsersACLSecretName:            getInternalSecretName(cluster.Name),
+			TLS:                           cluster.Spec.TLS,
+			Config:                        cluster.Spec.Config,
+			PodSecurityContext:            cluster.Spec.PodSecurityContext,
+			TerminationGracePeriodSeconds: &gracePeriod,
 		},
 	}
 }

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -153,16 +153,22 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// ConfigMap to avoid a race condition where the cache does not have the ConfigMap
 	configHash := serverConfigRollHash(cluster)
 
-	// Warn when an explicit terminationGracePeriodSeconds is too short for the
-	// graceful failover on SIGTERM to finish before SIGKILL. The value is still
-	// honoured; the operator does not silently override it.
-	if g := cluster.Spec.TerminationGracePeriodSeconds; g != nil {
-		if rec := recommendedGracePeriodSeconds(cluster); *g < rec {
+	// Surface a ConfigurationWarning condition when an explicit
+	// terminationGracePeriodSeconds is too short for the graceful failover on
+	// SIGTERM to finish before SIGKILL. The value is honoured; the operator does
+	// not silently override it. The condition is idempotent, so the event fires
+	// only when the cluster first enters the warning state.
+	if g := cluster.Spec.TerminationGracePeriodSeconds; g != nil && *g < recommendedGracePeriodSeconds(cluster) {
+		rec := recommendedGracePeriodSeconds(cluster)
+		msg := fmt.Sprintf("spec.terminationGracePeriodSeconds (%ds) is below the recommended %ds for cluster-manual-failover-timeout; SIGKILL may interrupt the graceful failover on shutdown", *g, rec)
+		if !meta.IsStatusConditionTrue(cluster.Status.Conditions, valkeyiov1alpha1.ConditionConfigurationWarning) {
 			log.Info("terminationGracePeriodSeconds is below the recommended minimum for graceful failover",
 				"requested", *g, "recommended", rec)
-			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "GracePeriodTooShort", "ReconcileValkeyCluster",
-				"spec.terminationGracePeriodSeconds (%ds) is below the recommended %ds for cluster-manual-failover-timeout; SIGKILL may interrupt the graceful failover on shutdown", *g, rec)
+			r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, valkeyiov1alpha1.ReasonGracePeriodTooShort, "ReconcileValkeyCluster", "%s", msg)
 		}
+		setCondition(cluster, valkeyiov1alpha1.ConditionConfigurationWarning, valkeyiov1alpha1.ReasonGracePeriodTooShort, msg, metav1.ConditionTrue)
+	} else {
+		removeConditionIfReason(&cluster.Status.Conditions, valkeyiov1alpha1.ConditionConfigurationWarning, valkeyiov1alpha1.ReasonGracePeriodTooShort)
 	}
 
 	nodes := &valkeyiov1alpha1.ValkeyNodeList{}
@@ -743,7 +749,13 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 	l[LabelShardIndex] = strconv.Itoa(shardIndex)
 	l[LabelNodeIndex] = strconv.Itoa(nodeIndex)
 
-	gracePeriod := effectiveGracePeriodSeconds(cluster)
+	// Only set the field when it differs from the Kubernetes default, so existing
+	// clusters that resolve to the default keep a nil value and are not rolled on
+	// operator upgrade.
+	var gracePeriod *int64
+	if g := effectiveGracePeriodSeconds(cluster); g != defaultGracePeriodSeconds {
+		gracePeriod = &g
+	}
 
 	return &valkeyiov1alpha1.ValkeyNode{
 		ObjectMeta: metav1.ObjectMeta{
@@ -769,7 +781,7 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 			TLS:                           cluster.Spec.TLS,
 			Config:                        cluster.Spec.Config,
 			PodSecurityContext:            cluster.Spec.PodSecurityContext,
-			TerminationGracePeriodSeconds: &gracePeriod,
+			TerminationGracePeriodSeconds: gracePeriod,
 		},
 	}
 }

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -158,8 +158,8 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// SIGTERM to finish before SIGKILL. The value is honoured; the operator does
 	// not silently override it. The condition is idempotent, so the event fires
 	// only when the cluster first enters the warning state.
-	if g := cluster.Spec.TerminationGracePeriodSeconds; g != nil && *g < recommendedGracePeriodSeconds(cluster) {
-		rec := recommendedGracePeriodSeconds(cluster)
+	rec := recommendedGracePeriodSeconds(cluster)
+	if g := cluster.Spec.TerminationGracePeriodSeconds; g != nil && *g < rec {
 		msg := fmt.Sprintf("spec.terminationGracePeriodSeconds (%ds) is below the recommended %ds for cluster-manual-failover-timeout; SIGKILL may interrupt the graceful failover on shutdown", *g, rec)
 		if !meta.IsStatusConditionTrue(cluster.Status.Conditions, valkeyiov1alpha1.ConditionConfigurationWarning) {
 			log.Info("terminationGracePeriodSeconds is below the recommended minimum for graceful failover",
@@ -752,9 +752,17 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 	// Only set the field when it differs from the Kubernetes default, so existing
 	// clusters that resolve to the default keep a nil value and are not rolled on
 	// operator upgrade.
+	// Store the user's value verbatim when set, so an explicit change (including
+	// back to the Kubernetes default) always propagates to the pod. When unset,
+	// only populate the field if the derived default deviates from the Kubernetes
+	// pod default, so existing clusters that resolve to the default are not rolled
+	// on operator upgrade.
 	var gracePeriod *int64
-	if g := effectiveGracePeriodSeconds(cluster); g != defaultGracePeriodSeconds {
+	if cluster.Spec.TerminationGracePeriodSeconds != nil {
+		g := *cluster.Spec.TerminationGracePeriodSeconds
 		gracePeriod = &g
+	} else if d := effectiveGracePeriodSeconds(cluster); d != defaultGracePeriodSeconds {
+		gracePeriod = &d
 	}
 
 	return &valkeyiov1alpha1.ValkeyNode{

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -376,14 +376,15 @@ func buildValkeyNodePodTemplateSpec(node *valkeyiov1alpha1.ValkeyNode, labels ma
 	}
 
 	podSpec := corev1.PodSpec{
-		Containers:                containers,
-		ImagePullSecrets:          node.Spec.ImagePullSecrets,
-		NodeSelector:              node.Spec.NodeSelector,
-		Affinity:                  node.Spec.Affinity,
-		Tolerations:               node.Spec.Tolerations,
-		PriorityClassName:         node.Spec.PriorityClassName,
-		TopologySpreadConstraints: buildShardTopologySpreadConstraints(node, labels),
-		SecurityContext:           node.Spec.PodSecurityContext,
+		Containers:                    containers,
+		ImagePullSecrets:              node.Spec.ImagePullSecrets,
+		NodeSelector:                  node.Spec.NodeSelector,
+		Affinity:                      node.Spec.Affinity,
+		Tolerations:                   node.Spec.Tolerations,
+		PriorityClassName:             node.Spec.PriorityClassName,
+		TopologySpreadConstraints:     buildShardTopologySpreadConstraints(node, labels),
+		SecurityContext:               node.Spec.PodSecurityContext,
+		TerminationGracePeriodSeconds: node.Spec.TerminationGracePeriodSeconds,
 		Volumes: []corev1.Volume{
 			{
 				Name: "scripts",


### PR DESCRIPTION
Closes #260

### Summary

Add `spec.terminationGracePeriodSeconds` to `ValkeyCluster` (threaded through to `ValkeyNode` and onto the pod) so the graceful `CLUSTER FAILOVER` triggered on SIGTERM has time to hand the shard off to a replica before SIGKILL.

### Design

Following the direction in #260:

- New `TerminationGracePeriodSeconds *int64` on both `ValkeyClusterSpec` (user-facing) and `ValkeyNodeSpec` (the cluster controller threads it through to the pod). Not grouped under a pod-template surface yet, per your note that we can redesign that while still in alpha.
- When unset, the operator derives a safe value: `max(30s, cluster-manual-failover-timeout / 1000 + 10s)`. With the defaults (5s timeout) that stays at the Kubernetes default of 30s. Raising the timeout pulls the grace period up with it.
- An explicit value is honoured as-is, so a user who wants a long grace period (for example to allow a final RDB snapshot) gets exactly what they asked for. If the value is below the recommended minimum, the operator emits a `GracePeriodTooShort` warning event on the `ValkeyCluster` instead of silently overriding it.

### On the "block the apply" idea

You floated blocking the manifest apply when the value is too short. i went with respect-the-value-and-warn instead, because the recommended minimum depends on `cluster-manual-failover-timeout`, which lives in `spec.config` as a string map entry. a CEL admission rule can't cleanly parse and compare that, so a hard block would need a validating webhook. happy to add that as a follow-up if you'd rather it be a hard stop; the warning event is the lighter "inform the user" mechanism for now.

### Acceptance criteria

- [x] Warns (event + log) when `terminationGracePeriodSeconds` is below the recommended minimum
- [~] Reconcile-time check (CEL block deferred, see above)
- [x] Documented in the CRD field comments and `docs/valkeycluster.md`

### Testing

- Unit tests for the timeout / recommended / effective grace-period helpers.
- `make test` and `make lint` pass locally.

Docs note: i added a `Termination grace period` section, which sits next to the `Graceful shutdown` section from #268 once that merges.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [ ] I have run pre-commit locally (ran `make test` and `make lint` instead)
