### PR TITLE
fix: filter excess shard pods in scheduling issue check

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -417,7 +417,14 @@ func (r *ValkeyClusterReconciler) findPodSchedulingIssue(ctx context.Context, cl
 		return nil, fmt.Errorf("list Valkey pods: %w", err)
 	}
 
+	desiredShards := int(cluster.Spec.Shards)
 	for i := range pods.Items {
+		if label, ok := pods.Items[i].Labels[LabelShardIndex]; ok {
+			si, err := strconv.Atoi(label)
+			if err == nil && si >= desiredShards {
+				continue
+			}
+		}
 		if issue := podSchedulingIssueForPod(&pods.Items[i]); issue != nil {
 			return issue, nil
 		}


### PR DESCRIPTION
## Summary

Follow-up to #258. The inner `handlePodSchedulingIssues` call in the `reconcileValkeyNodes` requeue branch (line 167) still lists all cluster pods, including those from excess shards pending removal. During a concurrent rolling update and scale-in, this can block progress.

## Implementation

Filter `findPodSchedulingIssue` to skip pods whose `shard-index` label is >= the desired shard count. Only pods belonging to desired shards are checked for scheduling issues. Excess shard pods are ignored since they will be cleaned up by `handleScaleIn`.

## Limitations

None. The filter is safe because excess shard pods are always cleaned up by `handleScaleIn` regardless of their scheduling state.

## Testing

Compiles clean. Existing test failures on main are pre-existing (unrelated `reconcileValkeyNode` signature change).