### PR TITLE
fix: Ensure shards required

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -76,8 +76,9 @@ type ValkeyClusterSpec struct {
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// The number of shards groups. Each shard group contains one primary and N replicas.
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
-	Shards int32 `json:"shards,omitempty"`
+	Shards int32 `json:"shards"`
 
 	// The number of replicas for each shard group.
 	// +kubebuilder:validation:Minimum=0

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3052,6 +3052,8 @@ spec:
                 x-kubernetes-validations:
                 - message: workloadType is immutable
                   rule: self == oldSelf
+            required:
+            - shards
             type: object
             x-kubernetes-validations:
             - message: persistence requires workloadType StatefulSet

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -508,6 +508,9 @@ var _ = Describe("updateStatus", func() {
 				Name:      "test-cluster",
 				Namespace: "default",
 			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards: 1,
+			},
 		}
 		// In a real scenario, the reconciler would be created with a real client,
 		// but for this focused unit test, we can use a fake client if needed,
@@ -693,6 +696,10 @@ var _ = Describe("EventRecorder", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "event-type-test",
 					Namespace: "default",
+				},
+				Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+					Shards:   3,
+					Replicas: 1,
 				},
 			}
 			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())


### PR DESCRIPTION
This PR closes https://github.com/valkey-io/valkey-operator/issues/282.

### Summary

This adds shards to the CRD's required list so the API server rejects manifests that omit it, and keeps Minimum=1 enforced for explicit values.

### Features / Behaviour Changes

- Users can't omit valkeycluster without shards input.

### Implementation

Make shards a required field and drop omitempty:
```
  // +kubebuilder:validation:Required
  // +kubebuilder:validation:Minimum=1
  Shards int32 `json:"shards"`
```

Tests:
- EventRecorder test (Shards: 3, Replicas: 1) — I mirrored its sibling specs in the same EventRecorder Describe block.
- updateStatus test: There is no convention and these tests don't read Spec.Shards/Spec.Replicas - so added minimal `Shards: 1`. If required I can change it to `Shards: 3, Replicas: 1`.

### Limitations

NA

### Testing

Same as other kubebuilder tests.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
