### PR TITLE
Init cluster metrics

### DIFF
--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -41,6 +41,20 @@ const (
 	eventActionProactiveFailover = "ProactiveFailover"
 )
 
+type FailoverType string
+
+const (
+	FailoverProactive FailoverType = "proactive"
+)
+
+var FailoverTypes = []FailoverType{
+	FailoverProactive,
+}
+
+func (ft FailoverType) String() string {
+	return string(ft)
+}
+
 // findFailoverShard returns the shard and its synced replicas if the node at
 // address is a primary that should be gracefully failed over before being
 // updated, or nil if no failover is needed.
@@ -106,7 +120,7 @@ func proactiveFailover(ctx context.Context, recorder events.EventRecorder, clust
 			if role == RolePrimary {
 				recorder.Eventf(cluster, nil, corev1.EventTypeNormal, eventReasonFailoverCompleted, eventActionProactiveFailover, "Failover completed: %s is now primary in shard %s", target.Address, shard.Id)
 				log.Info("proactive failover completed", "newPrimary", target.Address, "shard", shard.Id)
-				failoversTotal.WithLabelValues(cluster.Name, cluster.Namespace, "proactive").Inc()
+				failoversTotal.WithLabelValues(cluster.Name, cluster.Namespace, FailoverProactive.String()).Inc()
 				return nil
 			}
 		}

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -73,6 +73,20 @@ var (
 	)
 )
 
+// initClusterMetrics creates empty metrics for a valkey cluster
+func initClusterMetrics(name, namespace string) {
+	for _, s := range valkeyiov1alpha1.ClusterStates {
+		clusterStateInfo.WithLabelValues(name, namespace, string(s))
+	}
+	for _, s := range FailoverTypes {
+		failoversTotal.WithLabelValues(name, namespace, s.String())
+	}
+
+	clusterShards.WithLabelValues(name, namespace)
+	clusterShardsReady.WithLabelValues(name, namespace)
+	slotMigrationBatchesTotal.WithLabelValues(name, namespace)
+}
+
 // updateClusterMetrics sets the Prometheus gauges for a ValkeyCluster.
 func updateClusterMetrics(cluster *valkeyiov1alpha1.ValkeyCluster) {
 	name := cluster.Name

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -122,6 +122,8 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	initClusterMetrics(req.Name, req.Namespace)
+
 	if err := r.upsertService(ctx, cluster); err != nil {
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonServiceError, err.Error(), metav1.ConditionFalse)
 		_ = r.updateStatus(ctx, cluster, nil)


### PR DESCRIPTION
### Summary

Early in the cluster controller reconcile loop call `WithLabelValues` in order to make sure all metrics exist for a cluster. This espectially helps init the error counters at zero.

This is a followup to https://github.com/valkey-io/valkey-operator/pull/159.

### Features / Behaviour Changes

All of the operator cluster metrics will now exist for each managed cluster.


### Testing

<!--
Describe what tests have been conducted and any relevant test results
-->

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
