### PR TITLE
test: add default user password for e2e cluster test

### DIFF
--- a/config/samples/v1alpha1_valkeycluster-with-user.yaml
+++ b/config/samples/v1alpha1_valkeycluster-with-user.yaml
@@ -7,6 +7,7 @@ data:
   alicepw: M21wdHlQQHNzdzByZA==
   davidold: OVYqTHQlYXU4Mk5tdTlyeQ==
   davidnew: VmFsa2V5I1J1bHojMjIzMw==
+  defaultpw: dHg4OWx4elRLNEZjdXR2akZ4SmQ=
 ---
 apiVersion: valkey.io/v1alpha1
 kind: ValkeyCluster
@@ -50,6 +51,12 @@ spec:
           - davidnew
       commands:
         allow: ["@admin"]
+    - name: default
+      enabled: true
+      permissions: "+@all ~* &*"
+      passwordSecret:
+        name: valkey-cluster-sample-users
+        keys: [defaultpw]
     - name: edward
       enabled: true
       resetpass: true

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -503,12 +503,7 @@ spec:
 			verifyCreatedUsers := func(g Gomega) {
 				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", withUserClusterName)
 
-				cmd := exec.Command(
-					"sh", "-c",
-					`kubectl get secret valkey-cluster-sample-users \
-    -n default \
-    -o jsonpath='{.data.defaultpw}'`)
-
+				cmd := exec.Command("kubectl", "get", "secrets", "valkey-cluster-sample-users", "-o", "jsonpath={.data.defaultpw}")
 				b64Password, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package e2e
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -502,10 +503,24 @@ spec:
 			verifyCreatedUsers := func(g Gomega) {
 				clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", withUserClusterName)
 
-				cmd := exec.Command("kubectl", "run", "client",
+				cmd := exec.Command(
+					"sh", "-c",
+					`kubectl get secret valkey-cluster-sample-users \
+    -n default \
+    -o jsonpath='{.data.defaultpw}'`)
+
+				b64Password, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				b64Password = strings.TrimSpace(b64Password)
+				decoded, err := base64.StdEncoding.DecodeString(b64Password)
+				g.Expect(err).NotTo(HaveOccurred())
+				operatorPassword := string(decoded)
+
+				cmd = exec.Command("kubectl", "run", "client",
 					fmt.Sprintf("--image=%s", valkeyClientImage), "--restart=Never", "--",
-					"valkey-cli", "-c", "-h", clusterFqdn, "ACL", "LIST")
-				_, err := utils.Run(cmd)
+					"valkey-cli", "-c", "-h", clusterFqdn, "-a", operatorPassword, "ACL", "LIST")
+				_, err = utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
 
 				cmd = exec.Command("kubectl", "wait", "pod/client",


### PR DESCRIPTION
This PR closes #246 

### Summary

Sets a password on the default Valkey user in the e2e test cluster to prevent silent authentication fallback. Previously, any failed auth attempt (wrong credential, missing secret mount, misconfigured ACL) would silently execute commands as default (which had nopass and full permissions), masking real failures.

### Features / Behaviour Changes

The default user in the sample cluster manifest now has a password set. The e2e test fetches that password from the Kubernetes secret at runtime and passes it explicitly to valkey-cli via -a, ensuring commands are executed under the correct identity.

### Implementation

Two changes:

- config/samples/v1alpha1_valkeycluster-with-user.yaml: adds a defaultpw entry to the secret and a default user spec with `+@all ~* &*` permissions and a passwordSecret reference.
- test/e2e/valkeycluster_test.go: before running valkey-cli, fetches defaultpw from the secret via kubectl get secret, base64-decodes it, and passes it as the -a flag. This is the minimal change — no ACL WHOAMI assertion is added yet.

### Limitations

- Does not grant ACL LIST to _operator, so the operator still relies on default having sufficient permissions to run management commands.

### Testing

The existing e2e test verifyCreatedUsers now connects with the default user's password. A missing or incorrect credential will cause valkey-cli to fail rather than silently fall back, so the test now fails fast on auth regressions.

### Checklist

Before submitting the PR make sure the following are checked:

- [X] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [X] Tests are added or updated.
- [ ] Documentation files are updated.
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
