### PR TITLE
feat: add priorityClassName to ValkeyCluster and ValkeyNode specs

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -100,6 +100,12 @@ type ValkeyClusterSpec struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// PriorityClassName is the name of an existing PriorityClass applied to
+	// every pod in the cluster, protecting them from eviction under resource
+	// pressure.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// TopologySpreadConstraints defines pod topology spread constraints applied
 	// to the ValkeyNode workloads. The operator augments these constraints with
 	// shard-aware selectors so pods from the same shard can be spread across the

--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -76,6 +76,11 @@ type ValkeyNodeSpec struct {
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	// PriorityClassName is the name of an existing PriorityClass applied to
+	// the pod, protecting it from eviction under resource pressure.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// TopologySpreadConstraints defines pod topology spread constraints applied
 	// to the ValkeyNode workload. The operator augments these constraints with
 	// shard-aware selectors derived from node labels.

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3064,6 +3064,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              priorityClassName:
+                description: |-
+                  PriorityClassName is the name of an existing PriorityClass applied to
+                  every pod in the cluster, protecting them from eviction under resource
+                  pressure.
+                type: string
               replicas:
                 description: The number of replicas for each shard group.
                 format: int32

--- a/config/crd/bases/valkey.io_valkeynodes.yaml
+++ b/config/crd/bases/valkey.io_valkeynodes.yaml
@@ -3062,6 +3062,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              priorityClassName:
+                description: |-
+                  PriorityClassName is the name of an existing PriorityClass applied to
+                  the pod, protecting it from eviction under resource pressure.
+                type: string
               resources:
                 description: Resources defines the resource requirements for the Valkey
                   container.

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -153,9 +153,10 @@ affinity:
           matchLabels:
             app.kubernetes.io/name: valkey
         topologyKey: kubernetes.io/hostname
+priorityClassName: high-priority
 ```
 
-`tolerations`, `nodeSelector`, and `affinity` are passed through to every pod in the cluster.
+`tolerations`, `nodeSelector`, `affinity`, and `priorityClassName` are passed through to every pod in the cluster. `priorityClassName` must reference an existing [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) and protects the Valkey pods from eviction under resource pressure.
 
 #### Topology spread constraints
 

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -701,6 +701,7 @@ func buildClusterValkeyNode(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex 
 			NodeSelector:              cluster.Spec.NodeSelector,
 			Affinity:                  cluster.Spec.Affinity,
 			Tolerations:               cluster.Spec.Tolerations,
+			PriorityClassName:         cluster.Spec.PriorityClassName,
 			TopologySpreadConstraints: cluster.Spec.TopologySpreadConstraints,
 			Exporter:                  cluster.Spec.Exporter,
 			Containers:                cluster.Spec.Containers,

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -1256,3 +1256,30 @@ var _ = Describe("buildClusterValkeyNode config passthrough", Label("liveconfig"
 		Expect(node.Spec.Config).To(Equal(map[string]string{"maxmemory-policy": "allkeys-lru"}))
 	})
 })
+
+var _ = Describe("buildClusterValkeyNode scheduling passthrough", func() {
+	It("copies cluster Spec.PriorityClassName into the built ValkeyNode spec", func() {
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default"},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:            1,
+				Replicas:          0,
+				PriorityClassName: "high-priority",
+			},
+		}
+		node := buildClusterValkeyNode(cluster, 0, 0)
+		Expect(node.Spec.PriorityClassName).To(Equal("high-priority"))
+	})
+
+	It("leaves PriorityClassName empty when the cluster does not set it", func() {
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default"},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+			},
+		}
+		node := buildClusterValkeyNode(cluster, 0, 0)
+		Expect(node.Spec.PriorityClassName).To(BeEmpty())
+	})
+})

--- a/internal/controller/valkeynode_resources.go
+++ b/internal/controller/valkeynode_resources.go
@@ -381,6 +381,7 @@ func buildValkeyNodePodTemplateSpec(node *valkeyiov1alpha1.ValkeyNode, labels ma
 		NodeSelector:              node.Spec.NodeSelector,
 		Affinity:                  node.Spec.Affinity,
 		Tolerations:               node.Spec.Tolerations,
+		PriorityClassName:         node.Spec.PriorityClassName,
 		TopologySpreadConstraints: buildShardTopologySpreadConstraints(node, labels),
 		SecurityContext:           node.Spec.PodSecurityContext,
 		Volumes: []corev1.Volume{

--- a/internal/controller/valkeynode_resources_test.go
+++ b/internal/controller/valkeynode_resources_test.go
@@ -310,6 +310,7 @@ func TestBuildValkeyNodePodTemplateSpec_Scheduling(t *testing.T) {
 	node.Spec.NodeSelector = nodeSelector
 	node.Spec.Affinity = affinity
 	node.Spec.Tolerations = tolerations
+	node.Spec.PriorityClassName = "high-priority"
 
 	lbls := valkeyNodeLabels(node)
 	pts, err := buildValkeyNodePodTemplateSpec(node, lbls)
@@ -318,6 +319,16 @@ func TestBuildValkeyNodePodTemplateSpec_Scheduling(t *testing.T) {
 	assert.Equal(t, nodeSelector, pts.Spec.NodeSelector, "node selector should pass through")
 	assert.Equal(t, affinity, pts.Spec.Affinity, "affinity should pass through")
 	assert.Equal(t, tolerations, pts.Spec.Tolerations, "tolerations should pass through")
+	assert.Equal(t, "high-priority", pts.Spec.PriorityClassName, "priorityClassName should pass through")
+}
+
+func TestBuildValkeyNodePodTemplateSpec_PriorityClassNameDefaultsEmpty(t *testing.T) {
+	node := newTestValkeyNode("mynode", "test-ns")
+
+	pts, err := buildValkeyNodePodTemplateSpec(node, valkeyNodeLabels(node))
+	require.NoError(t, err)
+
+	assert.Empty(t, pts.Spec.PriorityClassName, "priorityClassName should be unset by default")
 }
 
 func TestBuildValkeyNodePodTemplateSpec_TopologySpreadConstraints(t *testing.T) {


### PR DESCRIPTION
This PR closes #269

### Summary

Adds `spec.priorityClassName` to `ValkeyCluster` and `ValkeyNode`, following the shape proposed in the issue discussion: setting it on the cluster trickles down to every `ValkeyNode` and from there into the pod template, so cluster pods can reference a `PriorityClass` and be protected from kubelet eviction under resource pressure.

The operator's own Deployment is intentionally out of scope, per the discussion — that belongs in the valkey-helm chart.

### Features / Behaviour Changes

- New optional `ValkeyCluster.Spec.PriorityClassName` — applied to every pod in the cluster.
- New optional `ValkeyNode.Spec.PriorityClassName` — applied to the node's pod template.
- Both default to empty (no `PriorityClass`), so existing clusters are unaffected.
- Adding/changing the value on a running cluster rolls the pods via the normal StatefulSet rolling update.

### Implementation

- `buildClusterValkeyNode` copies `cluster.Spec.PriorityClassName` into the `ValkeyNode` spec, alongside the other scheduling fields (`NodeSelector`, `Affinity`, `Tolerations`).
- `buildValkeyNodePodTemplateSpec` passes `node.Spec.PriorityClassName` through to `PodSpec.PriorityClassName`.
- CRD manifests regenerated with `make manifests generate`.
- `docs/valkeycluster.md` scheduling section updated.

### Limitations

- No admission validation that the referenced `PriorityClass` exists; if it doesn't, pod creation fails at admission with a clear error from the API server (same behaviour as vanilla workloads).
- Operator Deployment `priorityClassName` is left to the helm chart (see issue discussion).

### Testing

- `make test` — full envtest suite passes.
- `make lint` — 0 issues.
- New unit tests:
  - `TestBuildValkeyNodePodTemplateSpec_Scheduling` extended to cover `priorityClassName` pass-through, plus a new default-empty test.
  - `buildClusterValkeyNode` tests covering cluster→node trickle-down and the unset case.
- Verified end-to-end on a 3-node Kind cluster (operator image built from this branch):
  - `ValkeyCluster` with `shards: 3, replicas: 1` and `priorityClassName: valkey-high-priority`: all 6 `ValkeyNode` CRs, StatefulSet pod templates, and running pods carry the `PriorityClass` with resolved priority `1000000`; cluster reaches `Ready=True (ClusterHealthy)`.
  - Control cluster without the field: everything stays `<none>`, `Ready=True`.
  - Day-2: patching `priorityClassName` onto the running control cluster rolled the pod, which came back `Running` with the new priority.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
