### PR TITLE
fix(pdb): correct test assertions, pdbName call, and update docs

### DIFF
--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -113,12 +113,12 @@ When `persistence` is set, the operator manages a PVC for each ValkeyNode. With 
 podDisruptionBudget: Managed  # default
 ```
 
-The operator creates a `PodDisruptionBudget` with `maxUnavailable: 1` selecting all pods in the cluster. Set to `Disabled` when the PDB is managed externally or is not required.
+The operator creates a per-shard `PodDisruptionBudget` with `minAvailable: 1` selecting pods belonging to that shard. Set to `Disabled` when the PDB is managed externally or is not required.
 
 | Value | Behaviour |
 |---|---|
-| `Managed` | Operator creates and owns the PDB |
-| `Disabled` | Operator deletes the PDB if it exists and does not recreate it |
+| `Managed` | Operator creates and owns one PDB per shard |
+| `Disabled` | Operator deletes all per-shard PDBs if they exist and does not recreate them |
 
 ### Graceful shutdown
 

--- a/internal/controller/valkeycluster_pdb.go
+++ b/internal/controller/valkeycluster_pdb.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -31,53 +32,190 @@ import (
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
 )
 
-func pdbName(cluster *valkeyiov1alpha1.ValkeyCluster) string {
-	return resourcePrefix + cluster.Name
+const appInstanceLabel = "app.kubernetes.io/instance"
+
+func pdbName(cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex int) string {
+	return fmt.Sprintf("%s%s-%d", resourcePrefix, cluster.Name, shardIndex)
 }
 
-func (r *ValkeyClusterReconciler) reconcilePodDisruptionBudget(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) error {
+func (r *ValkeyClusterReconciler) reconcilePodDisruptionBudget(
+	ctx context.Context,
+	cluster *valkeyiov1alpha1.ValkeyCluster,
+) error {
+	// Remove the legacy cluster-wide PDB created by older operator versions.
+	legacyPDB := &policyv1.PodDisruptionBudget{}
+	legacyPDBName := resourcePrefix + cluster.Name
+
+	err := r.Get(
+		ctx,
+		client.ObjectKey{
+			Name:      legacyPDBName,
+			Namespace: cluster.Namespace,
+		},
+		legacyPDB,
+	)
+	switch {
+	case err == nil:
+		if metav1.IsControlledBy(legacyPDB, cluster) {
+			if err := r.Delete(ctx, legacyPDB); err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("deleting legacy PodDisruptionBudget %q: %w", legacyPDB.Name, err)
+			}
+
+			r.Recorder.Eventf(
+				cluster,
+				legacyPDB,
+				corev1.EventTypeNormal,
+				"PodDisruptionBudgetDeleted",
+				"DeletePodDisruptionBudget",
+				"Deleted legacy cluster-wide PodDisruptionBudget",
+			)
+		}
+	case apierrors.IsNotFound(err):
+		// Nothing to migrate.
+	default:
+		return fmt.Errorf("getting legacy PodDisruptionBudget %q: %w", legacyPDBName, err)
+	}
+
+	// List all PDBs belonging to this ValkeyCluster instance.
+	existingPDBs := &policyv1.PodDisruptionBudgetList{}
+	if err := r.List(
+		ctx,
+		existingPDBs,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{
+			appInstanceLabel: cluster.Name,
+		},
+	); err != nil {
+		return fmt.Errorf("listing PodDisruptionBudgets: %w", err)
+	}
+
 	if cluster.Spec.PodDisruptionBudget == valkeyiov1alpha1.PDBPolicyDisabled {
-		pdb := &policyv1.PodDisruptionBudget{}
-		err := r.Get(ctx, client.ObjectKey{Name: pdbName(cluster), Namespace: cluster.Namespace}, pdb)
-		if apierrors.IsNotFound(err) {
-			return nil
+		for i := range existingPDBs.Items {
+			pdb := &existingPDBs.Items[i]
+
+			if !metav1.IsControlledBy(pdb, cluster) {
+				continue
+			}
+
+			if err := r.Delete(ctx, pdb); err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("deleting PodDisruptionBudget %q: %w", pdb.Name, err)
+			}
+
+			r.Recorder.Eventf(
+				cluster,
+				pdb,
+				corev1.EventTypeNormal,
+				"PodDisruptionBudgetDeleted",
+				"DeletePodDisruptionBudget",
+				"Deleted PodDisruptionBudget %q",
+				pdb.Name,
+			)
 		}
-		if err != nil {
-			return fmt.Errorf("getting PDB for deletion: %w", err)
-		}
-		if err := r.Delete(ctx, pdb); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("deleting PDB: %w", err)
-		}
-		r.Recorder.Eventf(cluster, pdb, corev1.EventTypeNormal, "PodDisruptionBudgetDeleted", "DeletePodDisruptionBudget", "Deleted PodDisruptionBudget")
+
 		return nil
 	}
 
-	maxUnavailable := intstr.FromInt32(1)
-	existing := &policyv1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pdbName(cluster),
-			Namespace: cluster.Namespace,
-		},
+	desiredShards := int(cluster.Spec.Shards)
+
+	// Remove per-shard PDBs whose shard no longer exists after scale-in.
+	for i := range existingPDBs.Items {
+		pdb := &existingPDBs.Items[i]
+
+		if !metav1.IsControlledBy(pdb, cluster) {
+			continue
+		}
+
+		shardLabel, ok := pdb.Labels[LabelShardIndex]
+		if !ok {
+			continue
+		}
+
+		shardIndex, err := strconv.Atoi(shardLabel)
+		if err != nil {
+			return fmt.Errorf(
+				"parsing shard index label %q on PodDisruptionBudget %q: %w",
+				shardLabel,
+				pdb.Name,
+				err,
+			)
+		}
+
+		if shardIndex >= 0 && shardIndex < desiredShards {
+			continue
+		}
+
+		if err := r.Delete(ctx, pdb); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf(
+				"deleting PodDisruptionBudget %q for stale shard %d: %w",
+				pdb.Name,
+				shardIndex,
+				err,
+			)
+		}
+
+		r.Recorder.Eventf(
+			cluster,
+			pdb,
+			corev1.EventTypeNormal,
+			"PodDisruptionBudgetDeleted",
+			"DeletePodDisruptionBudget",
+			"Deleted PodDisruptionBudget for stale shard %d",
+			shardIndex,
+		)
 	}
-	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
-		existing.Labels = labels(cluster)
-		existing.Spec.MaxUnavailable = &maxUnavailable
-		existing.Spec.MinAvailable = nil
-		existing.Spec.Selector = &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				LabelCluster: cluster.Name,
+
+	minAvailable := intstr.FromInt32(1)
+
+	for shardIndex := range desiredShards {
+		existing := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pdbName(cluster, shardIndex),
+				Namespace: cluster.Namespace,
 			},
 		}
-		return controllerutil.SetControllerReference(cluster, existing, r.Scheme)
-	})
-	if err != nil {
-		return fmt.Errorf("upserting PDB: %w", err)
+
+		result, err := controllerutil.CreateOrUpdate(ctx, r.Client, existing, func() error {
+			existing.Labels = labels(cluster)
+			existing.Labels[LabelShardIndex] = strconv.Itoa(shardIndex)
+
+			existing.Spec.MinAvailable = &minAvailable
+			existing.Spec.MaxUnavailable = nil
+			existing.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					LabelCluster:    cluster.Name,
+					LabelShardIndex: strconv.Itoa(shardIndex),
+				},
+			}
+
+			return controllerutil.SetControllerReference(cluster, existing, r.Scheme)
+		})
+		if err != nil {
+			return fmt.Errorf("upserting PodDisruptionBudget for shard %d: %w", shardIndex, err)
+		}
+
+		switch result {
+		case controllerutil.OperationResultCreated:
+			r.Recorder.Eventf(
+				cluster,
+				existing,
+				corev1.EventTypeNormal,
+				"PodDisruptionBudgetCreated",
+				"CreatePodDisruptionBudget",
+				"Created PodDisruptionBudget for shard %d",
+				shardIndex,
+			)
+		case controllerutil.OperationResultUpdated:
+			r.Recorder.Eventf(
+				cluster,
+				existing,
+				corev1.EventTypeNormal,
+				"PodDisruptionBudgetUpdated",
+				"UpdatePodDisruptionBudget",
+				"Updated PodDisruptionBudget for shard %d",
+				shardIndex,
+			)
+		}
 	}
-	switch result {
-	case controllerutil.OperationResultCreated:
-		r.Recorder.Eventf(cluster, existing, corev1.EventTypeNormal, "PodDisruptionBudgetCreated", "CreatePodDisruptionBudget", "Created PodDisruptionBudget")
-	case controllerutil.OperationResultUpdated:
-		r.Recorder.Eventf(cluster, existing, corev1.EventTypeNormal, "PodDisruptionBudgetUpdated", "UpdatePodDisruptionBudget", "Updated PodDisruptionBudget")
-	}
+
 	return nil
 }

--- a/internal/controller/valkeycluster_pdb_test.go
+++ b/internal/controller/valkeycluster_pdb_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
@@ -58,7 +59,7 @@ var _ = Describe("reconcilePodDisruptionBudget", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
-		pdbKey = types.NamespacedName{Name: pdbName(cluster), Namespace: cluster.Namespace}
+		pdbKey = types.NamespacedName{Name: pdbName(cluster, 0), Namespace: cluster.Namespace}
 
 		DeferCleanup(func() {
 			_ = k8sClient.Delete(ctx, cluster)
@@ -79,9 +80,10 @@ var _ = Describe("reconcilePodDisruptionBudget", func() {
 			pdb := &policyv1.PodDisruptionBudget{}
 			Expect(k8sClient.Get(ctx, pdbKey, pdb)).To(Succeed())
 
-			maxUnavailable := intstr.FromInt32(1)
-			Expect(pdb.Spec.MaxUnavailable).To(Equal(&maxUnavailable))
+			minAvailable := intstr.FromInt32(1)
+			Expect(pdb.Spec.MinAvailable).To(Equal(&minAvailable))
 			Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(LabelCluster, cluster.Name))
+			Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(LabelShardIndex, "0"))
 		})
 
 		It("recreates the PDB if it is externally deleted", func() {
@@ -141,6 +143,38 @@ var _ = Describe("reconcilePodDisruptionBudget", func() {
 			err = k8sClient.Get(ctx, pdbKey, pdb)
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+	})
+
+	Context("when old-style PDB exists (without shard index)", func() {
+		It("deletes the old-style PDB and creates a new per-shard PDB", func() {
+			// Create an old-style PDB manually with controller reference
+			oldPdb := &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourcePrefix + cluster.Name,
+					Namespace: cluster.Namespace,
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: func() *intstr.IntOrString { v := intstr.FromInt32(1); return &v }(),
+				},
+			}
+			Expect(controllerutil.SetControllerReference(cluster, oldPdb, reconciler.Scheme)).To(Succeed())
+			Expect(k8sClient.Create(ctx, oldPdb)).To(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Old-style PDB should be deleted
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: resourcePrefix + cluster.Name, Namespace: cluster.Namespace}, oldPdb)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+			// New per-shard PDB should exist
+			newPdb := &policyv1.PodDisruptionBudget{}
+			Expect(k8sClient.Get(ctx, pdbKey, newPdb)).To(Succeed())
+			Expect(newPdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue(LabelShardIndex, "0"))
 		})
 	})
 })


### PR DESCRIPTION
This PR closes <Issue #303 >

### Summary


- Fix pdbName call in test to include shardIndex argument
- Change test expectation from MaxUnavailable to MinAvailable
- Add assertion for LabelShardIndex selector in PDB test
- Update docs/valkeycluster.md to describe per-shard PDB with minAvailable: 1 instead of maxUnavailable: 1



### Features / Behaviour Changes


Instead of creating a single cluster-wide PodDisruptionBudget, create one PDB per shard.
use minAvailable: 1 isnstead of maxUnvailable


### Implementation

<!--
Describe the implementation details. Highlight key code changes and call out any areas where you want reviewers to pay extra attention
-->

### Limitations

It is an improvement. Next step is to make pdbs configurable 

### Testing

All tests done

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
