### PR TITLE
fix: allow _replication user to apply atomic slot migration

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -71,6 +71,9 @@ var (
 		replicationUser: strings.Join([]string{
 			"-@all +psync +replconf +ping", // the ACL rawstring for replication is taken from Valkey documentation: https://valkey.io/topics/acl/#acl-rules-for-sentinel-and-replicas
 			"+cluster|syncslots",           // required for atomic slot migration
+			// Today, Atomic slot migration streams the snapshot as a command stream
+			// (SELECT + type-specific write commands from the AOF-rewrite)
+			"+select +@write ~*",
 		}, " "),
 	}
 )

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -73,7 +73,7 @@ var (
 			"+cluster|syncslots",           // required for atomic slot migration
 			// Today, Atomic slot migration streams the snapshot as a command stream
 			// (SELECT + type-specific write commands from the AOF-rewrite)
-			"+select +@write ~*",
+			"+select +@write ~* -flushall -flushdb -swapdb",
 		}, " "),
 	}
 )

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -554,6 +554,7 @@ spec:
 		It("rebalances slots on scale out", func() {
 			const baseShards = 2
 			const scaleOutShards = 3
+			const seedKeys = 500
 			valkeyClusterName = "valkeycluster-scaleout"
 
 			By("creating a smaller ValkeyCluster for scale-out")
@@ -602,10 +603,10 @@ spec:
 
 				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "--",
 					"sh", "-c",
-					"awk 'BEGIN{for(i=1;i<=500;i++) print \"SET key:\"i\" val:\"i}' | valkey-cli -c -h 127.0.0.1 >/dev/null && valkey-cli -c -h 127.0.0.1 DBSIZE")
+					fmt.Sprintf("unset VALKEYCLI_AUTH REDISCLI_AUTH; awk 'BEGIN{for(i=1;i<=%d;i++) print \"SET key:\"i\" val:\"i}' | valkey-cli -c -h 127.0.0.1 | grep -c '^OK$'", seedKeys))
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(strings.TrimSpace(output)).NotTo(Equal("0"), "Expected keys to be written across slots")
+				g.Expect(strings.TrimSpace(output)).To(Equal(fmt.Sprintf("%d", seedKeys)), "all seed writes should succeed across shards")
 			}
 			Eventually(seedData).Should(Succeed())
 
@@ -654,6 +655,24 @@ spec:
 				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
 			}
 			Eventually(verifyScaledOut).Should(Succeed())
+
+			By("verifying all seeded keys remain readable after slot migration")
+			verifySeededData := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", valkeyClusterName),
+					"-o", "jsonpath={.items[0].metadata.name}")
+				podName, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(podName)).NotTo(BeEmpty(), "Expected a valkey pod")
+
+				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "--",
+					"sh", "-c",
+					fmt.Sprintf("unset VALKEYCLI_AUTH REDISCLI_AUTH; awk 'BEGIN{for(i=1;i<=%d;i++) print \"GET key:\"i}' | valkey-cli -c -h 127.0.0.1 | grep -c '^val:'", seedKeys))
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(output)).To(Equal(fmt.Sprintf("%d", seedKeys)), "all seeded keys should survive after rebalance")
+			}
+			Eventually(verifySeededData).Should(Succeed())
 		})
 
 		It("drains slots on scale in", func() {

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -589,6 +589,26 @@ spec:
 			}
 			Eventually(verifyReadyForScaleOut, 10*time.Minute).Should(Succeed())
 
+			By("populating the cluster with data so slot migration snapshots real keys")
+			// the _replication user must be allowed to run SELECT and write commands
+			// or the slot migration will loop forever.
+			seedData := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "pods",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", valkeyClusterName),
+					"-o", "jsonpath={.items[0].metadata.name}")
+				podName, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(podName)).NotTo(BeEmpty(), "Expected a valkey pod")
+
+				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "--",
+					"sh", "-c",
+					"awk 'BEGIN{for(i=1;i<=500;i++) print \"SET key:\"i\" val:\"i}' | valkey-cli -c -h 127.0.0.1 >/dev/null && valkey-cli -c -h 127.0.0.1 DBSIZE")
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(strings.TrimSpace(output)).NotTo(Equal("0"), "Expected keys to be written across slots")
+			}
+			Eventually(seedData).Should(Succeed())
+
 			By(fmt.Sprintf("scaling the cluster to %d shards", scaleOutShards))
 			cmd = exec.Command("kubectl", "patch", "valkeycluster", valkeyClusterName,
 				"--type=merge", "-p", fmt.Sprintf(`{"spec":{"shards":%d}}`, scaleOutShards))

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -601,7 +601,7 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(strings.TrimSpace(podName)).NotTo(BeEmpty(), "Expected a valkey pod")
 
-				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "--",
+				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "-c", "server", "--",
 					"sh", "-c",
 					fmt.Sprintf("unset VALKEYCLI_AUTH REDISCLI_AUTH; awk 'BEGIN{for(i=1;i<=%d;i++) print \"SET key:\"i\" val:\"i}' | valkey-cli -c -h 127.0.0.1 | grep -c '^OK$'", seedKeys))
 				output, err := utils.Run(cmd)
@@ -665,7 +665,7 @@ spec:
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(strings.TrimSpace(podName)).NotTo(BeEmpty(), "Expected a valkey pod")
 
-				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "--",
+				cmd = exec.Command("kubectl", "exec", strings.TrimSpace(podName), "-c", "server", "--",
 					"sh", "-c",
 					fmt.Sprintf("unset VALKEYCLI_AUTH REDISCLI_AUTH; awk 'BEGIN{for(i=1;i<=%d;i++) print \"GET key:\"i}' | valkey-cli -c -h 127.0.0.1 | grep -c '^val:'", seedKeys))
 				output, err := utils.Run(cmd)


### PR DESCRIPTION

this PR closes https://github.com/valkey-io/valkey-operator/issues/305

### Summary

Fixes an issue where resharding a Valkey cluster that already contains data can become stuck indefinitely during `Reconciling/RebalancingSlots`.

The root cause was that the internal `_replication` user did not have sufficient ACL permissions to apply the select, write commands generated during Valkey's atomic slot migration


### Implementation

- updated acl permissions required.


### Testing

tested locally on kind cluster

### Checklist

Before submitting the PR make sure the following are checked:

- [X] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [X] Tests are added or updated.
- [ ] Documentation files are updated.
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
