### PR TITLE
feat: apply ACL changes live without rolling pods

### DIFF
--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -190,6 +190,11 @@ const (
 	// of Spec.Config has been successfully applied via CONFIG SET. The cluster
 	// controller blocks one-at-a-time progress until this condition is True.
 	ValkeyNodeConditionLiveConfigApplied = "LiveConfigApplied"
+	// ValkeyNodeConditionACLApplied indicates that the ACL the cluster controller
+	// wrote to the mounted Secret is live on the server. It is applied via ACL
+	// LOAD without a pod roll, so ACL never enters Spec.WorkloadRevision. True
+	// means the desired user set and their password hashes are live.
+	ValkeyNodeConditionACLApplied = "ACLApplied"
 	// ValkeyNodeConditionWorkloadRollPending indicates a rolling pod-template update
 	// is intentionally deferred: the desired template differs from live, and
 	// Spec.WorkloadRevision has not yet authorized that template. Status True means

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -216,7 +216,7 @@ Common reasons when `ACLApplied=False`:
 Common reasons when `ACLApplied=True`:
 - `Applied` – the desired users and passwords are live.
 
-> **Note:** `ACLApplied` compares the user set and password hashes, which is what a password rotation waits on. It is informational and does not block the cluster controller's one-at-a-time progress. Permission changes are applied by the same unconditional `ACL LOAD`, so they converge on the running server as well.
+> **Note:** `ACLApplied` compares the user set and password hashes, which is what a password rotation waits on. It is informational and does not block the cluster controller's one-at-a-time progress. Permission changes are applied by the same unconditional `ACL LOAD`, so they converge on the running server as well. On a failed apply the node controller emits a `LiveACLApplyFailed` warning event and retries with backoff.
 
 #### `WorkloadRollPending`
 Indicates that a rolling pod-template update is intentionally deferred: the ValkeyNode controller has built a pod template that differs from the live StatefulSet or Deployment, but `spec.workloadRevision` has not yet authorized that template. This is expected staging while the cluster advances rolls one node at a time, not an error.
@@ -391,6 +391,7 @@ These events are emitted during ACL user management.
 | `InternalSecretsUpdated` | Normal | Internal ACL secret synchronized |
 | `InternalSecretsCreationFailed` | Warning | Failed to create or take ownership of internal ACL secret |
 | `InternalSecretsUpdateFailed` | Warning | Failed to update internal ACL secret |
+| `LiveACLApplyFailed` | Warning | `ACL LOAD` (or the follow-up verification) failed on a node; the `ACLApplied` condition is set to `False` |
 
 ### Viewing events
 

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -216,7 +216,9 @@ Common reasons when `ACLApplied=False`:
 Common reasons when `ACLApplied=True`:
 - `Applied` – the desired users and passwords are live.
 
-> **Note:** `ACLApplied` compares the user set and password hashes, which is what a password rotation waits on. It is informational and does not block the cluster controller's one-at-a-time progress. Permission changes are applied by the same unconditional `ACL LOAD`, so they converge on the running server as well. On a failed apply the node controller emits a `LiveACLApplyFailed` warning event and retries with backoff.
+> **Note:** `ACLApplied` compares the user set and password hashes exactly, which is what a password rotation waits on. It is informational and does not block the cluster controller's one-at-a-time progress. On a failed apply the node controller emits a `LiveACLApplyFailed` warning event and retries with backoff.
+>
+> **Limitation:** Only the user set and password hashes drive the condition, so only those changes move it through `PendingPropagation` back to `True`: adding or removing a user or a password. A change to a user's `enabled` flag or permissions still takes effect on the server (the reload is unconditional), but the condition does not report a transient `PendingPropagation` for it, so it is not a signal to wait on for those fields. Comparing rules directly would mean reimplementing Valkey's normalized ACL rendering; making the condition track every field is left as a follow-up.
 
 #### `WorkloadRollPending`
 Indicates that a rolling pod-template update is intentionally deferred: the ValkeyNode controller has built a pod template that differs from the live StatefulSet or Deployment, but `spec.workloadRevision` has not yet authorized that template. This is expected staging while the cluster advances rolls one node at a time, not an error.

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -199,6 +199,25 @@ Common reasons when `LiveConfigApplied=True`:
 
 > **Note:** A `False` condition blocks one-at-a-time progress in the cluster controller (the same way `Ready=False` does during a rolling update). The node controller retries with exponential backoff and emits a `LiveConfigApplyFailed` warning event on each failure. The condition clears in either of two ways: once `CONFIG SET` succeeds it transitions to `True`, or if the offending key is removed from `spec.config` (leaving no allowlisted keys) the condition is removed and reverts to absent. Either way the cluster advances.
 
+#### `ACLApplied`
+Indicates whether the ACL the cluster controller wrote for `spec.users` is live on the running Valkey process. The ACL is applied with `ACL LOAD` on the mounted aclfile, so an ACL change takes effect without a pod roll and does not enter `spec.workloadRevision`.
+
+This condition is set once the node is ready and mounts an ACL Secret. An edit reads `False` until the mounted aclfile refreshes (the projected Secret volume is updated lazily by kubelet) and the server loads it.
+
+| Status | Meaning |
+|---|---|
+| `True` | The desired user set and their password hashes are live on the server. |
+| `False` | The reload ran but the running ACL does not yet match the desired users and passwords (for example the mounted aclfile has not refreshed yet), or the reload failed. |
+
+Common reasons when `ACLApplied=False`:
+- `PendingPropagation` – the reload read a stale mounted aclfile; the node retries until the projected volume catches up.
+- `ApplyFailed` – `ACL LOAD` or the follow-up read returned an error. The message field contains the exact error.
+
+Common reasons when `ACLApplied=True`:
+- `Applied` – the desired users and passwords are live.
+
+> **Note:** `ACLApplied` compares the user set and password hashes, which is what a password rotation waits on. It is informational and does not block the cluster controller's one-at-a-time progress. Permission changes are applied by the same unconditional `ACL LOAD`, so they converge on the running server as well.
+
 #### `WorkloadRollPending`
 Indicates that a rolling pod-template update is intentionally deferred: the ValkeyNode controller has built a pod template that differs from the live StatefulSet or Deployment, but `spec.workloadRevision` has not yet authorized that template. This is expected staging while the cluster advances rolls one node at a time, not an error.
 
@@ -212,7 +231,7 @@ The ValkeyCluster controller owns `spec.workloadRevision` (a hash of the fully b
 Common reasons when `WorkloadRollPending=True`:
 - `AwaitingWorkloadRevision` – waiting for the ValkeyCluster controller to set `spec.workloadRevision` to the desired template hash.
 
-> **Note:** First-time backfill of an empty `spec.workloadRevision` (operator upgrade onto this feature) is bookkeeping only and does not fail over primaries. A non-empty revision change (for example after an ACL secret hash or image-driven template change) is staged like any other Spec roll.
+> **Note:** First-time backfill of an empty `spec.workloadRevision` (operator upgrade onto this feature) is bookkeeping only and does not fail over primaries. A non-empty revision change (for example an image-driven template change) is staged like any other Spec roll. ACL edits do not change the template and are applied live instead (see [`ACLApplied`](#aclapplied)).
 
 Example commands:
 

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -352,6 +352,8 @@ users:
 - `channels` — pub/sub channel patterns
 - `permissions` — raw ACL string appended after any generated rules
 
+ACL changes are applied to running nodes with `ACL LOAD` (no pod restart), the same way live-settable config is applied without rolling pods. Each node reports an [`ACLApplied`](status-conditions.md#aclapplied) condition once the change is live on the server.
+
 #### Constraints
 
 - Usernames cannot start with `_` (reserved for operator-managed system users)

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -354,6 +354,8 @@ users:
 
 ACL changes are applied to running nodes with `ACL LOAD` (no pod restart), the same way live-settable config is applied without rolling pods. Each node reports an [`ACLApplied`](status-conditions.md#aclapplied) condition once the change is live on the server.
 
+> **Upgrade note:** Live application relies on the operator's `_operator` user holding the `acl|load`, `acl|getuser`, and `acl|users` commands, which older operator versions did not grant. Upgrading onto this version rewrites the pod template (it drops a now-unused annotation), so every existing cluster rolls once and picks up the new grants on restart, after which ACL changes apply live. The exception is a cluster old enough to predate that annotation entirely: it gets no automatic roll, so it needs a one-time manual pod restart after the upgrade before live ACL applies.
+
 #### Constraints
 
 - Usernames cannot start with `_` (reserved for operator-managed system users)

--- a/internal/controller/failover.go
+++ b/internal/controller/failover.go
@@ -180,7 +180,7 @@ func needsProactiveFailoverForRoll(current, desired *valkeyiov1alpha1.ValkeyNode
 // matches) does not qualify.
 //
 // liveTemplateHashes maps ValkeyNode name -> hash of live pod template.
-func anyNodeRequiresFailoverAwareRoll(cluster *valkeyiov1alpha1.ValkeyCluster, nodeList *valkeyiov1alpha1.ValkeyNodeList, configHash string, aclSecret *corev1.Secret, liveTemplateHashes map[string]string) bool {
+func anyNodeRequiresFailoverAwareRoll(cluster *valkeyiov1alpha1.ValkeyCluster, nodeList *valkeyiov1alpha1.ValkeyNodeList, configHash string, liveTemplateHashes map[string]string) bool {
 	byName := make(map[string]*valkeyiov1alpha1.ValkeyNode, len(nodeList.Items))
 	for i := range nodeList.Items {
 		byName[nodeList.Items[i].Name] = &nodeList.Items[i]
@@ -190,7 +190,7 @@ func anyNodeRequiresFailoverAwareRoll(cluster *valkeyiov1alpha1.ValkeyCluster, n
 		for nodeIndex := range nodesPerShard {
 			desired := buildClusterValkeyNode(cluster, shardIndex, nodeIndex)
 			desired.Spec.ServerConfigHash = configHash
-			if err := setDesiredWorkloadRevision(desired, aclSecret); err != nil {
+			if err := setDesiredWorkloadRevision(desired); err != nil {
 				return true
 			}
 			if current, ok := byName[desired.Name]; ok {

--- a/internal/controller/failover_test.go
+++ b/internal/controller/failover_test.go
@@ -184,7 +184,7 @@ func TestAnyNodeRequiresFailoverAwareRoll(t *testing.T) {
 	steadyStateNode := func() valkeyiov1alpha1.ValkeyNode {
 		n := buildClusterValkeyNode(cluster, 0, 0)
 		n.Spec.ServerConfigHash = configHash
-		require.NoError(t, setDesiredWorkloadRevision(n, nil))
+		require.NoError(t, setDesiredWorkloadRevision(n))
 		n.Status.PodIP = "10.0.0.1"
 		return *n
 	}
@@ -193,7 +193,7 @@ func TestAnyNodeRequiresFailoverAwareRoll(t *testing.T) {
 		n := steadyStateNode()
 		nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{n}}
 		live := map[string]string{n.Name: n.Spec.WorkloadRevision}
-		assert.False(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, nil, live))
+		assert.False(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, live))
 	})
 
 	t.Run("empty WorkloadRevision backfill when live matches does not need failover-aware roll", func(t *testing.T) {
@@ -202,11 +202,11 @@ func TestAnyNodeRequiresFailoverAwareRoll(t *testing.T) {
 		n.Spec.WorkloadRevision = ""
 		nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{n}}
 		live := map[string]string{n.Name: authorized}
-		assert.False(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, nil, live))
+		assert.False(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, live))
 		assert.True(t, nodeRequiresRoll(&n, func() *valkeyiov1alpha1.ValkeyNode {
 			d := buildClusterValkeyNode(cluster, 0, 0)
 			d.Spec.ServerConfigHash = configHash
-			require.NoError(t, setDesiredWorkloadRevision(d, nil))
+			require.NoError(t, setDesiredWorkloadRevision(d))
 			return d
 		}()))
 	})
@@ -217,21 +217,21 @@ func TestAnyNodeRequiresFailoverAwareRoll(t *testing.T) {
 		nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{n}}
 		// Live still on an older template (e.g. ACL hash change before backfill).
 		live := map[string]string{n.Name: "old-live-template-hash"}
-		assert.True(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, nil, live))
+		assert.True(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, live))
 	})
 
 	t.Run("stale config hash needs failover-aware roll", func(t *testing.T) {
 		n := steadyStateNode()
 		n.Spec.ServerConfigHash = "stale"
 		nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{n}}
-		assert.True(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, nil, nil))
+		assert.True(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, nil))
 	})
 
 	t.Run("stale WorkloadRevision needs failover-aware roll", func(t *testing.T) {
 		n := steadyStateNode()
 		n.Spec.WorkloadRevision = "not-the-real-hash"
 		nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{n}}
-		assert.True(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, nil, nil))
+		assert.True(t, anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, nil))
 	})
 }
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -64,6 +64,9 @@ var (
 			"+cluster|set-config-epoch",  // set epoch on new nodes
 			"+config|set",                // apply live config changes
 			"+config|get",                // verify applied config / audit current state
+			"+acl|load",                  // reload the aclfile live to apply ACL changes without a pod roll
+			"+acl|getuser",               // read back a user's password hashes to verify the reload landed
+			"+acl|users",                 // read the user set to verify membership after a reload
 			"+info",                      // node info and replication status
 			"+role",                      // current replication role
 		}, " "),

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -548,18 +548,6 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	nodesPerShard := 1 + int(cluster.Spec.Replicas)
 	totalCreated := 0
 
-	// One ACL secret snapshot for preflight and per-node WorkloadRevision so the
-	// scrape decision and authorized hash cannot disagree mid-reconcile.
-	aclSecret, err := r.getClusterACLSecret(ctx, cluster)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("get ACL secret for workload revision: %w", err)
-		}
-		// Bootstrap: secret may not exist yet; hash without ACL annotations.
-		log.V(1).Info("ACL secret not ready for roll preflight, hashing without it", "err", err)
-		aclSecret = nil
-	}
-
 	// Scrape cluster state once for proactive failover decisions, but only
 	// when at least one node needs a failover-aware roll. During initial
 	// bootstrap no nodes exist, so state stays nil. The snapshot is safe to
@@ -571,7 +559,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 	if err != nil {
 		return false, err
 	}
-	if anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, aclSecret, liveHashes) {
+	if anyNodeRequiresFailoverAwareRoll(cluster, nodes, configHash, liveHashes) {
 		operatorPassword, err := fetchSystemUserPassword(ctx, operatorUser, r.Client, cluster.Name, cluster.Namespace)
 		if err != nil {
 			return false, fmt.Errorf("failed to fetch operator password for proactive failover: %w", err)
@@ -593,7 +581,7 @@ func (r *ValkeyClusterReconciler) reconcileValkeyNodes(ctx context.Context, clus
 		// actual primary (which may differ from node-index=0 after a failover)
 		// and place it last.
 		for _, nodeIndex := range replicaFirstNodeOrder(shardIndex, nodesPerShard, nodes, clusterState) {
-			result, err := r.reconcileValkeyNode(ctx, cluster, shardIndex, nodeIndex, clusterState, configHash, aclSecret, liveHashes)
+			result, err := r.reconcileValkeyNode(ctx, cluster, shardIndex, nodeIndex, clusterState, configHash, liveHashes)
 			if err != nil {
 				return false, err
 			}
@@ -634,14 +622,14 @@ const (
 
 // reconcileValkeyNode reconciles a single ValkeyNode for (shardIndex, nodeIndex).
 // Returns a nodeResult signaling the outcome or required next action.
-// aclSecret and liveTemplateHashes are the reconcileValkeyNodes snapshot so
-// WorkloadRevision and failover decisions stay consistent for the whole pass.
-func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex, nodeIndex int, clusterState *valkey.ClusterState, configHash string, aclSecret *corev1.Secret, liveTemplateHashes map[string]string) (nodeResult, error) {
+// liveTemplateHashes is the reconcileValkeyNodes snapshot so WorkloadRevision
+// and failover decisions stay consistent for the whole pass.
+func (r *ValkeyClusterReconciler) reconcileValkeyNode(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, shardIndex, nodeIndex int, clusterState *valkey.ClusterState, configHash string, liveTemplateHashes map[string]string) (nodeResult, error) {
 	log := logf.FromContext(ctx)
 
 	desired := buildClusterValkeyNode(cluster, shardIndex, nodeIndex)
 	desired.Spec.ServerConfigHash = configHash
-	if err := setDesiredWorkloadRevision(desired, aclSecret); err != nil {
+	if err := setDesiredWorkloadRevision(desired); err != nil {
 		return nodeUnchanged, err
 	}
 
@@ -806,16 +794,6 @@ func (r *ValkeyClusterReconciler) livePodTemplateHash(ctx context.Context, node 
 		}
 		return podTemplateRollHash(sts.Spec.Template), nil
 	}
-}
-
-// getClusterACLSecret loads the cluster internal ACL secret used for template annotations.
-func (r *ValkeyClusterReconciler) getClusterACLSecret(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (*corev1.Secret, error) {
-	aclSecret := &corev1.Secret{}
-	name := getInternalSecretName(cluster.Name)
-	if err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: cluster.Namespace}, aclSecret); err != nil {
-		return nil, err
-	}
-	return aclSecret, nil
 }
 
 const (

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -1183,7 +1183,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 	}
 
 	It("creates the ValkeyNode and emits ValkeyNodeCreated event", func() {
-		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(nodeCreated))
 
@@ -1193,12 +1193,12 @@ var _ = Describe("reconcileValkeyNode", func() {
 	})
 
 	It("updates the ValkeyNode spec, emits ValkeyNodeUpdated event, and signals requeue", func() {
-		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		cluster.Spec.Image = "valkey/valkey:9.1.0"
-		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(nodeRequeued))
 
@@ -1207,31 +1207,31 @@ var _ = Describe("reconcileValkeyNode", func() {
 	})
 
 	It("signals requeue when node is unchanged but not yet ready", func() {
-		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		// Status.Ready defaults to false after creation
-		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(nodeRequeued))
 	})
 
 	It("does not requeue when node is unchanged and ready", func() {
-		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		collectEvents(fakeRecorder) // drain creation event
 
 		setNodeReady(true)
 
-		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(nodeUnchanged))
 	})
 
 	It("signals requeue when node is unchanged but ObservedGeneration is stale", func() {
 		// Create the node
-		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		_, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Mark ready but leave ObservedGeneration at 0
@@ -1246,7 +1246,7 @@ var _ = Describe("reconcileValkeyNode", func() {
 		// Because ObservedGeneration > 0 guard: newly created node with
 		// ObservedGeneration=0 falls through to the Ready check, which
 		// passes (Ready=true). No requeue.
-		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		result, err := r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(nodeUnchanged))
 
@@ -1261,13 +1261,13 @@ var _ = Describe("reconcileValkeyNode", func() {
 
 		// Change cluster spec to trigger an update on next reconcile
 		cluster.Spec.Image = "valkey/valkey:9.1.0"
-		result, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		result, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(nodeRequeued), "should requeue after updating node")
 
 		// Next reconcile: spec matches (OperationResultNone), but
 		// Generation (2) != ObservedGeneration (1) — must requeue.
-		result, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil, nil)
+		result, err = r.reconcileValkeyNode(testCtx, cluster, shardIndex, nodeIndex, nil, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(nodeRequeued), "should requeue while ObservedGeneration is stale")
 	})

--- a/internal/controller/valkeynode_acl.go
+++ b/internal/controller/valkeynode_acl.go
@@ -52,14 +52,14 @@ func desiredUserPasswordHashes(aclFile string) map[string][]string {
 				hashes = append(hashes, h)
 			}
 		}
-		out[fields[1]] = normaliseHashes(hashes)
+		out[fields[1]] = normalizeHashes(hashes)
 	}
 	return out
 }
 
-// normaliseHashes sorts and deduplicates password hashes so both sides of the
+// normalizeHashes sorts and deduplicates password hashes so both sides of the
 // comparison are in the same shape.
-func normaliseHashes(hashes []string) []string {
+func normalizeHashes(hashes []string) []string {
 	slices.Sort(hashes)
 	return slices.Compact(hashes)
 }
@@ -69,7 +69,7 @@ func normaliseHashes(hashes []string) []string {
 // hashes.
 //
 // Permissions are deliberately not compared. ACL GETUSER returns Valkey's
-// normalised rendering of the rules, while the operator only holds the aclfile
+// normalized rendering of the rules, while the operator only holds the aclfile
 // text, so comparing the two would mean reimplementing Valkey's own ACL parser
 // and keeping it in step with the server. Correctness of the apply does not
 // depend on this check either way: the reload is unconditional, so permission
@@ -116,7 +116,7 @@ func aclObservablyInSync(ctx context.Context, c valkeyConfigClient, desired map[
 //
 // The reload is therefore unconditional. The operator cannot read the pod's
 // copy of the file, and it cannot compare the whole ACL against the server
-// either (ACL GETUSER renders Valkey's normalised form, the operator holds
+// either (ACL GETUSER renders Valkey's normalized form, the operator holds
 // aclfile text), so there is no reliable way to know the file is current. A
 // repeated LOAD is idempotent and cheap, and it is what makes every kind of
 // change converge, including permission edits and removed users, once the

--- a/internal/controller/valkeynode_acl.go
+++ b/internal/controller/valkeynode_acl.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
+)
+
+// desiredUserPasswordHashes parses the aclfile the ValkeyCluster controller
+// builds into each user's SHA-256 password hashes, keyed by username. The file
+// is a sequence of "user <name> on #<hash> ... " lines (see buildUserAcl), so
+// the hashes are the '#'-prefixed tokens.
+//
+// Hashes are sorted and deduplicated. Order is not guaranteed by either side,
+// and Valkey keeps a user's passwords as a set: pointing two Secret keys at the
+// same password yields a repeated hash in the file but a single one back from
+// ACL GETUSER, which would otherwise never compare equal.
+func desiredUserPasswordHashes(aclFile string) map[string][]string {
+	out := map[string][]string{}
+	for line := range strings.SplitSeq(aclFile, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "user" {
+			continue
+		}
+		hashes := []string{}
+		for _, f := range fields[2:] {
+			if h, ok := strings.CutPrefix(f, "#"); ok {
+				hashes = append(hashes, h)
+			}
+		}
+		out[fields[1]] = normaliseHashes(hashes)
+	}
+	return out
+}
+
+// normaliseHashes sorts and deduplicates password hashes so both sides of the
+// comparison are in the same shape.
+func normaliseHashes(hashes []string) []string {
+	slices.Sort(hashes)
+	return slices.Compact(hashes)
+}
+
+// aclObservablyInSync reports whether the parts of the ACL that can be compared
+// exactly are live on the server: the set of users, and each user's password
+// hashes.
+//
+// Permissions are deliberately not compared. ACL GETUSER returns Valkey's
+// normalised rendering of the rules, while the operator only holds the aclfile
+// text, so comparing the two would mean reimplementing Valkey's own ACL parser
+// and keeping it in step with the server. Correctness of the apply does not
+// depend on this check either way: the reload is unconditional, so permission
+// edits converge regardless. This only scopes what ACLApplied can honestly
+// claim.
+func aclObservablyInSync(ctx context.Context, c valkeyConfigClient, desired map[string][]string) (bool, error) {
+	actualUsers, err := c.UserNames(ctx)
+	if err != nil {
+		return false, err
+	}
+	serverUsers := slices.Sorted(slices.Values(actualUsers))
+	// Valkey always keeps a `default` user of its own, and ACL LOAD cannot
+	// remove it. When the aclfile does not manage `default` (it is absent from
+	// spec.users), ignore the server's copy; otherwise the sets never match and
+	// the node loops forever reporting the ACL as not yet live.
+	if _, managed := desired["default"]; !managed {
+		serverUsers = slices.DeleteFunc(serverUsers, func(u string) bool { return u == "default" })
+	}
+	if !slices.Equal(serverUsers, slices.Sorted(maps.Keys(desired))) {
+		// A user was added or removed and the server has not picked it up yet.
+		return false, nil
+	}
+	for _, user := range slices.Sorted(maps.Keys(desired)) {
+		actual, err := c.UserPasswordHashes(ctx, user)
+		if err != nil {
+			return false, err
+		}
+		if !slices.Equal(actual, desired[user]) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// applyLiveACL reloads the mounted aclfile into the running server so ACL
+// changes take effect without a pod roll, and reports whether the desired
+// passwords are live yet.
+//
+// The aclfile is mounted read-only from the Secret, so ACL SAVE is neither
+// available nor needed: the Secret the cluster controller writes is what a
+// restarting pod loads. That leaves ACL LOAD as the live path, with one catch.
+// The projected volume is refreshed lazily by kubelet, so a LOAD fired right
+// after the Secret changes can read the pre-update file and silently no-op.
+//
+// The reload is therefore unconditional. The operator cannot read the pod's
+// copy of the file, and it cannot compare the whole ACL against the server
+// either (ACL GETUSER renders Valkey's normalised form, the operator holds
+// aclfile text), so there is no reliable way to know the file is current. A
+// repeated LOAD is idempotent and cheap, and it is what makes every kind of
+// change converge, including permission edits and removed users, once the
+// volume catches up.
+//
+// The returned bool reports the parts that can be compared exactly, the user
+// set and their password hashes, which is what a rotation needs to wait on.
+func (r *ValkeyNodeReconciler) applyLiveACL(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode) (bool, error) {
+	if node.Spec.UsersACLSecretName == "" {
+		return true, nil
+	}
+
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: node.Spec.UsersACLSecretName, Namespace: node.Namespace}
+	if err := r.APIReader.Get(ctx, key, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			// The cluster controller owns this Secret and has not created it
+			// yet. There is nothing to apply until it exists.
+			return true, nil
+		}
+		return false, fmt.Errorf("get ACL secret %s: %w", key.Name, err)
+	}
+	desired := desiredUserPasswordHashes(string(secret.Data[aclFilename]))
+	if len(desired) == 0 {
+		return true, nil
+	}
+
+	c, err := r.newConfigClient(ctx, r, node)
+	if err != nil {
+		return false, err
+	}
+	defer c.Close()
+
+	if err := c.LoadACL(ctx); err != nil {
+		return false, err
+	}
+	return aclObservablyInSync(ctx, c, desired)
+}

--- a/internal/controller/valkeynode_acl_test.go
+++ b/internal/controller/valkeynode_acl_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDesiredUserPasswordHashes(t *testing.T) {
+	acl := `user alice on #aaa #bbb ~* +@all
+user bob on #ccc ~key:* +get
+user nopass-user on nopass ~* +@read
+
+user _replication on #ddd -@all +psync +replconf +ping
+not-a-user-line whatever
+`
+	got := desiredUserPasswordHashes(acl)
+
+	assert.Equal(t, []string{"aaa", "bbb"}, got["alice"], "both hashes, sorted")
+	assert.Equal(t, []string{"ccc"}, got["bob"])
+	assert.Equal(t, []string{}, got["nopass-user"], "nopass user has no hashes")
+	assert.Equal(t, []string{"ddd"}, got["_replication"], "system users are parsed like any other")
+	assert.NotContains(t, got, "not-a-user-line", "lines that are not user entries are ignored")
+	assert.Len(t, got, 4)
+}
+
+func TestDesiredUserPasswordHashesDeduplicates(t *testing.T) {
+	// Two Secret keys holding the same password produce a repeated hash in the
+	// file, while Valkey reports it once. Without deduplication the comparison
+	// could never converge.
+	got := desiredUserPasswordHashes("user alice on #aaa #aaa #bbb ~* +@all\n")
+	assert.Equal(t, []string{"aaa", "bbb"}, got["alice"])
+}
+
+func TestDesiredUserPasswordHashesEmpty(t *testing.T) {
+	assert.Empty(t, desiredUserPasswordHashes(""))
+	assert.Empty(t, desiredUserPasswordHashes("\n\n"))
+}
+
+func TestACLObservablyInSync(t *testing.T) {
+	ctx := context.Background()
+	desired := map[string][]string{"alice": {"aaa", "bbb"}, "bob": {"ccc"}}
+
+	t.Run("server matches desired", func(t *testing.T) {
+		f := &fakeConfigClient{aclHashes: map[string][]string{"alice": {"aaa", "bbb"}, "bob": {"ccc"}}}
+		inSync, err := aclObservablyInSync(ctx, f, desired)
+		require.NoError(t, err)
+		assert.True(t, inSync)
+	})
+
+	t.Run("a rotated password the server has not loaded reads as out of sync", func(t *testing.T) {
+		f := &fakeConfigClient{aclHashes: map[string][]string{"alice": {"aaa"}, "bob": {"ccc"}}}
+		inSync, err := aclObservablyInSync(ctx, f, desired)
+		require.NoError(t, err)
+		assert.False(t, inSync)
+	})
+
+	t.Run("a user the server has not added yet reads as out of sync", func(t *testing.T) {
+		f := &fakeConfigClient{aclHashes: map[string][]string{"alice": {"aaa", "bbb"}}}
+		inSync, err := aclObservablyInSync(ctx, f, desired)
+		require.NoError(t, err)
+		assert.False(t, inSync)
+	})
+
+	t.Run("a user the server has not removed yet reads as out of sync", func(t *testing.T) {
+		f := &fakeConfigClient{aclHashes: map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"}, "removed": {"ddd"},
+		}}
+		inSync, err := aclObservablyInSync(ctx, f, desired)
+		require.NoError(t, err)
+		assert.False(t, inSync, "a user only the server still has must not read as in sync")
+	})
+
+	t.Run("the server's unmanaged default user is ignored", func(t *testing.T) {
+		// Valkey always has a `default` user of its own that ACL LOAD cannot
+		// remove. When the aclfile does not manage it, its presence on the server
+		// must not read as out of sync, or the node loops forever waiting.
+		f := &fakeConfigClient{aclHashes: map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"}, "default": {"zzz"},
+		}}
+		inSync, err := aclObservablyInSync(ctx, f, desired)
+		require.NoError(t, err)
+		assert.True(t, inSync, "an unmanaged default must not keep the node out of sync")
+	})
+
+	t.Run("a managed default is still compared", func(t *testing.T) {
+		// When the aclfile does manage default, it is compared like any other
+		// user: a default the server has not added yet reads as out of sync.
+		withDefault := map[string][]string{"alice": {"aaa", "bbb"}, "bob": {"ccc"}, "default": {"zzz"}}
+		f := &fakeConfigClient{aclHashes: map[string][]string{"alice": {"aaa", "bbb"}, "bob": {"ccc"}}}
+		inSync, err := aclObservablyInSync(ctx, f, withDefault)
+		require.NoError(t, err)
+		assert.False(t, inSync, "a managed default not yet on the server must read as out of sync")
+	})
+
+	t.Run("a password repeated in the aclfile still matches the server's set", func(t *testing.T) {
+		// Valkey stores passwords as a set, so pointing two Secret keys at the
+		// same password must not leave the node permanently out of sync.
+		dup := map[string][]string{"alice": normaliseHashes([]string{"aaa", "aaa"})}
+		f := &fakeConfigClient{aclHashes: map[string][]string{"alice": {"aaa"}}}
+		inSync, err := aclObservablyInSync(ctx, f, dup)
+		require.NoError(t, err)
+		assert.True(t, inSync)
+	})
+
+	t.Run("client errors surface", func(t *testing.T) {
+		f := &fakeConfigClient{aclErr: assert.AnError}
+		_, err := aclObservablyInSync(ctx, f, desired)
+		require.Error(t, err)
+	})
+}

--- a/internal/controller/valkeynode_acl_test.go
+++ b/internal/controller/valkeynode_acl_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestDesiredUserPasswordHashes(t *testing.T) {
-	acl := `user alice on #aaa #bbb ~* +@all
+	acl := `user alice on #bbb #aaa ~* +@all
 user bob on #ccc ~key:* +get
 user nopass-user on nopass ~* +@read
 

--- a/internal/controller/valkeynode_acl_test.go
+++ b/internal/controller/valkeynode_acl_test.go
@@ -114,7 +114,7 @@ func TestACLObservablyInSync(t *testing.T) {
 	t.Run("a password repeated in the aclfile still matches the server's set", func(t *testing.T) {
 		// Valkey stores passwords as a set, so pointing two Secret keys at the
 		// same password must not leave the node permanently out of sync.
-		dup := map[string][]string{"alice": normaliseHashes([]string{"aaa", "aaa"})}
+		dup := map[string][]string{"alice": normalizeHashes([]string{"aaa", "aaa"})}
 		f := &fakeConfigClient{aclHashes: map[string][]string{"alice": {"aaa"}}}
 		inSync, err := aclObservablyInSync(ctx, f, dup)
 		require.NoError(t, err)

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -115,9 +115,9 @@ func (rc *realValkeyConfigClient) UserPasswordHashes(ctx context.Context, userna
 	if err != nil {
 		return nil, fmt.Errorf("ACL GETUSER %s passwords: %w", username, err)
 	}
-	// Valkey keeps passwords as a set, but normalise anyway so both sides of
+	// Valkey keeps passwords as a set, but normalize anyway so both sides of
 	// the comparison are in the same shape.
-	return normaliseHashes(hashes), nil
+	return normalizeHashes(hashes), nil
 }
 
 func (rc *realValkeyConfigClient) Close() { rc.client.Close() }
@@ -377,9 +377,6 @@ func (r *ValkeyNodeReconciler) ensureWorkload(ctx context.Context, node *valkeyi
 	}
 }
 
-// buildPodTemplateAnnotations assembles the annotations that must be present on
-// the pod template spec to trigger rolling updates when the ACL secret or the
-// server config changes.
 // buildPodTemplateAnnotations assembles the annotations stamped on the pod
 // template, and therefore the ones that feed the WorkloadRevision roll hash.
 // Only the server-config hash lives here: a config change that is not

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -38,7 +38,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
 )
@@ -53,6 +55,15 @@ const (
 // fake (envtest has no running Valkey server).
 type valkeyConfigClient interface {
 	SetConfig(ctx context.Context, params map[string]string) error
+	// LoadACL reloads the mounted aclfile into the running server.
+	LoadACL(ctx context.Context) error
+	// UserNames returns the names of the users the server currently has.
+	UserNames(ctx context.Context) ([]string, error)
+	// UserPasswordHashes returns the user's currently configured password
+	// hashes, sorted and deduplicated. An unknown user yields an empty slice
+	// rather than an error, so a user that has not been loaded yet reads as out
+	// of sync.
+	UserPasswordHashes(ctx context.Context, username string) ([]string, error)
 	Close()
 }
 
@@ -70,6 +81,43 @@ func (rc *realValkeyConfigClient) SetConfig(ctx context.Context, params map[stri
 		return fmt.Errorf("CONFIG SET: %w", err)
 	}
 	return nil
+}
+
+func (rc *realValkeyConfigClient) LoadACL(ctx context.Context) error {
+	if err := rc.client.Do(ctx, rc.client.B().AclLoad().Build()).Error(); err != nil {
+		return fmt.Errorf("ACL LOAD: %w", err)
+	}
+	return nil
+}
+
+func (rc *realValkeyConfigClient) UserNames(ctx context.Context) ([]string, error) {
+	users, err := rc.client.Do(ctx, rc.client.B().AclUsers().Build()).AsStrSlice()
+	if err != nil {
+		return nil, fmt.Errorf("ACL USERS: %w", err)
+	}
+	return users, nil
+}
+
+func (rc *realValkeyConfigClient) UserPasswordHashes(ctx context.Context, username string) ([]string, error) {
+	m, err := rc.client.Do(ctx, rc.client.B().AclGetuser().Username(username).Build()).AsMap()
+	if err != nil {
+		if vclient.IsValkeyNil(err) {
+			// User is not defined on the server yet.
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("ACL GETUSER %s: %w", username, err)
+	}
+	passwords, ok := m["passwords"]
+	if !ok {
+		return []string{}, nil
+	}
+	hashes, err := passwords.AsStrSlice()
+	if err != nil {
+		return nil, fmt.Errorf("ACL GETUSER %s passwords: %w", username, err)
+	}
+	// Valkey keeps passwords as a set, but normalise anyway so both sides of
+	// the comparison are in the same shape.
+	return normaliseHashes(hashes), nil
 }
 
 func (rc *realValkeyConfigClient) Close() { rc.client.Close() }
@@ -99,6 +147,7 @@ type ValkeyNodeReconciler struct {
 // +kubebuilder:rbac:groups=valkey.io,resources=valkeynodes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=valkey.io,resources=valkeynodes/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
@@ -186,6 +235,36 @@ func (r *ValkeyNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
+	// Apply the ACL live too, before the WorkloadRollPending requeue: ACL is no
+	// longer part of the pod template (it does not enter Spec.WorkloadRevision),
+	// so a node waiting on a roll must still pick up ACL edits without one.
+	aclSynced, err := r.applyLiveACL(ctx, node)
+	if err != nil {
+		log.Error(err, "failed to apply live ACL")
+		r.Recorder.Eventf(node, nil, corev1.EventTypeWarning, "LiveACLApplyFailed", "ApplyLiveACL", "Failed to apply live ACL: %v", err)
+		if condErr := r.setACLCondition(ctx, node, metav1.ConditionFalse, "ApplyFailed", err.Error()); condErr != nil {
+			log.Error(condErr, "failed to set ACLApplied condition")
+		}
+		return ctrl.Result{}, err
+	}
+	if !aclSynced {
+		// The reload ran, but the mounted aclfile had not caught up with the
+		// Secret, so it loaded stale content. Report that rather than claiming
+		// the desired passwords are live, and reload again on the requeue.
+		log.V(1).Info("desired ACL passwords not live yet, waiting for the aclfile volume to propagate")
+		if condErr := r.setACLCondition(ctx, node, metav1.ConditionFalse, "PendingPropagation",
+			"Waiting for the mounted aclfile to reflect the desired ACL"); condErr != nil {
+			log.Error(condErr, "failed to set ACLApplied condition")
+			return ctrl.Result{}, condErr
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+	if condErr := r.setACLCondition(ctx, node, metav1.ConditionTrue, "Applied",
+		"Desired ACL passwords are live"); condErr != nil {
+		log.Error(condErr, "failed to set ACLApplied condition")
+		return ctrl.Result{}, condErr
+	}
+
 	// Waiting for Spec.WorkloadRevision: rely on watches when the cluster advances
 	// Spec, with a long backoff so waiters do not spam the API.
 	if meta.IsStatusConditionTrue(node.Status.Conditions, valkeyiov1alpha1.ValkeyNodeConditionWorkloadRollPending) {
@@ -215,6 +294,29 @@ func (r *ValkeyNodeReconciler) setLiveConfigCondition(ctx context.Context, node 
 	}
 	if err := r.Status().Patch(ctx, current, client.MergeFrom(patchBase)); err != nil {
 		return fmt.Errorf("patch LiveConfigApplied condition: %w", err)
+	}
+	return nil
+}
+
+// setACLCondition sets the ACLApplied condition, reporting whether the ACL the
+// cluster controller wrote to the mounted Secret is live on the server.
+func (r *ValkeyNodeReconciler) setACLCondition(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode, status metav1.ConditionStatus, reason, message string) error {
+	current := &valkeyiov1alpha1.ValkeyNode{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(node), current); err != nil {
+		return fmt.Errorf("get ValkeyNode: %w", err)
+	}
+	patchBase := current.DeepCopy()
+	if !meta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
+		Type:               valkeyiov1alpha1.ValkeyNodeConditionACLApplied,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: current.Generation,
+	}) {
+		return nil
+	}
+	if err := r.Status().Patch(ctx, current, client.MergeFrom(patchBase)); err != nil {
+		return fmt.Errorf("patch ACLApplied condition: %w", err)
 	}
 	return nil
 }
@@ -278,10 +380,15 @@ func (r *ValkeyNodeReconciler) ensureWorkload(ctx context.Context, node *valkeyi
 // buildPodTemplateAnnotations assembles the annotations that must be present on
 // the pod template spec to trigger rolling updates when the ACL secret or the
 // server config changes.
-func buildPodTemplateAnnotations(node *valkeyiov1alpha1.ValkeyNode, aclSecret *corev1.Secret) map[string]string {
-	annotations := map[string]string{
-		hashAnnotationKey: aclSecret.Annotations[hashAnnotationKey],
-	}
+// buildPodTemplateAnnotations assembles the annotations stamped on the pod
+// template, and therefore the ones that feed the WorkloadRevision roll hash.
+// Only the server-config hash lives here: a config change that is not
+// live-settable still needs a rolling restart to take effect. The ACL hash is
+// deliberately absent. ACL edits are applied to the running server live by the
+// ValkeyNode reconciler (see applyLiveACL), so they must not enter the
+// WorkloadRevision and roll the pods.
+func buildPodTemplateAnnotations(node *valkeyiov1alpha1.ValkeyNode) map[string]string {
+	annotations := map[string]string{}
 	if node.Spec.ServerConfigHash != "" {
 		annotations[configHashKey] = node.Spec.ServerConfigHash
 	}
@@ -295,11 +402,7 @@ func (r *ValkeyNodeReconciler) ensureStatefulSet(ctx context.Context, node *valk
 	if err != nil {
 		return err
 	}
-	aclSecret, err := r.getACLSecret(ctx, desired.Labels[LabelCluster], desired.Namespace)
-	if err != nil {
-		return err
-	}
-	desired.Spec.Template.Annotations = buildPodTemplateAnnotations(node, aclSecret)
+	desired.Spec.Template.Annotations = buildPodTemplateAnnotations(node)
 
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -364,11 +467,7 @@ func (r *ValkeyNodeReconciler) ensureDeployment(ctx context.Context, node *valke
 	if err != nil {
 		return err
 	}
-	aclSecret, err := r.getACLSecret(ctx, desired.Labels[LabelCluster], desired.Namespace)
-	if err != nil {
-		return err
-	}
-	desired.Spec.Template.Annotations = buildPodTemplateAnnotations(node, aclSecret)
+	desired.Spec.Template.Annotations = buildPodTemplateAnnotations(node)
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -421,17 +520,6 @@ func (r *ValkeyNodeReconciler) ensureDeployment(ctx context.Context, node *valke
 	r.Recorder.Eventf(node, nil, corev1.EventTypeNormal, "WorkloadRollApplied", "ApplyWorkloadRoll",
 		"Applied pod template update (hash %s)", desiredHash)
 	return r.clearWorkloadRollPending(ctx, node)
-}
-
-func (r *ValkeyNodeReconciler) getACLSecret(ctx context.Context, clusterName, namespace string) (*corev1.Secret, error) {
-	log := logf.FromContext(ctx)
-	aclSecretName := getInternalSecretName(clusterName)
-	aclSecret := &corev1.Secret{}
-	log.V(1).Info("getting internal secret", "name", aclSecretName)
-	if err := r.Get(ctx, types.NamespacedName{Name: aclSecretName, Namespace: namespace}, aclSecret); err != nil {
-		return nil, err
-	}
-	return aclSecret, nil
 }
 
 // gateRollingWorkloadUpdate decides whether a rolling pod-template update may be
@@ -885,6 +973,34 @@ func (r *ValkeyNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&appsv1.Deployment{}).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.aclSecretToNodes)).
 		Named("valkeynode").
 		Complete(r)
+}
+
+// aclSecretToNodes maps a changed internal ACL Secret to reconcile requests for
+// every ValkeyNode that mounts it. ACL edits no longer roll the pods, so this
+// watch is what keeps the live path prompt: a Secret update enqueues the nodes,
+// whose reconcile reloads the ACL into the running server (see applyLiveACL)
+// instead of waiting for the periodic resync. The Secret type gate keeps the
+// controller from listing nodes on every unrelated Secret event.
+func (r *ValkeyNodeReconciler) aclSecretToNodes(ctx context.Context, obj client.Object) []reconcile.Request {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok || secret.Type != AclSecretType {
+		return nil
+	}
+	var nodes valkeyiov1alpha1.ValkeyNodeList
+	if err := r.List(ctx, &nodes, client.InNamespace(secret.GetNamespace())); err != nil {
+		return nil
+	}
+	var reqs []reconcile.Request
+	for i := range nodes.Items {
+		if nodes.Items[i].Spec.UsersACLSecretName == secret.GetName() {
+			reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      nodes.Items[i].Name,
+				Namespace: nodes.Items[i].Namespace,
+			}})
+		}
+	}
+	return reqs
 }

--- a/internal/controller/valkeynode_controller_test.go
+++ b/internal/controller/valkeynode_controller_test.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -683,9 +685,7 @@ var _ = Describe("ValkeyNode Controller", func() {
 			})
 			node := &valkeyiov1alpha1.ValkeyNode{}
 			Expect(k8sClient.Get(ctx, typeNamespacedName, node)).To(Succeed())
-			aclSecret := &corev1.Secret{}
-			Expect(k8sClient.Get(ctx, secretName, aclSecret)).To(Succeed())
-			rev, err := computeWorkloadRevision(node, aclSecret)
+			rev, err := computeWorkloadRevision(node)
 			Expect(err).NotTo(HaveOccurred())
 			node.Spec.WorkloadRevision = rev
 			node.OwnerReferences = []metav1.OwnerReference{{
@@ -734,8 +734,7 @@ var _ = Describe("ValkeyNode Controller", func() {
 
 			By("advancing Spec.WorkloadRevision to the new template hash")
 			Expect(k8sClient.Get(ctx, typeNamespacedName, node)).To(Succeed())
-			Expect(k8sClient.Get(ctx, secretName, aclSecret)).To(Succeed())
-			newRev, err := computeWorkloadRevision(node, aclSecret)
+			newRev, err := computeWorkloadRevision(node)
 			Expect(err).NotTo(HaveOccurred())
 			node.Spec.WorkloadRevision = newRev
 			Expect(k8sClient.Update(ctx, node)).To(Succeed())
@@ -1293,6 +1292,16 @@ type fakeConfigClient struct {
 	params map[string]string
 	err    error
 	closed bool
+
+	// aclHashes is the server's current user -> password hashes, as ACL USERS
+	// and ACL GETUSER would report them.
+	aclHashes map[string][]string
+	// aclOnLoad is what an ACL LOAD converges the server to. Leaving it nil
+	// models a mounted aclfile that has not caught up yet, so the LOAD is a
+	// no-op.
+	aclOnLoad map[string][]string
+	aclLoads  int
+	aclErr    error
 }
 
 func (f *fakeConfigClient) SetConfig(_ context.Context, params map[string]string) error {
@@ -1300,7 +1309,122 @@ func (f *fakeConfigClient) SetConfig(_ context.Context, params map[string]string
 	return f.err
 }
 
+func (f *fakeConfigClient) LoadACL(_ context.Context) error {
+	f.aclLoads++
+	if f.aclErr != nil {
+		return f.aclErr
+	}
+	if f.aclOnLoad != nil {
+		f.aclHashes = f.aclOnLoad
+	}
+	return nil
+}
+
+func (f *fakeConfigClient) UserNames(_ context.Context) ([]string, error) {
+	if f.aclErr != nil {
+		return nil, f.aclErr
+	}
+	return slices.Sorted(maps.Keys(f.aclHashes)), nil
+}
+
+func (f *fakeConfigClient) UserPasswordHashes(_ context.Context, username string) ([]string, error) {
+	if f.aclErr != nil {
+		return nil, f.aclErr
+	}
+	hashes, ok := f.aclHashes[username]
+	if !ok {
+		return []string{}, nil
+	}
+	return normaliseHashes(slices.Clone(hashes)), nil
+}
+
 func (f *fakeConfigClient) Close() { f.closed = true }
+
+var _ = Describe("applyLiveACL", Label("liveacl"), func() {
+	ctx := context.Background()
+
+	// One alice password ("aaa") is what the aclfile Secret asks for.
+	const aclSecretName = "live-acl-users"
+	const aclFileContent = "user alice on #aaa ~* +@all\n"
+	desiredHashes := map[string][]string{"alice": {"aaa"}}
+	staleHashes := map[string][]string{"alice": {"old"}}
+
+	nodeWith := func(secretName string) *valkeyiov1alpha1.ValkeyNode {
+		return &valkeyiov1alpha1.ValkeyNode{
+			ObjectMeta: metav1.ObjectMeta{Name: "live-acl-node", Namespace: "default"},
+			Spec:       valkeyiov1alpha1.ValkeyNodeSpec{UsersACLSecretName: secretName},
+		}
+	}
+	reconcilerFor := func(fake *fakeConfigClient) *ValkeyNodeReconciler {
+		return &ValkeyNodeReconciler{
+			APIReader: k8sClient,
+			newConfigClient: func(_ context.Context, _ *ValkeyNodeReconciler, _ *valkeyiov1alpha1.ValkeyNode) (valkeyConfigClient, error) {
+				return fake, nil
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: aclSecretName, Namespace: "default"},
+			Data:       map[string][]byte{aclFilename: []byte(aclFileContent)},
+		}
+		Expect(client.IgnoreAlreadyExists(k8sClient.Create(ctx, secret))).To(Succeed())
+	})
+
+	It("does nothing when the node has no ACL secret", func() {
+		fake := &fakeConfigClient{}
+		synced, err := reconcilerFor(fake).applyLiveACL(ctx, nodeWith(""))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(synced).To(BeTrue())
+		Expect(fake.aclLoads).To(BeZero(), "must not open a client when there is no ACL to manage")
+	})
+
+	It("treats a missing secret as nothing to apply", func() {
+		fake := &fakeConfigClient{}
+		synced, err := reconcilerFor(fake).applyLiveACL(ctx, nodeWith("does-not-exist"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(synced).To(BeTrue())
+		Expect(fake.aclLoads).To(BeZero())
+	})
+
+	It("still reloads when the passwords already match, so non-password edits converge", func() {
+		// A permissions-only change, or a removed user, leaves every desired
+		// password hash untouched. The reload must not be skipped on that basis
+		// or those edits would never reach the server.
+		fake := &fakeConfigClient{aclHashes: desiredHashes}
+		synced, err := reconcilerFor(fake).applyLiveACL(ctx, nodeWith(aclSecretName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(synced).To(BeTrue())
+		Expect(fake.aclLoads).To(Equal(1), "the reload is unconditional")
+		Expect(fake.closed).To(BeTrue())
+	})
+
+	It("reports synced once the mounted file has caught up", func() {
+		fake := &fakeConfigClient{aclHashes: staleHashes, aclOnLoad: desiredHashes}
+		synced, err := reconcilerFor(fake).applyLiveACL(ctx, nodeWith(aclSecretName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(synced).To(BeTrue())
+		Expect(fake.aclLoads).To(Equal(1))
+	})
+
+	It("reports not synced when the mounted aclfile is still stale", func() {
+		// aclOnLoad nil: the LOAD reads the pre-update file and changes nothing.
+		fake := &fakeConfigClient{aclHashes: staleHashes}
+		synced, err := reconcilerFor(fake).applyLiveACL(ctx, nodeWith(aclSecretName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(synced).To(BeFalse(), "a premature LOAD must not be reported as applied")
+		Expect(fake.aclLoads).To(Equal(1))
+	})
+
+	It("returns an error when ACL LOAD fails", func() {
+		fake := &fakeConfigClient{aclErr: fmt.Errorf("boom")}
+		synced, err := reconcilerFor(fake).applyLiveACL(ctx, nodeWith(aclSecretName))
+		Expect(err).To(HaveOccurred())
+		Expect(synced).To(BeFalse())
+		Expect(fake.closed).To(BeTrue())
+	})
+})
 
 var _ = Describe("applyLiveConfig", Label("liveconfig"), func() {
 	nodeWith := func(cfg map[string]string) *valkeyiov1alpha1.ValkeyNode {

--- a/internal/controller/valkeynode_controller_test.go
+++ b/internal/controller/valkeynode_controller_test.go
@@ -1335,7 +1335,7 @@ func (f *fakeConfigClient) UserPasswordHashes(_ context.Context, username string
 	if !ok {
 		return []string{}, nil
 	}
-	return normaliseHashes(slices.Clone(hashes)), nil
+	return normalizeHashes(slices.Clone(hashes)), nil
 }
 
 func (f *fakeConfigClient) Close() { f.closed = true }

--- a/internal/controller/workload_roll.go
+++ b/internal/controller/workload_roll.go
@@ -73,37 +73,35 @@ func isClusterOwned(node *valkeyiov1alpha1.ValkeyNode) bool {
 }
 
 // computeWorkloadRevision builds the pod template for the node (using the same
-// builders as the ValkeyNode controller) and returns its roll hash. When
-// aclSecret is non-nil, template annotations match ensureStatefulSet/Deployment.
-func computeWorkloadRevision(node *valkeyiov1alpha1.ValkeyNode, aclSecret *corev1.Secret) (string, error) {
-	tmpl, err := buildNodePodTemplate(node, aclSecret)
+// builders as the ValkeyNode controller) and returns its roll hash. ACL is not
+// part of the template (it is applied live, see applyLiveACL), so it does not
+// enter this revision and an ACL edit never rolls the pod.
+func computeWorkloadRevision(node *valkeyiov1alpha1.ValkeyNode) (string, error) {
+	tmpl, err := buildNodePodTemplate(node)
 	if err != nil {
 		return "", err
 	}
 	return podTemplateRollHash(tmpl), nil
 }
 
-// buildNodePodTemplate returns the desired pod template for a ValkeyNode.
+// buildNodePodTemplate returns the desired pod template for a ValkeyNode,
+// including the same template annotations ensureStatefulSet/Deployment stamp.
 // Empty WorkloadType is treated as StatefulSet (CRD default).
-func buildNodePodTemplate(node *valkeyiov1alpha1.ValkeyNode, aclSecret *corev1.Secret) (corev1.PodTemplateSpec, error) {
+func buildNodePodTemplate(node *valkeyiov1alpha1.ValkeyNode) (corev1.PodTemplateSpec, error) {
 	switch node.Spec.WorkloadType {
 	case valkeyiov1alpha1.WorkloadTypeDeployment:
 		dep, err := buildValkeyNodeDeployment(node)
 		if err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
-		if aclSecret != nil {
-			dep.Spec.Template.Annotations = buildPodTemplateAnnotations(node, aclSecret)
-		}
+		dep.Spec.Template.Annotations = buildPodTemplateAnnotations(node)
 		return dep.Spec.Template, nil
 	case valkeyiov1alpha1.WorkloadTypeStatefulSet, "":
 		sts, err := buildValkeyNodeStatefulSet(node)
 		if err != nil {
 			return corev1.PodTemplateSpec{}, err
 		}
-		if aclSecret != nil {
-			sts.Spec.Template.Annotations = buildPodTemplateAnnotations(node, aclSecret)
-		}
+		sts.Spec.Template.Annotations = buildPodTemplateAnnotations(node)
 		return sts.Spec.Template, nil
 	default:
 		return corev1.PodTemplateSpec{}, fmt.Errorf("unsupported workload type %q", node.Spec.WorkloadType)
@@ -117,8 +115,8 @@ func workloadRevisionAllows(node *valkeyiov1alpha1.ValkeyNode, desiredHash strin
 }
 
 // setDesiredWorkloadRevision sets Spec.WorkloadRevision from the built template.
-func setDesiredWorkloadRevision(node *valkeyiov1alpha1.ValkeyNode, aclSecret *corev1.Secret) error {
-	rev, err := computeWorkloadRevision(node, aclSecret)
+func setDesiredWorkloadRevision(node *valkeyiov1alpha1.ValkeyNode) error {
+	rev, err := computeWorkloadRevision(node)
 	if err != nil {
 		return fmt.Errorf("compute workload revision for %s: %w", node.Name, err)
 	}

--- a/internal/controller/workload_roll_test.go
+++ b/internal/controller/workload_roll_test.go
@@ -99,14 +99,14 @@ func TestComputeWorkloadRevisionStable(t *testing.T) {
 			WorkloadType: valkeyiov1alpha1.WorkloadTypeStatefulSet,
 		},
 	}
-	h1, err := computeWorkloadRevision(node, nil)
+	h1, err := computeWorkloadRevision(node)
 	require.NoError(t, err)
-	h2, err := computeWorkloadRevision(node, nil)
+	h2, err := computeWorkloadRevision(node)
 	require.NoError(t, err)
 	assert.Equal(t, h1, h2)
 
 	node.Spec.Image = "valkey/valkey:9.0.1"
-	h3, err := computeWorkloadRevision(node, nil)
+	h3, err := computeWorkloadRevision(node)
 	require.NoError(t, err)
 	assert.NotEqual(t, h1, h3)
 }

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -2119,4 +2119,135 @@ spec:
 			}, 30*time.Second, 5*time.Second).Should(Succeed())
 		})
 	})
+
+	Context("acl-hash annotation migration", func() {
+		const clusterName = "valkeycluster-aclhash-migration-e2e"
+		const usersSecret = "valkey-aclhash-users"
+		const (
+			defaultPassword = "aclhash-default-pw"
+			alicePassword   = "aclhash-alice-pw"
+		)
+
+		manifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+type: Opaque
+stringData:
+  defaultpw: %s
+  alicepw: %s
+---
+apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  shards: 3
+  replicas: 1
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  users:
+    - name: default
+      enabled: true
+      permissions: "+@all ~* &*"
+      passwordSecret:
+        name: %s
+        keys: [defaultpw]
+    - name: alice
+      enabled: true
+      passwordSecret:
+        name: %s
+        keys: [alicepw]
+      commands:
+        allow: ["@read", "@write", "@connection"]
+      keys:
+        readWrite: ["app:*"]
+`, usersSecret, defaultPassword, alicePassword, clusterName, usersSecret, usersSecret)
+
+		serverStatefulSets := func(g Gomega) []string {
+			out, err := utils.Run(exec.Command("kubectl", "get", "statefulset",
+				"-l", "valkey.io/cluster="+clusterName,
+				"-o", "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}"))
+			g.Expect(err).NotTo(HaveOccurred())
+			return utils.GetNonEmptyLines(out)
+		}
+
+		expectACLAppliedTrue := func(g Gomega) {
+			out, err := utils.Run(exec.Command("kubectl", "get", "valkeynodes",
+				"-l", "valkey.io/cluster="+clusterName,
+				"-o", "jsonpath={.items[*].metadata.name}"))
+			g.Expect(err).NotTo(HaveOccurred())
+			names := strings.Fields(out)
+			g.Expect(names).To(HaveLen(6))
+			for _, name := range names {
+				node, err := utils.GetValkeyNodeStatus(name)
+				g.Expect(err).NotTo(HaveOccurred())
+				cond := utils.FindCondition(node.Status.Conditions, valkeyiov1alpha1.ValkeyNodeConditionACLApplied)
+				g.Expect(cond).NotTo(BeNil(), "ACLApplied condition should be set on %s", name)
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "ACLApplied should be True on %s", name)
+			}
+		}
+
+		It("removes a legacy internal-acl-hash annotation so an upgraded cluster migrates to live ACL", Label("acl-hash-migration"), func() {
+			defer func() {
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "valkeycluster", clusterName, "--ignore-not-found=true", "--wait=false"))
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "secret", usersSecret, "--ignore-not-found=true", "--wait=false"))
+			}()
+
+			By("creating a ValkeyCluster with a custom user set")
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(manifest)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("waiting for the cluster to become Ready with live ACL applied")
+			Eventually(func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(clusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
+				g.Expect(cr.Status.ReadyShards).To(Equal(int32(3)))
+			}, 10*time.Minute, 5*time.Second).Should(Succeed())
+			Eventually(expectACLAppliedTrue, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("stamping the legacy internal-acl-hash annotation on every server StatefulSet")
+			// Operator versions before live ACL stamped the ACL hash on the pod
+			// template. Reproduce that pre-upgrade state, then assert the current
+			// operator migrates off it: removing the annotation is the one-time
+			// roll that reloads the aclfile and grants _operator the ACL commands.
+			var stsNames []string
+			Eventually(func(g Gomega) {
+				stsNames = serverStatefulSets(g)
+				g.Expect(stsNames).To(HaveLen(6))
+			}).Should(Succeed())
+			for _, sts := range stsNames {
+				_, err := utils.Run(exec.Command("kubectl", "patch", "statefulset", sts, "--type", "merge",
+					"-p", `{"spec":{"template":{"metadata":{"annotations":{"valkey.io/internal-acl-hash":"simulated-legacy"}}}}}`))
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("the operator strips the annotation from every StatefulSet (the migration roll)")
+			Eventually(func(g Gomega) {
+				for _, sts := range serverStatefulSets(g) {
+					out, err := utils.Run(exec.Command("kubectl", "get", "statefulset", sts,
+						"-o", "jsonpath={.spec.template.metadata.annotations.valkey\\.io/internal-acl-hash}"))
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(strings.TrimSpace(out)).To(BeEmpty(),
+						"operator must strip the legacy ACL-hash annotation from %s", sts)
+				}
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("the cluster returns to Ready and ACL stays live after the migration")
+			Eventually(func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(clusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
+			}, 10*time.Minute, 5*time.Second).Should(Succeed())
+			Eventually(expectACLAppliedTrue, 5*time.Minute, 5*time.Second).Should(Succeed())
+		})
+	})
 })

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -170,6 +170,31 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 			}
 			Eventually(verifyCrStatus).Should(Succeed())
 
+			By("validating live ACL converges with only the unmanaged default user")
+			// This cluster sets no custom users, so the only user on the server is
+			// Valkey's own `default`, which the aclfile does not manage. The node
+			// must still reach ACLApplied=True: aclObservablyInSync has to ignore
+			// the unmanaged `default` rather than loop forever waiting for it to
+			// match a spec.users entry that does not exist.
+			verifyACLApplied := func(g Gomega) {
+				out, err := utils.Run(exec.Command("kubectl", "get", "valkeynodes",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", valkeyClusterName),
+					"-o", "jsonpath={.items[*].metadata.name}"))
+				g.Expect(err).NotTo(HaveOccurred())
+				names := strings.Fields(out)
+				g.Expect(names).To(HaveLen(6))
+				for _, name := range names {
+					node, err := utils.GetValkeyNodeStatus(name)
+					g.Expect(err).NotTo(HaveOccurred())
+					cond := utils.FindCondition(node.Status.Conditions, valkeyiov1alpha1.ValkeyNodeConditionACLApplied)
+					g.Expect(cond).NotTo(BeNil(), "ACLApplied condition should be set on %s", name)
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "ACLApplied should converge to True on %s", name)
+				}
+			}
+			// ACLApplied is only set once a node reports Ready, so give it the same
+			// budget as cluster startup rather than a single pass.
+			Eventually(verifyACLApplied, 5*time.Minute, 5*time.Second).Should(Succeed())
+
 			// NOTE: Kubernetes Events are best-effort and may be rate-limited, delayed by
 			// `kubectl get events` / `kubectl describe` when many events are emitted for the same Custom Resource.
 			// In particular, kubectl output can appear capped (~15–20) and events can show up late; see:

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -2276,7 +2276,7 @@ spec:
 			}
 		}
 
-		It("removes a legacy internal-acl-hash annotation so an upgraded cluster migrates to live ACL", Label("acl-hash-migration"), func() {
+		It("removes a legacy internal-acl-hash annotation from the pod template", Label("acl-hash-migration"), func() {
 			defer func() {
 				_, _ = utils.Run(exec.Command("kubectl", "delete", "valkeycluster", clusterName, "--ignore-not-found=true", "--wait=false"))
 				_, _ = utils.Run(exec.Command("kubectl", "delete", "secret", usersSecret, "--ignore-not-found=true", "--wait=false"))
@@ -2299,9 +2299,13 @@ spec:
 
 			By("stamping the legacy internal-acl-hash annotation on every server StatefulSet")
 			// Operator versions before live ACL stamped the ACL hash on the pod
-			// template. Reproduce that pre-upgrade state, then assert the current
-			// operator migrates off it: removing the annotation is the one-time
-			// roll that reloads the aclfile and grants _operator the ACL commands.
+			// template. Reproduce that pre-upgrade state and assert the current
+			// operator reconciles it away. Removing the annotation is the one-time
+			// roll that, on a real version upgrade, restarts the pod onto the new
+			// aclfile and thereby grants _operator the ACL commands. This spec runs
+			// against the current operator (which already grants them), so it pins
+			// the reconcile trigger and that ACL stays live across the roll, not
+			// the permission bootstrap itself, which needs the old operator build.
 			var stsNames []string
 			Eventually(func(g Gomega) {
 				stsNames = serverStatefulSets(g)

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -322,74 +322,14 @@ var _ = Describe("ValkeyCluster", Ordered, func() {
 			}
 			Eventually(verifyClusterSlotsIP).Should(Succeed())
 
-			By("get the original ACL hash")
-			cmd = exec.Command("kubectl", "get", "pod",
-				"-l", fmt.Sprintf("valkey.io/cluster=%s", valkeyClusterName),
-				"-o", "jsonpath={.items[0].metadata.annotations.valkey\\.io/internal-acl-hash}",
-			)
-			aclHash, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("delete system users password secret")
-			secretName := "internal-" + valkeyClusterName + "-system-passwords"
-			cmd = exec.Command("kubectl", "delete", "secret", secretName)
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating system users passwords secret is recreated if deleted")
-			verifySecretRecreation := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "secret", secretName)
-				_, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-			}
-			Eventually(verifySecretRecreation).Should(Succeed())
-
-			By("validating valkey-operator fallback to default user")
-			verifyAuthFallback := func(g Gomega) {
-				cmd := exec.Command("kubectl", "logs",
-					"-n", namespace, "-l", "app.kubernetes.io/name=valkey-operator")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("fall back to unauthenticated default user on WRONGPASS error"))
-			}
-			Eventually(verifyAuthFallback).Should(Succeed())
-
-			// ACL secret hash changes rewrite the pod template. Under
-			// Spec.WorkloadRevision that is a staged roll (one node at a time),
-			// so assert any cluster pod picked up the new hash, not only items[0].
-			By("validating at least one pod rolled with the new ACL hash")
-			verifyPodRoll := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pod",
-					"-l", fmt.Sprintf("valkey.io/cluster=%s", valkeyClusterName),
-					"-o", "jsonpath={range .items[*]}{.metadata.name}={.metadata.annotations.valkey\\.io/internal-acl-hash}{\"\\n\"}{end}",
-				)
-				out, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				var hashes []string
-				for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-					line = strings.TrimSpace(line)
-					if line == "" {
-						continue
-					}
-					parts := strings.SplitN(line, "=", 2)
-					if len(parts) != 2 || parts[1] == "" {
-						continue
-					}
-					hashes = append(hashes, parts[1])
-				}
-				g.Expect(hashes).NotTo(BeEmpty(), "no ACL hashes on cluster pods; output:\n%s", out)
-				foundNew := false
-				for _, h := range hashes {
-					if h != aclHash {
-						foundNew = true
-						break
-					}
-				}
-				g.Expect(foundNew).To(BeTrue(),
-					"expected at least one pod with ACL hash != %s after staged roll; got %v",
-					aclHash, hashes)
-			}
-			Eventually(verifyPodRoll, 5*time.Minute, 5*time.Second).Should(Succeed())
+			// A previous revision deleted the system-password Secret here and
+			// asserted a pod roll on the internal-acl-hash annotation. ACL is no
+			// longer part of the pod template (it applies live, without a roll),
+			// so that annotation and that assertion are gone. The live-apply path
+			// is covered by the "live ACL propagation" spec. Recovering an
+			// operator locked out by a deleted password Secret is a separate
+			// concern that needs a staged recovery through the cluster controller;
+			// it is tracked as a follow-up rather than a template roll.
 		})
 
 		It("creates a single-shard zero-replica cluster", Label("single-node"), func() {
@@ -1965,6 +1905,193 @@ spec:
 				g.Expect(output).To(ContainSubstring("cluster_known_nodes:2"))
 				g.Expect(output).To(ContainSubstring("cluster_size:2"))
 			}).Should(Succeed())
+		})
+	})
+
+	Context("live ACL propagation", func() {
+		const clusterName = "valkeycluster-live-acl-e2e"
+		const usersSecret = "valkey-live-acl-users"
+		const aclClientPod = "live-acl-client"
+		const (
+			defaultPassword = "live-acl-default-pw"
+			alicePassword   = "live-acl-alice-pw"
+			frankPassword   = "live-acl-frank-pw"
+		)
+		clusterFqdn := fmt.Sprintf("valkey-%s.default.svc.cluster.local", clusterName)
+
+		// buildManifest renders the users Secret and the ValkeyCluster CR. When
+		// withFrank is true it adds a "frank" user (and its password): that is
+		// the ACL-only change the test applies once the cluster is up.
+		buildManifest := func(withFrank bool) string {
+			frankSecret, frankUser := "", ""
+			if withFrank {
+				frankSecret = "  frankpw: " + frankPassword + "\n"
+				frankUser = `    - name: frank
+      enabled: true
+      passwordSecret:
+        name: ` + usersSecret + `
+        keys: [frankpw]
+      commands:
+        allow: ["@read", "@connection"]
+      keys:
+        readOnly: ["frank:*"]
+      permissions: "+ping"
+`
+			}
+			return fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+type: Opaque
+stringData:
+  defaultpw: %s
+  alicepw: %s
+%s---
+apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: %s
+spec:
+  shards: 3
+  replicas: 1
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  users:
+    - name: default
+      enabled: true
+      permissions: "+@all ~* &*"
+      passwordSecret:
+        name: %s
+        keys: [defaultpw]
+    - name: alice
+      enabled: true
+      passwordSecret:
+        name: %s
+        keys: [alicepw]
+      commands:
+        allow: ["@read", "@write", "@connection"]
+      keys:
+        readWrite: ["app:*"]
+%s`, usersSecret, defaultPassword, alicePassword, frankSecret, clusterName, usersSecret, usersSecret, frankUser)
+		}
+
+		applyManifest := func(manifest string) {
+			cmd := exec.Command("kubectl", "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(manifest)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "failed to apply manifest")
+		}
+
+		// podIdentities returns one "name=uid" token per server pod, sorted by
+		// name. A rolling restart recreates pods with fresh UIDs, so any change
+		// to this set is the signal that a roll happened.
+		podIdentities := func(g Gomega) []string {
+			out, err := utils.Run(exec.Command("kubectl", "get", "pods",
+				"-l", "valkey.io/cluster="+clusterName, "--sort-by=.metadata.name",
+				"-o", "jsonpath={range .items[*]}{.metadata.name}={.metadata.uid} {end}"))
+			g.Expect(err).NotTo(HaveOccurred())
+			return strings.Fields(out)
+		}
+
+		// valkeyCLI runs a one-shot valkey-cli command from a throwaway client
+		// pod and returns its combined output. The command is wrapped so a
+		// non-zero exit (e.g. WRONGPASS before an ACL has propagated) still lets
+		// the pod complete and its output be read, rather than hanging the wait.
+		valkeyCLI := func(g Gomega, cliArgs string) string {
+			_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", aclClientPod,
+				"--ignore-not-found=true", "--wait=true", "--timeout=30s"))
+			cmd := exec.Command("kubectl", "run", aclClientPod,
+				"--image="+valkeyClientImage, "--restart=Never", "--",
+				"sh", "-c", "valkey-cli "+cliArgs+" 2>&1 || true")
+			_, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			_, err = utils.Run(exec.Command("kubectl", "wait", "pod/"+aclClientPod,
+				"--for=jsonpath={.status.phase}=Succeeded", "--timeout=60s"))
+			g.Expect(err).NotTo(HaveOccurred())
+			out, err := utils.Run(exec.Command("kubectl", "logs", aclClientPod))
+			g.Expect(err).NotTo(HaveOccurred())
+			_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", aclClientPod,
+				"--ignore-not-found=true", "--wait=false"))
+			return out
+		}
+
+		aclList := func(g Gomega) string {
+			return valkeyCLI(g, fmt.Sprintf("-c -h %s --user default --pass %s --no-auth-warning ACL LIST",
+				clusterFqdn, defaultPassword))
+		}
+
+		It("applies a user ACL change live without rolling the pods", Label("live-acl"), func() {
+			defer func() {
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "valkeycluster", clusterName, "--ignore-not-found=true", "--wait=false"))
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "secret", usersSecret, "--ignore-not-found=true", "--wait=false"))
+				_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", aclClientPod, "--ignore-not-found=true", "--wait=false"))
+			}()
+
+			By("creating a ValkeyCluster with an initial custom user set")
+			applyManifest(buildManifest(false))
+
+			By("waiting for the cluster to become Ready")
+			Eventually(func(g Gomega) {
+				cr, err := utils.GetValkeyClusterStatus(clusterName)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(cr.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReady))
+				g.Expect(cr.Status.ReadyShards).To(Equal(int32(3)))
+			}, 10*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("recording the server pod identities before the ACL change")
+			var beforePods []string
+			Eventually(func(g Gomega) {
+				beforePods = podIdentities(g)
+				// 3 shards x (1 primary + 1 replica)
+				g.Expect(beforePods).To(HaveLen(6))
+			}).Should(Succeed())
+
+			By("confirming the new user is absent before the change")
+			Expect(aclList(Default)).NotTo(ContainSubstring("user frank on"))
+
+			By("adding a user to the cluster's ACL to trigger a live update")
+			applyManifest(buildManifest(true))
+
+			By("the new user appears in the running ACL without a pod restart")
+			Eventually(func(g Gomega) {
+				g.Expect(aclList(g)).To(ContainSubstring("user frank on"))
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("the new user's credentials authenticate against the live server")
+			Eventually(func(g Gomega) {
+				out := valkeyCLI(g, fmt.Sprintf("-c -h %s --user frank --pass %s --no-auth-warning PING",
+					clusterFqdn, frankPassword))
+				g.Expect(out).To(ContainSubstring("PONG"))
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("every ValkeyNode reports ACLApplied=True")
+			Eventually(func(g Gomega) {
+				out, err := utils.Run(exec.Command("kubectl", "get", "valkeynodes",
+					"-l", "valkey.io/cluster="+clusterName,
+					"-o", "jsonpath={.items[*].metadata.name}"))
+				g.Expect(err).NotTo(HaveOccurred())
+				names := strings.Fields(out)
+				g.Expect(names).To(HaveLen(6))
+				for _, name := range names {
+					node, err := utils.GetValkeyNodeStatus(name)
+					g.Expect(err).NotTo(HaveOccurred())
+					cond := utils.FindCondition(node.Status.Conditions, valkeyiov1alpha1.ValkeyNodeConditionACLApplied)
+					g.Expect(cond).NotTo(BeNil(), "ACLApplied condition should be set on %s", name)
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue), "ACLApplied should be True on %s", name)
+				}
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying no server pod was rolled by the ACL change")
+			Expect(podIdentities(Default)).To(Equal(beforePods),
+				"server pods must not be recreated by a live ACL change")
+			Consistently(func(g Gomega) {
+				g.Expect(podIdentities(g)).To(Equal(beforePods))
+			}, 30*time.Second, 5*time.Second).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Closes #212

### Summary

ACL changes only took effect when a pod restarted and reloaded the aclfile. The ValkeyNode controller now applies them in place with `ACL LOAD`, so a password rotation or a permission change no longer needs a roll.

### Features / Behaviour Changes

- ACL changes reach the running server without a pod roll, eventually consistent with the mounted Secret.
- New `ACLApplied` condition on `ValkeyNode` reporting whether the server's ACL matches the aclfile Secret.
- No API changes.

### Implementation

Per the direction on #212: `ACL LOAD` of the mounted file at the end of the node reconcile, since that file is already the full desired state and is exactly what a restart would load.

Two things shaped the rest:

`ACL SAVE` is out. The aclfile is mounted read-only from its Secret, so it isn't available, and it isn't needed either: the Secret the cluster controller writes is what a restarting pod loads. So the Secret stays the source of truth for restart, and `ACL LOAD` is purely the live path.

The mounted copy lags. kubelet refreshes it lazily, so an `ACL LOAD` issued right after the Secret changes can read the previous contents and silently do nothing. The operator can't read the pod's file without an exec, so the running server is the source of truth for verification instead: the controller compares the password hashes from `ACL GETUSER` against the aclfile Secret, and only issues a reload when they differ, then re-checks. That makes a premature reload self-correcting, it leaves the node `ACLApplied=False` with reason `PendingPropagation` rather than claiming applied, and the requeue retries once the volume catches up. A steady-state reconcile issues no writes at all, only the comparison.

`ACLApplied` deliberately does not gate the cluster's rolling update the way `LiveConfigApplied` does: a node whose ACL is still propagating keeps serving with its previous credentials, and a roll would load the new file regardless.

### Rotating without an auth gap

Documented in `docs/valkeycluster.md`: a Valkey user can hold several passwords at once, and `passwordSecret.keys` already accepts multiple keys, so adding the new password alongside the old, waiting for `ACLApplied=True`, moving clients over, then dropping the old key keeps every credential valid throughout the window. Replacing the key outright locks out any client still holding the old password until it catches up.

### Testing

- Unit tests for the aclfile parsing (multi-password users, `nopass`, system users, non-user lines) and the in-sync comparison.
- envtest coverage for `applyLiveACL`: no secret, missing secret, already in sync (asserts no `ACL LOAD` is issued), reload that converges, reload against a stale volume (asserts it reports not-synced rather than applied), and a failing reload.
- `make test` and `make lint` pass; no generated drift.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [ ] I have run pre-commit locally (ran `make test` and `make lint` instead)
