### PR TITLE
fix: scheduling correct internal imports

### DIFF
--- a/internal/controller/scheduling.go
+++ b/internal/controller/scheduling.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
 )
 
 // effectiveNodeSpread resolves the node-axis spread modes, defaulting every

--- a/internal/controller/scheduling_test.go
+++ b/internal/controller/scheduling_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
-	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
 )
 
 func TestEffectiveNodeSpread_Defaults(t *testing.T) {

--- a/internal/controller/scheduling_validation_test.go
+++ b/internal/controller/scheduling_validation_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	valkeyiov1alpha1 "valkey.io/valkey-operator/api/v1alpha1"
+	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
 )
 
 // schedulingCluster builds a minimal ValkeyCluster with an explicit


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

### Summary

We updated the go module paths in this PR: https://github.com/valkey-io/valkey-operator/pull/316

It did not contain the new files added in: https://github.com/valkey-io/valkey-operator/pull/310

This corrects that

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
