### PR TITLE
feat: Add cmdline flag for log level

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,6 +75,8 @@ func main() {
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
 	var watchNamespaces []string
+	var logLevel zapcore.LevelEnabler
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -107,12 +109,29 @@ func main() {
 		watchNamespaces = append(watchNamespaces, s)
 		return nil
 	})
+	flag.Func("log-level", "Log level for operator output (debug/info/warn/error).", func(s string) error {
+		switch strings.ToLower(s) {
+		case "debug":
+			logLevel = zapcore.DebugLevel
+		case "info", "":
+			logLevel = zapcore.InfoLevel
+		case "warn":
+			logLevel = zapcore.WarnLevel
+		case "error":
+			logLevel = zapcore.ErrorLevel
+		default:
+			return fmt.Errorf("log-level: %s, valid: debug/info/warn/error", s)
+		}
+		return nil
+	})
+	flag.Parse()
+
 	opts := zap.Options{
 		Development:     true,
 		StacktraceLevel: zapcore.FatalLevel,
+		Level:           logLevel,
 	}
 	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 


### PR DESCRIPTION
This PR closes #321

### Summary

PR adding new command line flag to configure log verbosity. Atm it's debug, which generates quite a lot of messages on every reconcile loop.

### Features / Behaviour Changes

New `-log-level` option. `info` by default.

### Implementation

I added new variable and `flag.Func` for log-level command line flag. It parses provided string value, validates it and assigns one of `zapcore.LevelEnabler` accordingly.
Had to move `flag.Parse()` before `opts := zap.Options{` in order to get logLevel before assigning it in `zap.Options{`.

I also added couple of empty lines before and after flags definition to make them visibly separated. Please let me know if it should be reverted.

### Limitations

Current issue is that with log-level = warn|error operator doesn't show even starting message.

### Testing

Local test shows that setting is passed to logger.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
