### PR TITLE
fix: Set debug level for "getting system users secret" output

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -112,7 +112,7 @@ func operatorUserPasswordSecret(clusterName string) *corev1.SecretKeySelector {
 
 func (r *ValkeyClusterReconciler) createSystemUsersAcl(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) (string, error) {
 	log := logf.FromContext(ctx)
-	log.Info("getting system users secret: " + cluster.Name)
+	log.V(1).Info("getting system users secret: " + cluster.Name)
 	var systemsAcls strings.Builder
 	systemUserSecret := &corev1.Secret{}
 	err := r.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
This PR closes #328

### Summary

This PR sets proper log level for the "getting system users secret" message from `internal/controller/users.go`, which repeats on every reconcile loop, added in https://github.com/valkey-io/valkey-operator/pull/129

### Features / Behaviour Changes

"getting system users secret" message will be shown only if operator started with "--zap-log-level=debug"

### Implementation

As sigs.k8s.io/controller-runtime/pkg/log doesn't have method for `log.Debug`, `log.V(1).Info()` used instead, like in other parts of operator.

### Limitations

No

### Testing

No testing required I think.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
