### PR TITLE
fix: set version/branch labels in valkey_operator_build_info metric

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,12 @@ jobs:
 
       - name: Get version info
         id: version
-        run: echo "$(make print-version-ldflags)" | tee -a "$GITHUB_OUTPUT"
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            echo "ldflags=$(make print-version-ldflags VERSION=${GITHUB_REF_NAME} BRANCH=${GITHUB_REF_NAME})" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "ldflags=$(make print-version-ldflags BRANCH=${GITHUB_REF_NAME})" | tee -a "$GITHUB_OUTPUT"
+          fi
 
       - name: Build and publish container
         id: publish
@@ -71,7 +76,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          build-args: VERSION_LDFLAGS=${{ steps.version.outputs.result }}
+          build-args: VERSION_LDFLAGS=${{ steps.version.outputs.ldflags }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR closes #327 

### Summary

The `valkey_operator_build_info` Prometheus metric reports empty `version` and `branch` labels in published container images.

The publish workflow derived VERSION from IMG (always `latest`) and BRANCH from `git rev-parse --abbrev-ref HEAD` (returns `HEAD` on tag checkouts). The GITHUB_OUTPUT line also lacked the [`key=value`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-output-parameter) format so the step output was never populated.

Pass VERSION and BRANCH from GITHUB_REF_NAME on tag builds, and only BRANCH on branch builds.

### Features / Behaviour Changes

After this fix, a tagged and published container from any branch, like for tag `v0.4.0` will report:

    valkey_operator_build_info{version="v0.4.0", branch="v0.4.0", ...} 1

while a published container from main will give:

    valkey_operator_build_info{version="latest", branch="main", ...} 1

We use the `v` in releases, so keeping it even it's not strictly semver.

### Testing

The publish procedure was [run](https://github.com/Nordix/valkey-operator/actions/runs/30262510819/job/89965477002) on a fork to verify that the expected ldflags was given:
```
#22 [linux/amd64 builder 7/7] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "-X github.com/prometheus/common/version.Version=v0.1.2-test -X github.com/prometheus/common/version.Revision=40eb4a63ebb3d1a80ac85c49dfee5b69e4066924 -X github.com/prometheus/common/version.Branch=v0.1.2-test -X github.com/prometheus/common/version.BuildDate=2026-07-27T11:36:09+00:00" -o manager cmd/main.go
```

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
