### PR TITLE
feat(acl): allow config|get for auditability

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -63,6 +63,7 @@ var (
 			"+cluster|migrateslots",      // migrate slots between shards
 			"+cluster|set-config-epoch",  // set epoch on new nodes
 			"+config|set",                // apply live config changes
+			"+config|get",                // verify applied config / audit current state
 			"+info",                      // node info and replication status
 			"+role",                      // current replication role
 		}, " "),


### PR DESCRIPTION
### Summary

The `_operator` user had only the permission to `CONFIG SET`, not to `CONFIG GET`. Due to this limitation the user wasn't able to retrieve the current configurations of the cluster and audit the state.

### Features / Behaviour Changes

The `_operator` user can check the applied settings of the valkey instance and audit changes

### Implementation

The permisson for `config|get` was added to the `_operator` user.

### Testing

Tested by e2e tests

### Checklist

Before submitting the PR make sure the following are checked:

- [X] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
