### PR TITLE
fixed e2e test failing on main branch as config get is allowed by operator users

### DIFF
--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -584,6 +584,7 @@ CLUSTER MYSHARDID
 CLUSTER NODES
 CLUSTER FAILOVER
 INFO
+CONFIG GET maxmemory
 ROLE 
 EOF`,
 						clusterFqdn,
@@ -631,7 +632,6 @@ EOF`,
 					"GET foo",
 					"DEL foo",
 					"KEYS *",
-					"CONFIG GET *",
 					"ACL LIST",
 				}
 


### PR DESCRIPTION
### Summary

#341 addes +config|get to operator ACL. Fixes the failing e2e test on main https://github.com/valkey-io/valkey-operator/actions/runs/30701407296/job/91372936404
#245 added e2e test that asserts these commands return NOPERM for operator user


### Changes

- update e2e test to add Config GET to allowed list and removed it from disallowed check.


### Testing

tested on local kind cluster by running multiple times.

### Checklist

Before submitting the PR make sure the following are checked:

- [X] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [X] Tests are added or updated.
- [ ] Documentation files are updated.
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)


