### PR TITLE
test: update operator-user ACL e2e for the config|get grant

### DIFF
--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -583,8 +583,9 @@ CLUSTER MYID
 CLUSTER MYSHARDID
 CLUSTER NODES
 CLUSTER FAILOVER
+CONFIG GET maxmemory
 INFO
-ROLE 
+ROLE
 EOF`,
 						clusterFqdn,
 						operatorPassword,
@@ -626,12 +627,16 @@ EOF`,
 				g.Expect(err).NotTo(HaveOccurred())
 				operatorPassword := string(decoded)
 
+				// CONFIG GET is intentionally absent: the _operator user is
+				// granted +config|get for auditability (#341), covered by the
+				// allowed-commands check above (+config|set is granted too,
+				// so neither CONFIG subcommand belongs here).
 				disallowedCommands := []string{
 					"SET foo bar",
 					"GET foo",
 					"DEL foo",
 					"KEYS *",
-					"CONFIG GET *",
+					"FLUSHALL",
 					"ACL LIST",
 				}
 


### PR DESCRIPTION
## Summary

Main's e2e suite is currently red: [the run for #341's merge commit](https://github.com/valkey-io/valkey-operator/actions/runs/30701407296) fails in `verifying denied commands fail for operator user`:

```
expected all 6 disallowed commands to be denied but got: ... (5 NOPERM; CONFIG GET * succeeds)
Expected <int>: 5 to equal <int>: 6
```

#341 granted the `_operator` user `+config|get` for auditability, but the denied-commands e2e still expects `CONFIG GET *` to return NOPERM. Every PR branch inherits the failure (hit it on #333).

## Changes

- `CONFIG GET maxmemory` added to the allowed-commands check, covering the new grant positively.
- The denied-list slot is replaced with `FLUSHALL`, which no grant covers. `CONFIG SET` deliberately not used: `+config|set` is also granted, so neither CONFIG subcommand belongs in the denied list.