### PR TITLE
fix: grant _replication user +sync for dual-channel replication

### DIFF
--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -71,8 +71,8 @@ var (
 		exporterUser: "-@all +@connection +memory -readonly +strlen +config|get +xinfo +pfcount -quit +zcard +type +xlen -readwrite -command +client -wait +scard +llen +hlen +get +eval +slowlog +cluster|info +cluster|slots +cluster|nodes -hello -echo +info +latency +scan -reset -auth -asking",
 
 		replicationUser: strings.Join([]string{
-			"-@all +psync +replconf +ping", // the ACL rawstring for replication is taken from Valkey documentation: https://valkey.io/topics/acl/#acl-rules-for-sentinel-and-replicas
-			"+cluster|syncslots",           // required for atomic slot migration
+			"-@all +psync +sync +replconf +ping", // the ACL rawstring for replication is taken from Valkey documentation: https://valkey.io/topics/acl/#acl-rules-for-sentinel-and-replicas; +sync is required for dual-channel replication
+			"+cluster|syncslots",                 // required for atomic slot migration
 			// Today, Atomic slot migration streams the snapshot as a command stream
 			// (SELECT + type-specific write commands from the AOF-rewrite)
 			"+select +@write ~* -flushall -flushdb -swapdb",


### PR DESCRIPTION
This PR closes #358

### Summary

The `_replication` system user's ACL grants `+psync` but not `+sync`. When `dual-channel-replication-enabled yes` is set on the Valkey server, the RDB-only side channel issues a legacy `SYNC` (not `PSYNC`) to start its transfer, which fails with `-NOPERM`. The replica then retries the full handshake from scratch roughly every second, indefinitely, and never completes sync.

### Features / Behaviour Changes

No new features or CRD changes. This only widens the built-in `_replication` system user's ACL to include `+sync`, matching the maintainer-suggested grant order from the linked issue.

### Implementation

Single-line fix in `internal/controller/users.go`: added `+sync` to the initial `-@all +psync +sync +replconf +ping` grant for `replicationUser`. No other behaviour changes.

### Limitations

The upstream Valkey ACL documentation (referenced in the code comment) doesn't currently call out `+sync` as a requirement for dual-channel replication specifically — that's a separate doc fix outside this operator repo, noted by @jdheyburn on the linked issue.

### Testing

- `make test`: all packages pass, including `internal/controller` (existing ACL/user tests unaffected since none assert the literal ACL string content).
- `make lint`: could not run to completion in my local environment — `golangci-lint` was built against go1.25 but a transitive dependency (`sigs.k8s.io/controller-tools`) now requires go1.26, causing a pre-existing toolchain version mismatch (`can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26)`). This reproduces on a clean checkout of `main` with no changes, so it's unrelated to this PR. `go vet ./...` (part of the `make test` prerequisite chain) passes cleanly.
- Did not stand up a live cluster to reproduce end-to-end in this session; the fix is verified against the exact `-NOPERM` log signature reported in #358, and the grant matches what @jdheyburn confirmed would resolve it.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated. (No new test added — happy to add a regression test asserting `+sync` is present in the `_replication` ACL if maintainers want one; didn't want to presume the preferred test shape.)
- [x] Documentation files are updated. (N/A for this repo; see Limitations re: upstream Valkey docs.)
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit) — not installed in my environment; ran `go fmt`/`gofmt` and `make test` manually instead.
