### PR TITLE
chore: Auto update and freeze pre-commit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v0.7.1
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-merge-conflict


### PR DESCRIPTION
This PR closes https://github.com/valkey-io/valkey-operator/discussions/363

### Summary

As discussed, it makes sense to update pre-commit hooks and freeze version by SHA, similar to GH actions.

### Features / Behaviour Changes

No changes.

### Implementation

Run `pre-commit autoupdate --freeze`:

```sh
$ pre-commit run -a             
generate code and manifests..............................................Passed
run go mod tidy..........................................................Passed
run golangci-lint........................................................Passed
check for merge conflicts................................................Passed
```

### Limitations

None

### Testing

`pre-commit run -a` runs without issues.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
