### PR TITLE
fix: skip reconciliation while ValkeyCluster is being deleted

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -124,6 +124,13 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	// During deletion (e.g. a foreground cascading delete, where the garbage
+	// collector removes dependents before the cluster itself) reconciling would
+	// recreate the very children being deleted and deadlock the delete
+	if !cluster.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	initClusterMetrics(req.Name, req.Namespace)
 
 	if err := r.upsertService(ctx, cluster); err != nil {

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -118,6 +118,62 @@ var _ = Describe("ValkeyCluster Controller", func() {
 
 		})
 	})
+
+	Context("When the ValkeyCluster is being deleted", func() {
+		const resourceName = "deleting-resource"
+
+		ctx := context.Background()
+
+		typeNamespacedName := types.NamespacedName{
+			Name:      resourceName,
+			Namespace: "default",
+		}
+
+		It("should not create child resources while deletion is in progress", func() {
+			By("creating a ValkeyCluster held under deletion by a finalizer")
+			resource := &valkeyiov1alpha1.ValkeyCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{"test.valkey.io/block-deletion"},
+				},
+				Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+					Shards:   3,
+					Replicas: 1,
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func() {
+				latest := &valkeyiov1alpha1.ValkeyCluster{}
+				Expect(k8sClient.Get(ctx, typeNamespacedName, latest)).To(Succeed())
+				latest.Finalizers = nil
+				Expect(k8sClient.Update(ctx, latest)).To(Succeed())
+			})
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			By("reconciling the deleting resource")
+			controllerReconciler := &ValkeyClusterReconciler{
+				Client:    k8sClient,
+				APIReader: k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  events.NewFakeRecorder(100),
+			}
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+
+			By("verifying no child resources were created")
+			svc := &corev1.Service{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: headlessServiceName(resourceName), Namespace: "default"}, svc)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "headless Service should not be created for a deleting cluster")
+
+			node := &valkeyiov1alpha1.ValkeyNode{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: valkeyNodeName(resourceName, 0, 0), Namespace: "default"}, node)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "ValkeyNode should not be created for a deleting cluster")
+		})
+	})
 })
 
 var _ = Describe("ValkeyCluster config hash propagation", func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

This PR closes #364

### Summary

Adds a check to determine if DeletionTimestamp is set on the Cluster. If yes then we exit reconciliation.

Prevents an endless loop of the operator recreating resources when it is supposed to be deleted.

### Testing

Tested with kind cluster locally to verify the fix.

```
kubectl apply -f config/samples/v1alpha1_valkeycluster.yaml
# wait for cluster ok
kubectl get valkeyclusters.valkey.io cluster-sample -w
# delete with cascade=foreground
kubectl delete valkeyclusters.valkey.io cluster-sample --cascade=foreground
```

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
