### PR TITLE
feat: gate ACLApplied on an ACL revision user so permission edits are honest

### DIFF
--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -218,7 +218,10 @@ const (
 	// ValkeyNodeConditionACLApplied indicates that the ACL the cluster controller
 	// wrote to the mounted Secret is live on the server. It is applied via ACL
 	// LOAD without a pod roll, so ACL never enters Spec.WorkloadRevision. True
-	// means the desired user set and their password hashes are live.
+	// means the desired user set, their password hashes, and the current ACL
+	// revision are live, confirmed by a bookkeeping revision user whose password
+	// is a hash of the managed ACL (see aclRevisionUser); permission-only
+	// edits are therefore honoured too.
 	ValkeyNodeConditionACLApplied = "ACLApplied"
 	// ValkeyNodeConditionWorkloadRollPending indicates a rolling pod-template update
 	// is intentionally deferred: the desired template differs from live, and

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -206,19 +206,17 @@ This condition is set once the node is ready and mounts an ACL Secret. An edit r
 
 | Status | Meaning |
 |---|---|
-| `True` | The desired user set and their password hashes are live on the server. |
-| `False` | The reload ran but the running ACL does not yet match the desired users and passwords (for example the mounted aclfile has not refreshed yet), or the reload failed. |
+| `True` | The desired user set, their password hashes, and the current ACL revision are live on the server. |
+| `False` | The reload ran but the running ACL does not yet match the desired revision (for example the mounted aclfile has not refreshed yet), or the reload failed. |
 
 Common reasons when `ACLApplied=False`:
 - `PendingPropagation` – the reload read a stale mounted aclfile; the node retries until the projected volume catches up.
 - `ApplyFailed` – `ACL LOAD` or the follow-up read returned an error. The message field contains the exact error.
 
 Common reasons when `ACLApplied=True`:
-- `Applied` – the desired users and passwords are live.
+- `Applied` – the desired ACL revision is live.
 
-> **Note:** `ACLApplied` compares the user set and password hashes exactly, which is what a password rotation waits on. It is informational and does not block the cluster controller's one-at-a-time progress. On a failed apply the node controller emits a `LiveACLApplyFailed` warning event and retries with backoff.
->
-> **Limitation:** Only the user set and password hashes drive the condition, so only those changes move it through `PendingPropagation` back to `True`: adding or removing a user or a password. A change to a user's `enabled` flag or permissions still takes effect on the server (the reload is unconditional), but the condition does not report a transient `PendingPropagation` for it, so it is not a signal to wait on for those fields. Comparing rules directly would mean reimplementing Valkey's normalized ACL rendering; making the condition track every field is left as a follow-up.
+> **Note:** The operator appends a disabled bookkeeping user, `_operator_acl_revision`, to the aclfile. Its only password is a hash of the whole managed ACL, so a node reports `ACLApplied=True` only once the running server has loaded that exact revision. This keeps the condition honest for permission-only edits, which leave every user and password unchanged but still change the revision hash. The user is disabled (`off`) and cannot authenticate; it is expected to appear in `ACL LIST`. The condition is informational and does not block the cluster controller's one-at-a-time progress. On a failed apply the node controller emits a `LiveACLApplyFailed` warning event and retries with backoff.
 
 #### `WorkloadRollPending`
 Indicates that a rolling pod-template update is intentionally deferred: the ValkeyNode controller has built a pod template that differs from the live StatefulSet or Deployment, but `spec.workloadRevision` has not yet authorized that template. This is expected staging while the cluster advances rolls one node at a time, not an error.

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -395,7 +395,7 @@ users:
 - `channels` — pub/sub channel patterns
 - `permissions` — raw ACL string appended after any generated rules
 
-ACL changes are applied to running nodes with `ACL LOAD` (no pod restart), the same way live-settable config is applied without rolling pods. Each node reports an [`ACLApplied`](status-conditions.md#aclapplied) condition once the change is live on the server.
+ACL changes are applied to running nodes with `ACL LOAD` (no pod restart), the same way live-settable config is applied without rolling pods. Each node reports an [`ACLApplied`](status-conditions.md#aclapplied) condition once the change is live on the server. To confirm a node loaded the current revision, including permission-only edits, the operator appends a disabled bookkeeping user `_operator_acl_revision` whose password is a hash of the managed ACL. It cannot authenticate and is expected to appear in `ACL LIST`.
 
 > **Upgrade note:** Live application relies on the operator's `_operator` user holding the `acl|load`, `acl|getuser`, and `acl|users` commands, which older operator versions did not grant. Upgrading onto this version rewrites the pod template (it drops a now-unused annotation), so every existing cluster rolls once and picks up the new grants on restart, after which ACL changes apply live. The exception is a cluster old enough to predate that annotation entirely: it gets no automatic roll, so it needs a one-time manual pod restart after the upgrade before live ACL applies.
 

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -40,6 +40,16 @@ const (
 	hashAnnotationKey = "valkey.io/internal-acl-hash"
 	aclFilename       = "users.acl"
 	passwordLength    = 26
+	// aclRevisionUser is a disabled bookkeeping user appended to the
+	// aclfile whose only password hash is the hash of the managed ACL content
+	// above it. The ValkeyNode controller waits for this user to be present with
+	// the current hash before reporting ACLApplied, which is how it knows the
+	// running server loaded the current aclfile revision rather than a stale
+	// mounted copy. Because the hash covers the whole managed ACL, it also
+	// catches permission-only edits that leave user and password identities
+	// unchanged. It is disabled (off), so its content-hash password is never a
+	// usable credential.
+	aclRevisionUser = "_operator_acl_revision"
 )
 
 var (
@@ -199,6 +209,22 @@ func (r *ValkeyClusterReconciler) reconcileUsersAcl(ctx context.Context, cluster
 		return err
 	}
 	fmt.Fprintf(&usersAcls, "%s\n", systemUsersAcl)
+
+	// Append the revision user last, so its password hash covers every
+	// managed entry above. A node reports ACLApplied only once this user loads
+	// with this exact hash, which confirms the running server holds the current
+	// aclfile revision. Because the hash covers the whole managed ACL, a
+	// permission-only edit (unchanged users and passwords) still changes this
+	// user's hash and is detected. See aclRevisionUser and aclObservablyInSync.
+	//
+	// This is the only place the internal ACL Secret's aclfile is assembled,
+	// and the revision user must be present in every version written here. Any
+	// future code path that writes aclFilename without appending it would leave
+	// a stale revision on disk: aclObservablyInSync would then never match, and
+	// every node would report ACLApplied=False forever. Keep aclfile assembly in
+	// this one function.
+	revisionHash := fmt.Sprintf("%x", sha256.Sum256([]byte(usersAcls.String())))
+	fmt.Fprintf(&usersAcls, "user %s off resetchannels -@all #%s\n", aclRevisionUser, revisionHash)
 	usersAclsBytes := []byte(usersAcls.String())
 
 	// update the internal ACL secret with the generated users ACLs

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -623,6 +623,16 @@ var _ = Describe("reconcileUsersAcl", func() {
 
 			// assert that the generated password for users are not nil/empty string
 			Expect(acl).NotTo(ContainSubstring(nilPassword))
+
+			// The revision user is appended last, disabled, and its only
+			// password is the hash of every managed entry above it.
+			revisionPrefix := "user " + aclRevisionUser + " off"
+			Expect(acl).To(ContainSubstring(revisionPrefix))
+			idx := strings.Index(acl, revisionPrefix)
+			Expect(idx).To(BeNumerically(">", 0), "the revision user must come after the managed users")
+			managed := acl[:idx]
+			Expect(acl).To(ContainSubstring(fmt.Sprintf("#%x", sha256.Sum256([]byte(managed)))),
+				"its password must be the hash of the managed ACL above it")
 		})
 
 		It("should update the system user secret when spec.exporter is enabled after cluster creation", func() {

--- a/internal/controller/valkeynode_acl.go
+++ b/internal/controller/valkeynode_acl.go
@@ -64,17 +64,20 @@ func normalizeHashes(hashes []string) []string {
 	return slices.Compact(hashes)
 }
 
-// aclObservablyInSync reports whether the parts of the ACL that can be compared
-// exactly are live on the server: the set of users, and each user's password
+// aclObservablyInSync reports whether the ACL the cluster controller wrote is
+// live on the server, by comparing the set of users and each user's password
 // hashes.
 //
-// Permissions are deliberately not compared. ACL GETUSER returns Valkey's
+// Permissions are not compared field by field. ACL GETUSER returns Valkey's
 // normalized rendering of the rules, while the operator only holds the aclfile
-// text, so comparing the two would mean reimplementing Valkey's own ACL parser
-// and keeping it in step with the server. Correctness of the apply does not
-// depend on this check either way: the reload is unconditional, so permission
-// edits converge regardless. This only scopes what ACLApplied can honestly
-// claim.
+// text, so comparing the two directly would mean reimplementing Valkey's own
+// ACL parser and keeping it in step with the server. Instead the aclfile carries
+// a revision user (see aclRevisionUser): a disabled user whose only
+// password hash is the hash of the whole managed ACL. It is compared here like
+// any other user, so an edit that changes only permissions still changes the
+// revision hash and reads as out of sync until the running server loads the
+// current revision. That closes the window where a permission-only change would
+// otherwise read as applied while a stale mounted aclfile was still in effect.
 func aclObservablyInSync(ctx context.Context, c valkeyConfigClient, desired map[string][]string) (bool, error) {
 	actualUsers, err := c.UserNames(ctx)
 	if err != nil {
@@ -114,16 +117,17 @@ func aclObservablyInSync(ctx context.Context, c valkeyConfigClient, desired map[
 // The projected volume is refreshed lazily by kubelet, so a LOAD fired right
 // after the Secret changes can read the pre-update file and silently no-op.
 //
-// The reload is therefore unconditional. The operator cannot read the pod's
-// copy of the file, and it cannot compare the whole ACL against the server
-// either (ACL GETUSER renders Valkey's normalized form, the operator holds
-// aclfile text), so there is no reliable way to know the file is current. A
-// repeated LOAD is idempotent and cheap, and it is what makes every kind of
-// change converge, including permission edits and removed users, once the
-// volume catches up.
+// The reload is therefore unconditional: the operator cannot read the pod's copy
+// of the file, so before a LOAD it has no way to know whether the mounted file
+// is current. A repeated LOAD is idempotent and cheap, and it is what makes
+// every kind of change converge, including permission edits and removed users,
+// once the volume catches up.
 //
-// The returned bool reports the parts that can be compared exactly, the user
-// set and their password hashes, which is what a rotation needs to wait on.
+// The returned bool reports whether the load took: aclObservablyInSync compares
+// the user set, their password hashes, and the revision user whose hash
+// covers the whole managed ACL. A True result therefore means the current
+// revision is live, permissions included, not only that users and passwords
+// match.
 func (r *ValkeyNodeReconciler) applyLiveACL(ctx context.Context, node *valkeyiov1alpha1.ValkeyNode) (bool, error) {
 	if node.Spec.UsersACLSecretName == "" {
 		return true, nil

--- a/internal/controller/valkeynode_acl_test.go
+++ b/internal/controller/valkeynode_acl_test.go
@@ -55,6 +55,17 @@ func TestDesiredUserPasswordHashesEmpty(t *testing.T) {
 	assert.Empty(t, desiredUserPasswordHashes("\n\n"))
 }
 
+func TestDesiredUserPasswordHashesParsesRevisionUser(t *testing.T) {
+	// The revision user is an ordinary "user <name> ... #hash" line, so it is
+	// parsed like any other user and flows through aclObservablyInSync with no
+	// special handling.
+	got := desiredUserPasswordHashes(
+		"user alice on #aaa ~* +@all\n" +
+			"user " + aclRevisionUser + " off resetchannels -@all #deadbeef\n")
+	assert.Equal(t, []string{"aaa"}, got["alice"])
+	assert.Equal(t, []string{"deadbeef"}, got[aclRevisionUser], "the revision user is parsed as a normal user")
+}
+
 func TestACLObservablyInSync(t *testing.T) {
 	ctx := context.Background()
 	desired := map[string][]string{"alice": {"aaa", "bbb"}, "bob": {"ccc"}}
@@ -125,5 +136,49 @@ func TestACLObservablyInSync(t *testing.T) {
 		f := &fakeConfigClient{aclErr: assert.AnError}
 		_, err := aclObservablyInSync(ctx, f, desired)
 		require.Error(t, err)
+	})
+
+	t.Run("a stale revision user reads as out of sync even when users and passwords match", func(t *testing.T) {
+		// A permission-only edit leaves every user and password identity
+		// unchanged but changes the managed-content hash the revision user carries.
+		// It must read as out of sync until the current revision loads,
+		// or a permission change would be reported applied while the stale
+		// mounted aclfile is still in effect.
+		withRevision := map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"}, aclRevisionUser: {"newrev"},
+		}
+		f := &fakeConfigClient{aclHashes: map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"}, aclRevisionUser: {"oldrev"},
+		}}
+		inSync, err := aclObservablyInSync(ctx, f, withRevision)
+		require.NoError(t, err)
+		assert.False(t, inSync, "a stale revision must keep the node out of sync")
+	})
+
+	t.Run("a matching revision user reads as in sync", func(t *testing.T) {
+		withRevision := map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"}, aclRevisionUser: {"rev1"},
+		}
+		f := &fakeConfigClient{aclHashes: map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"}, aclRevisionUser: {"rev1"},
+		}}
+		inSync, err := aclObservablyInSync(ctx, f, withRevision)
+		require.NoError(t, err)
+		assert.True(t, inSync)
+	})
+
+	t.Run("a server missing the revision user reads as out of sync", func(t *testing.T) {
+		// Until the server loads a revision that includes the revision user, the
+		// desired revision user is absent from the server, so the node is not yet
+		// in sync even if every real user and password already matches.
+		withRevision := map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"}, aclRevisionUser: {"rev1"},
+		}
+		f := &fakeConfigClient{aclHashes: map[string][]string{
+			"alice": {"aaa", "bbb"}, "bob": {"ccc"},
+		}}
+		inSync, err := aclObservablyInSync(ctx, f, withRevision)
+		require.NoError(t, err)
+		assert.False(t, inSync, "a server without the revision user must not read as in sync")
 	})
 }


### PR DESCRIPTION
This PR closes #369

### Summary

`ACLApplied` compares the user set and each user's password hashes, so a permission-only edit leaves it reading `True` for the whole window before the mounted aclfile refreshes, while the granted or revoked command is not yet live on the server.

### Features / Behaviour Changes

The aclfile gains a trailing disabled user, `_operator_acl_revision`, whose only password hash is a hash of the managed ACL above it. It appears in `ACL LIST` and `ACL USERS`. It is `off` with `-@all` and no keys or channels, so it cannot authenticate and holds no capability.

`ACLApplied` now reads `True` only once the running server has loaded the current revision, permission edits included.

### Implementation

Comparing permissions directly is not practical: `ACL GETUSER` returns Valkey's normalized rendering of the rules while the operator only holds the aclfile text, so a field-by-field comparison would mean reimplementing Valkey's ACL parser and keeping it in step with the server.

The revision user sidesteps that. Its password hash covers every managed entry above it, so any edit changes it, and it then flows through the user and password-hash comparison that `aclObservablyInSync` already does. It needs no new comparison logic, and the condition stops depending on which fields happen to be comparable.

`reconcileUsersAcl` is the only place the aclfile is assembled, and the revision user has to be appended in every version written there. A path that wrote the file without it would leave a stale revision on the server and hold every node at `ACLApplied=False` forever, so there is a comment on that function saying to keep aclfile assembly in one place.

### Limitations

The revision user is a workaround for the server having no way to report which ACL revision it holds. valkey-io/valkey#4355 proposes `ACL DIGEST` for exactly this, and the TSC vote on it is currently 3 core-team approvals with no objections. Once that command exists, the operator can compare the server's digest directly and the bookkeeping user can be dropped, behind a version gate of the kind #307 is adding.

### Testing

Unit tests cover the revision user being appended last and its hash covering the managed entries above it, plus the sync comparison.

Verified on a local k3d cluster, both directions, using a permission-only edit that leaves users and passwords untouched.

On this branch, `ACLApplied` held `False` with reason `PendingPropagation` for about 40 seconds, the mounted-secret refresh window, then flipped to `True` once the reload landed. The revision hash changed with the edit. `ACL GETUSER _operator_acl_revision` on the server reported `off`, `-@all`, no keys and no channels.

On a build of `main` with the same cluster and the same class of edit, starting from a stable `True`, the condition stayed `True` for the full 60 seconds and never signalled, which is the behaviour #369 describes.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)