### PR TITLE
ci: remove unnecessary disk space reclaim from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,6 @@ jobs:
           # Registry refs must be lowercase; $GITHUB_REPOSITORY may not be.
           echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
-      - name: Reclaim disk space
-        run: |
-          docker image prune --force --all
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-
       - name: Sanitize platform for artifact name
         id: prep
         run: |


### PR DESCRIPTION
This PR is part of #371

### Summary

Remove the "Reclaim disk space" step from the publish workflow. It is no longer needed since the move from QEMU emulation to native per-arch runners.

Cuts the amd64 build time in half for most publish runs, i.e. removes up to 4 minutes in some runs (!!?).

### Testing

Verified on a fork with disk space logging. The runner starts with 105GB free and the build uses ~4GB, well within capacity without any reclaim.

### Checklist

Before submitting the PR make sure the following are checked:

- [X] This Pull Request is related to one issue.
- [X] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [ ] Documentation files are updated.
- [X] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
