### PR TITLE
test(e2e): add AST-based scan to verify _operator ACL covers all operator commands

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -38,6 +38,44 @@ Run a specific e2e test by label:
 TEST_LABELS="<label>" make test-e2e
 ```
 
+## Keeping the "_operator" ACL in sync
+
+The operator connects to Valkey as a system user called `_operator`, whose ACL is
+hand-maintained in `internal/controller/users.go`. If reconciliation code starts
+issuing a new command, that ACL has to grant it too, or the operator locks itself
+out at runtime.
+
+Rather than trust that ACL to be kept up to date by hand, `internal/aclscan`
+statically discovers every Valkey command the operator's reconciliation code
+(`cmd/`, `internal/`) actually issues, by scanning its source for valkey-go
+client calls — both the builder pattern (`client.B().ClusterInfo()...Build()`)
+and raw `Arbitrary(...)` calls. Builder method names are resolved to command
+tokens by parsing valkey-go's own generated command builders on disk, so the
+mapping tracks whichever valkey-go version the operator is built against
+instead of being a second hand-maintained list.
+
+To see the current set of commands the operator issues:
+
+```sh
+go run ./hack/aclscan
+```
+
+The e2e suite (`test/e2e/valkeycluster_test.go`, "validating the _operator ACL
+covers every command the operator runs") uses the same package to check this
+list against a live cluster: for every discovered command it runs
+`ACL DRYRUN _operator <command>` and fails if any of them come back denied.
+That test only runs as part of `make test-e2e`, so a missing ACL grant won't
+be caught by `make test` alone — when you add a new valkey-go client call to
+the operator's reconciliation code, update the `_operator` ACL in
+`internal/controller/users.go` accordingly and run `make test-e2e` (or at
+least `go run ./hack/aclscan` plus a manual `ACL DRYRUN`) to confirm.
+
+Because it works by parsing Go source rather than executing it, `aclscan` can't
+resolve a command whose tokens aren't literal at the call site (e.g. an entirely
+dynamic `Arbitrary(cmdVar)`); it errors out in that case rather than silently
+skipping the call, so an unscannable call site gets noticed instead of quietly
+falling out of ACL coverage.
+
 ## Prerequisites
 
 - Go v1.25.0+.

--- a/hack/aclscan/main.go
+++ b/hack/aclscan/main.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command aclscan prints the Valkey commands the operator's reconciliation
+// code issues, as discovered by statically scanning cmd/ and internal/ for
+// valkey-go client calls. It's a manual-inspection aid for keeping the
+// "_operator" system user's ACL (internal/controller/users.go) in sync with
+// the code; test/e2e uses the same package to verify ACL coverage against a
+// live cluster via ACL DRYRUN.
+//
+// Usage: go run ./hack/aclscan
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/valkey-io/valkey-operator/internal/aclscan"
+)
+
+func main() {
+	commands, err := aclscan.OperatorCommands()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "aclscan:", err)
+		os.Exit(1)
+	}
+	for _, c := range commands {
+		fmt.Println(c.String())
+	}
+}

--- a/internal/aclscan/aclscan.go
+++ b/internal/aclscan/aclscan.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package aclscan statically discovers the Valkey commands the operator
+// issues, by scanning its source for valkey-go client calls. It exists so
+// the operator's own ACL for its "_operator" system user can be checked
+// against what the code actually does, rather than a hand-maintained list
+// that can silently drift as commands are added.
+//
+// Two call shapes are recognized:
+//   - the valkey-go builder pattern, e.g. `client.B().ClusterInfo()...Build()`
+//   - raw `client.B().Arbitrary("CLUSTER", "GETSLOTMIGRATIONS")` calls
+//
+// Builder method names are resolved to command tokens by parsing valkey-go's
+// own generated command builders on disk, so the mapping tracks whichever
+// valkey-go version the operator is built against instead of being
+// hand-maintained here.
+package aclscan
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const (
+	operatorModule = "github.com/valkey-io/valkey-operator"
+	valkeyGoModule = "github.com/valkey-io/valkey-go"
+)
+
+// operatorScanDirs are the source directories, relative to the operator
+// module root, that make up the operator's reconciliation code and are
+// therefore in scope for command discovery.
+var operatorScanDirs = []string{"cmd", "internal"}
+
+// Command is a single Valkey command/subcommand, e.g. []string{"CLUSTER", "INFO"},
+// together with the source location it was discovered at.
+type Command struct {
+	Tokens []string
+	Pos    string
+}
+
+func (c Command) String() string {
+	return strings.Join(c.Tokens, " ")
+}
+
+// OperatorCommands returns the set of Valkey commands issued by the
+// operator's own reconciliation code (cmd/ and internal/), discovered via
+// static analysis rather than a hand-maintained list.
+func OperatorCommands() ([]Command, error) {
+	operatorDir, err := moduleDir(operatorModule)
+	if err != nil {
+		return nil, fmt.Errorf("locating %s module: %w", operatorModule, err)
+	}
+	valkeyGoDir, err := moduleDir(valkeyGoModule)
+	if err != nil {
+		return nil, fmt.Errorf("locating %s module: %w", valkeyGoModule, err)
+	}
+
+	builderTokens, err := builderCommandTokens(filepath.Join(valkeyGoDir, "internal", "cmds"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing valkey-go command builders: %w", err)
+	}
+
+	var commands []Command
+	for _, dir := range operatorScanDirs {
+		found, err := scanDir(filepath.Join(operatorDir, dir), builderTokens)
+		if err != nil {
+			return nil, fmt.Errorf("scanning %s: %w", dir, err)
+		}
+		commands = append(commands, found...)
+	}
+
+	return dedupe(commands), nil
+}
+
+// moduleDir resolves the on-disk directory of a Go module via the local
+// module graph/cache, so results always match the version actually in use.
+func moduleDir(modulePath string) (string, error) {
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", modulePath).Output()
+	if err != nil {
+		return "", fmt.Errorf("go list -m %s: %w", modulePath, err)
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return "", fmt.Errorf("module %s resolved to no directory", modulePath)
+	}
+	return dir, nil
+}
+
+// builderCommandTokens parses valkey-go's command builder source and returns
+// a map of Builder entry-point method name (e.g. "ClusterSetConfigEpoch") to
+// the literal command tokens it sends (e.g. []string{"CLUSTER", "SET-CONFIG-EPOCH"}).
+func builderCommandTokens(cmdsDir string) (map[string][]string, error) {
+	entries, err := os.ReadDir(cmdsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := make(map[string][]string)
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(cmdsDir, name), nil, 0)
+		if err != nil {
+			return nil, err
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || !isBuilderEntryPoint(fn) {
+				continue
+			}
+			if cmd := firstAppendLiterals(fn.Body); cmd != nil {
+				tokens[fn.Name.Name] = cmd
+			}
+		}
+	}
+	return tokens, nil
+}
+
+// isBuilderEntryPoint reports whether fn is a method on valkey-go's
+// `Builder` type, i.e. the entry point of a command chain reachable as
+// `client.B().Xxx()`. Methods on the various `Incomplete`-derived chain
+// types (e.g. the return of ClusterInfo) are intentionally excluded: they
+// continue a command already identified by its entry point.
+func isBuilderEntryPoint(fn *ast.FuncDecl) bool {
+	if fn.Recv == nil || len(fn.Recv.List) != 1 {
+		return false
+	}
+	ident, ok := fn.Recv.List[0].Type.(*ast.Ident)
+	return ok && ident.Name == "Builder"
+}
+
+// firstAppendLiterals finds the first `x.cs.s = append(x.cs.s, "A", "B", ...)`
+// statement in body and returns the literal string tokens being appended, or
+// nil if the command's tokens aren't static literals (e.g. Arbitrary, which
+// forwards a caller-supplied slice).
+func firstAppendLiterals(body *ast.BlockStmt) []string {
+	if body == nil {
+		return nil
+	}
+	for _, stmt := range body.List {
+		assign, ok := stmt.(*ast.AssignStmt)
+		if !ok || len(assign.Rhs) != 1 {
+			continue
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		fun, ok := call.Fun.(*ast.Ident)
+		if !ok || fun.Name != "append" || len(call.Args) < 2 {
+			continue
+		}
+		if tokens := stringLiteralArgs(call.Args[1:]); tokens != nil {
+			return tokens
+		}
+	}
+	return nil
+}
+
+// scanDir walks dir for non-test Go source, looking for `x.B().Method(...)`
+// builder-pattern calls and `x.Arbitrary("A", "B", ...)` calls, resolving
+// them to Valkey command tokens via builderTokens.
+func scanDir(dir string, builderTokens map[string][]string) ([]Command, error) {
+	var commands []Command
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pos := fset.Position(call.Pos()).String()
+			if sel.Sel.Name == "Arbitrary" {
+				if tok := stringLiteralArgs(call.Args); tok != nil {
+					commands = append(commands, Command{Tokens: tok, Pos: pos})
+				}
+				return true
+			}
+			if isBuilderCall(sel.X) {
+				if tok, ok := builderTokens[sel.Sel.Name]; ok {
+					commands = append(commands, Command{Tokens: tok, Pos: pos})
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return commands, nil
+}
+
+// isBuilderCall reports whether expr is a call to a niladic `B()` method,
+// i.e. the receiver of the call being inspected is `x.B()`.
+func isBuilderCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "B"
+}
+
+// stringLiteralArgs returns the unquoted values of args if every one of them
+// is a string literal, or nil otherwise (e.g. a variable or spread argument).
+func stringLiteralArgs(args []ast.Expr) []string {
+	tokens := make([]string, 0, len(args))
+	for _, arg := range args {
+		lit, ok := arg.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return nil
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			return nil
+		}
+		tokens = append(tokens, value)
+	}
+	return tokens
+}
+
+func dedupe(commands []Command) []Command {
+	seen := make(map[string]Command, len(commands))
+	for _, c := range commands {
+		key := strings.Join(c.Tokens, " ")
+		if _, ok := seen[key]; !ok {
+			seen[key] = c
+		}
+	}
+	result := make([]Command, 0, len(seen))
+	for _, c := range seen {
+		result = append(result, c)
+	}
+	slices.SortFunc(result, func(a, b Command) int {
+		return strings.Compare(a.String(), b.String())
+	})
+	return result
+}

--- a/internal/aclscan/aclscan.go
+++ b/internal/aclscan/aclscan.go
@@ -183,8 +183,17 @@ func firstAppendLiterals(body *ast.BlockStmt) []string {
 }
 
 // scanDir walks dir for non-test Go source, looking for `x.B().Method(...)`
-// builder-pattern calls and `x.Arbitrary("A", "B", ...)` calls, resolving
-// them to Valkey command tokens via builderTokens.
+// builder-pattern calls and `x.B().Arbitrary("A", "B", ...)` calls, resolving
+// them to Valkey command tokens via builderTokens (see scanFunc). A bare
+// `y.Method(...)` call is only treated as a command when y is itself an
+// inline `x.B()` call; other receivers (including a variable previously
+// assigned `x.B()`) are not builder calls and are either ignored or, for the
+// variable case, reported as an error so the gap is visible rather than
+// silently under-reporting commands. Every function body — a top-level
+// *ast.FuncDecl or a *ast.FuncLit wherever one appears, e.g. a package-level
+// `var handler = func() {...}` — is scanned independently via scanFunc, so
+// builder-variable tracking can't leak from one function's scope into an
+// unrelated one that happens to reuse the same variable name.
 func scanDir(dir string, builderTokens map[string][]string) ([]Command, error) {
 	var commands []Command
 	fset := token.NewFileSet()
@@ -199,35 +208,91 @@ func scanDir(dir string, builderTokens map[string][]string) ([]Command, error) {
 		if err != nil {
 			return err
 		}
+		var scanErr error
 		ast.Inspect(file, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
+			var body *ast.BlockStmt
+			switch fn := n.(type) {
+			case *ast.FuncDecl:
+				body = fn.Body
+			case *ast.FuncLit:
+				body = fn.Body
+			default:
 				return true
 			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
+			if body == nil {
 				return true
 			}
-			pos := fset.Position(call.Pos()).String()
-			if sel.Sel.Name == "Arbitrary" {
-				if tok := stringLiteralArgs(call.Args); tok != nil {
-					commands = append(commands, Command{Tokens: tok, Pos: pos})
-				}
-				return true
+			found, err := scanFunc(body, fset, builderTokens)
+			if err != nil {
+				scanErr = err
+				return false
 			}
-			if isBuilderCall(sel.X) {
-				if tok, ok := builderTokens[sel.Sel.Name]; ok {
-					commands = append(commands, Command{Tokens: tok, Pos: pos})
-				}
-			}
-			return true
+			commands = append(commands, found...)
+			// scanFunc's own ast.Inspect already covers this function's
+			// entire body, including any nested func literals, so don't
+			// descend into it again from here.
+			return false
 		})
-		return nil
+		return scanErr
 	})
 	if err != nil {
 		return nil, err
 	}
 	return commands, nil
+}
+
+// scanFunc scans a single function body for builder-pattern and Arbitrary
+// calls, resolving them to Valkey command tokens via builderTokens.
+// builderVars, which tracks local variables assigned a bare `x.B()` result
+// (whether via `b := client.B()` or `var b = client.B()`), is scoped to this
+// one function body: see scanDir's doc comment for why. A nested func
+// literal shares its enclosing function's builderVars rather than getting
+// its own (scanDir only calls scanFunc at the outermost function it finds),
+// which is a conservative approximation of real lexical scoping but not one
+// that matters in practice for this codebase's style.
+func scanFunc(body *ast.BlockStmt, fset *token.FileSet, builderTokens map[string][]string) ([]Command, error) {
+	var commands []Command
+	var scanErr error
+	builderVars := make(map[string]bool)
+	ast.Inspect(body, func(n ast.Node) bool {
+		if assign, ok := n.(*ast.AssignStmt); ok && len(assign.Lhs) == 1 && len(assign.Rhs) == 1 {
+			if ident, ok := assign.Lhs[0].(*ast.Ident); ok {
+				recordBuilderVar(ident.Name, assign.Rhs[0], builderVars)
+			}
+		}
+		if spec, ok := n.(*ast.ValueSpec); ok && len(spec.Names) == 1 && len(spec.Values) == 1 {
+			recordBuilderVar(spec.Names[0].Name, spec.Values[0], builderVars)
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pos := fset.Position(call.Pos()).String()
+		switch {
+		case isBuilderCall(sel.X):
+			if sel.Sel.Name == "Arbitrary" {
+				tok := leadingStringLiterals(call.Args)
+				if len(tok) == 0 {
+					scanErr = fmt.Errorf("%s: Arbitrary call whose command is not a string literal; aclscan cannot resolve it", pos)
+					return false
+				}
+				commands = append(commands, Command{Tokens: tok, Pos: pos})
+				return true
+			}
+			if tok, ok := builderTokens[sel.Sel.Name]; ok {
+				commands = append(commands, Command{Tokens: tok, Pos: pos})
+			}
+		case isBuilderVarRef(sel.X, builderVars):
+			scanErr = fmt.Errorf("%s: builder call made through a variable (e.g. `b := client.B(); b.%s(...)`); aclscan only recognizes the inline client.B().Method() form", pos, sel.Sel.Name)
+			return false
+		}
+		return true
+	})
+	return commands, scanErr
 }
 
 // isBuilderCall reports whether expr is a call to a niladic `B()` method,
@@ -241,9 +306,27 @@ func isBuilderCall(expr ast.Expr) bool {
 	return ok && sel.Sel.Name == "B"
 }
 
+// isBuilderVarRef reports whether expr is a reference to a local variable
+// previously assigned a bare `x.B()` result, per builderVars.
+func isBuilderVarRef(expr ast.Expr, builderVars map[string]bool) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && builderVars[ident.Name]
+}
+
+// recordBuilderVar marks name in builderVars if value is a bare `x.B()`
+// call, e.g. the right-hand side of `b := client.B()` or `var b = client.B()`.
+func recordBuilderVar(name string, value ast.Expr, builderVars map[string]bool) {
+	if isBuilderCall(value) {
+		builderVars[name] = true
+	}
+}
+
 // stringLiteralArgs returns the unquoted values of args if every one of them
 // is a string literal, or nil otherwise (e.g. a variable or spread argument).
 func stringLiteralArgs(args []ast.Expr) []string {
+	if len(args) == 0 {
+		return nil
+	}
 	tokens := make([]string, 0, len(args))
 	for _, arg := range args {
 		lit, ok := arg.(*ast.BasicLit)
@@ -253,6 +336,27 @@ func stringLiteralArgs(args []ast.Expr) []string {
 		value, err := strconv.Unquote(lit.Value)
 		if err != nil {
 			return nil
+		}
+		tokens = append(tokens, value)
+	}
+	return tokens
+}
+
+// leadingStringLiterals returns the leading string-literal arguments of
+// args, stopping at the first non-literal (e.g. a slot number formatted via
+// strconv.Itoa) and capped at two, since an ACL only ever needs to know the
+// command and subcommand, not the arguments that follow.
+func leadingStringLiterals(args []ast.Expr) []string {
+	n := min(len(args), 2)
+	tokens := make([]string, 0, n)
+	for _, arg := range args[:n] {
+		lit, ok := arg.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			break
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			break
 		}
 		tokens = append(tokens, value)
 	}

--- a/internal/aclscan/aclscan_test.go
+++ b/internal/aclscan/aclscan_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aclscan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperatorCommands is a regression test: it locks in the set of Valkey
+// commands the operator's reconciliation code currently issues. Adding a
+// new client.B().Xxx() or Arbitrary() call anywhere under cmd/ or internal/
+// should update this list - and, together with it, the "_operator" ACL in
+// internal/controller/users.go and the e2e ACL DRYRUN coverage check.
+func TestOperatorCommands(t *testing.T) {
+	commands, err := OperatorCommands()
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(commands))
+	for _, c := range commands {
+		got = append(got, c.String())
+	}
+
+	want := []string{
+		"ACL GETUSER",
+		"ACL LOAD",
+		"ACL USERS",
+		"CLUSTER ADDSLOTSRANGE",
+		"CLUSTER FAILOVER",
+		"CLUSTER FORGET",
+		"CLUSTER GETSLOTMIGRATIONS",
+		"CLUSTER INFO",
+		"CLUSTER MEET",
+		"CLUSTER MIGRATESLOTS",
+		"CLUSTER MYID",
+		"CLUSTER MYSHARDID",
+		"CLUSTER NODES",
+		"CLUSTER REPLICATE",
+		"CLUSTER SET-CONFIG-EPOCH",
+		"CONFIG SET",
+		"INFO",
+	}
+	assert.ElementsMatch(t, want, got)
+}
+
+func TestBuilderCommandTokens(t *testing.T) {
+	valkeyGoDir, err := moduleDir(valkeyGoModule)
+	require.NoError(t, err)
+
+	tokens, err := builderCommandTokens(valkeyGoDir + "/internal/cmds")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"CLUSTER", "INFO"}, tokens["ClusterInfo"])
+	assert.Equal(t, []string{"CLUSTER", "SET-CONFIG-EPOCH"}, tokens["ClusterSetConfigEpoch"])
+	assert.Equal(t, []string{"CONFIG", "SET"}, tokens["ConfigSet"])
+	assert.Equal(t, []string{"INFO"}, tokens["Info"])
+	// Arbitrary forwards a caller-supplied slice rather than static
+	// literals, so it must not be resolvable via the builder token map;
+	// callers are expected to special-case it instead.
+	_, ok := tokens["Arbitrary"]
+	assert.False(t, ok)
+}
+
+func TestDedupe(t *testing.T) {
+	in := []Command{
+		{Tokens: []string{"CLUSTER", "INFO"}, Pos: "a.go:1"},
+		{Tokens: []string{"INFO"}, Pos: "b.go:2"},
+		{Tokens: []string{"CLUSTER", "INFO"}, Pos: "c.go:3"},
+	}
+	got := dedupe(in)
+	require.Len(t, got, 2)
+	assert.Equal(t, []string{"CLUSTER", "INFO"}, got[0].Tokens)
+	assert.Equal(t, []string{"INFO"}, got[1].Tokens)
+}
+
+func TestStringLiteralArgs(t *testing.T) {
+	assert.Empty(t, stringLiteralArgs(nil))
+}

--- a/internal/aclscan/aclscan_test.go
+++ b/internal/aclscan/aclscan_test.go
@@ -17,6 +17,9 @@ limitations under the License.
 package aclscan
 
 import (
+	"go/ast"
+	"go/parser"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,6 +80,148 @@ func TestBuilderCommandTokens(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestScanDirArbitraryNonLiteralCommand(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fake
+
+func run(client any) {
+	cmd := "CLUSTER"
+	client.B().Arbitrary(cmd, "SETSLOT")
+}
+`
+	require.NoError(t, os.WriteFile(dir+"/fake.go", []byte(src), 0o600))
+
+	_, err := scanDir(dir, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Arbitrary call whose command is not a string literal")
+}
+
+func TestScanDirArbitraryTrailingNonLiteral(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fake
+
+import "strconv"
+
+func run(client any) {
+	slot := 1
+	client.B().Arbitrary("CLUSTER", "SETSLOT", strconv.Itoa(slot))
+}
+`
+	require.NoError(t, os.WriteFile(dir+"/fake.go", []byte(src), 0o600))
+
+	commands, err := scanDir(dir, nil)
+	require.NoError(t, err)
+	require.Len(t, commands, 1)
+	assert.Equal(t, []string{"CLUSTER", "SETSLOT"}, commands[0].Tokens)
+}
+
+// TestScanDirArbitraryNonBuilderReceiver is a regression test for an
+// unrelated method that happens to be named Arbitrary but isn't reached via
+// client.B(): it must not be misdetected as a Valkey command.
+func TestScanDirArbitraryNonBuilderReceiver(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fake
+
+func run(formatter any) {
+	formatter.Arbitrary("X")
+}
+`
+	require.NoError(t, os.WriteFile(dir+"/fake.go", []byte(src), 0o600))
+
+	commands, err := scanDir(dir, nil)
+	require.NoError(t, err)
+	assert.Empty(t, commands)
+}
+
+// TestScanDirBuilderCallThroughVariable is a regression test for the
+// `b := client.B(); b.Method()` shape, which aclscan cannot currently
+// resolve: it must be surfaced as an error rather than silently dropped, so
+// the gap doesn't produce an under-reported command set.
+func TestScanDirBuilderCallThroughVariable(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fake
+
+func run(client any) {
+	b := client.B()
+	b.ClusterInfo()
+}
+`
+	require.NoError(t, os.WriteFile(dir+"/fake.go", []byte(src), 0o600))
+
+	_, err := scanDir(dir, map[string][]string{"ClusterInfo": {"CLUSTER", "INFO"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "builder call made through a variable")
+}
+
+// TestScanDirBuilderCallThroughVarDeclaredVariable is a regression test for
+// the `var b = client.B(); b.Method()` shape: builder variables introduced
+// via a var declaration (*ast.ValueSpec) must be tracked the same way as
+// ones introduced via `:=` (*ast.AssignStmt), or this case would silently
+// under-report commands instead of surfacing the same error.
+func TestScanDirBuilderCallThroughVarDeclaredVariable(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fake
+
+func run(client any) {
+	var b = client.B()
+	b.ClusterInfo()
+}
+`
+	require.NoError(t, os.WriteFile(dir+"/fake.go", []byte(src), 0o600))
+
+	_, err := scanDir(dir, map[string][]string{"ClusterInfo": {"CLUSTER", "INFO"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "builder call made through a variable")
+}
+
+// TestScanDirBuilderVarNameNotSharedAcrossFunctions is a regression test
+// ensuring builderVars is scoped per function: a local named `b` bound to
+// client.B() in one function (never itself called through, so it doesn't
+// trip the "unsupported" error above) must not cause an unrelated
+// `b.ClusterInfo()` call on a same-named but different `b` in a separate
+// function to be misdetected as a builder-via-variable call, which would
+// otherwise fail the whole scan over a false positive.
+func TestScanDirBuilderVarNameNotSharedAcrossFunctions(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fake
+
+func run(client any) {
+	b := client.B()
+	_ = b
+}
+
+func other(b any) {
+	b.ClusterInfo()
+}
+`
+	require.NoError(t, os.WriteFile(dir+"/fake.go", []byte(src), 0o600))
+
+	commands, err := scanDir(dir, map[string][]string{"ClusterInfo": {"CLUSTER", "INFO"}})
+	require.NoError(t, err)
+	assert.Empty(t, commands)
+}
+
+// TestScanDirBuilderCallInPackageLevelFuncLiteral is a regression test for a
+// func literal that isn't a top-level *ast.FuncDecl at all, e.g. a
+// package-level `var handler = func() {...}`: scanDir must still descend
+// into it rather than skipping it because it isn't a named function
+// declaration.
+func TestScanDirBuilderCallInPackageLevelFuncLiteral(t *testing.T) {
+	dir := t.TempDir()
+	src := `package fake
+
+var handler = func(client any) {
+	client.B().ClusterInfo()
+}
+`
+	require.NoError(t, os.WriteFile(dir+"/fake.go", []byte(src), 0o600))
+
+	commands, err := scanDir(dir, map[string][]string{"ClusterInfo": {"CLUSTER", "INFO"}})
+	require.NoError(t, err)
+	require.Len(t, commands, 1)
+	assert.Equal(t, []string{"CLUSTER", "INFO"}, commands[0].Tokens)
+}
+
 func TestDedupe(t *testing.T) {
 	in := []Command{
 		{Tokens: []string{"CLUSTER", "INFO"}, Pos: "a.go:1"},
@@ -91,4 +236,42 @@ func TestDedupe(t *testing.T) {
 
 func TestStringLiteralArgs(t *testing.T) {
 	assert.Empty(t, stringLiteralArgs(nil))
+
+	// A non-literal expression (e.g. a variable) means the command's tokens
+	// aren't statically known, so it must resolve to nil rather than being
+	// silently skipped.
+	dynamic, err := parser.ParseExpr("command")
+	require.NoError(t, err)
+	assert.Nil(t, stringLiteralArgs([]ast.Expr{dynamic}))
+
+	literal, err := parser.ParseExpr(`"CLUSTER"`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CLUSTER"}, stringLiteralArgs([]ast.Expr{literal}))
+}
+
+func TestLeadingStringLiterals(t *testing.T) {
+	assert.Empty(t, leadingStringLiterals(nil))
+
+	// A non-literal leading argument means the command itself isn't
+	// statically known, so nothing can be resolved.
+	dynamic, err := parser.ParseExpr("command")
+	require.NoError(t, err)
+	assert.Empty(t, leadingStringLiterals([]ast.Expr{dynamic}))
+
+	// An ACL only needs the command and subcommand: a call like
+	// Arbitrary("CLUSTER", "SETSLOT", strconv.Itoa(slot)) resolves to
+	// "CLUSTER SETSLOT" rather than being rejected outright for having a
+	// non-literal trailing argument.
+	cmd, err := parser.ParseExpr(`"CLUSTER"`)
+	require.NoError(t, err)
+	sub, err := parser.ParseExpr(`"SETSLOT"`)
+	require.NoError(t, err)
+	arg, err := parser.ParseExpr(`strconv.Itoa(slot)`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CLUSTER", "SETSLOT"}, leadingStringLiterals([]ast.Expr{cmd, sub, arg}))
+
+	// Capped at two tokens even if every argument is a literal.
+	third, err := parser.ParseExpr(`"EXTRA"`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CLUSTER", "SETSLOT"}, leadingStringLiterals([]ast.Expr{cmd, sub, third}))
 }

--- a/test/e2e/acl_dryrun_helper_test.go
+++ b/test/e2e/acl_dryrun_helper_test.go
@@ -1,0 +1,160 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/valkey-io/valkey-operator/internal/aclscan"
+	"github.com/valkey-io/valkey-operator/test/utils"
+)
+
+// maxAclDryRunPlaceholders bounds how many placeholder arguments aclDryRun
+// will pad a command with to satisfy its arity, as a safety net for
+// commands commandArities couldn't resolve (see its doc comment). Since ACL
+// DRYRUN never executes the command, placeholder values are never
+// interpreted; only the argument count matters for admin/cluster commands.
+const maxAclDryRunPlaceholders = 8
+
+// commandName is the "container|subcommand" form Valkey uses to name a
+// command in COMMAND INFO and in ACL rules (e.g. "+cluster|info"). aclscan
+// discovers commands as token slices (e.g. []string{"CLUSTER", "INFO"}); this
+// is the inverse of that for the handful of places that need the string form.
+func commandName(tokens []string) string {
+	return strings.ToLower(strings.Join(tokens, "|"))
+}
+
+// commandArities looks up the arity Valkey's own command table reports for
+// each discovered command, via a single COMMAND INFO call, so aclDryRun can
+// pad a command with exactly the right number of placeholder arguments up
+// front instead of probing one at a time (a wrong-arity ACL DRYRUN call for
+// e.g. CLUSTER MEET is itself a round-trip to the cluster over kubectl exec).
+//
+// arity follows Valkey's COMMAND INFO convention: a positive value is the
+// exact total token count (command name and subcommand included), a
+// negative value is the minimum. Commands missing from the result (e.g. if
+// the output format doesn't parse as expected) are simply absent from the
+// returned map; callers fall back to aclDryRun's own probing for those.
+func commandArities(podName string, valkeyCli []string, commands []aclscan.Command) (map[string]int, error) {
+	wanted := make(map[string]bool, len(commands))
+	names := make([]string, 0, len(commands))
+	for _, c := range commands {
+		name := commandName(c.Tokens)
+		if !wanted[name] {
+			wanted[name] = true
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	kubectlArgs := []string{"exec", podName, "-c", "server", "--"}
+	kubectlArgs = append(kubectlArgs, valkeyCli...)
+	kubectlArgs = append(kubectlArgs, "COMMAND", "INFO")
+	kubectlArgs = append(kubectlArgs, names...)
+
+	output, err := utils.Run(exec.Command("kubectl", kubectlArgs...))
+	if err != nil {
+		return nil, err
+	}
+
+	// valkey-cli isn't attached to a terminal under kubectl exec, so it
+	// prints each COMMAND INFO reply element on its own line rather than the
+	// "N) M) ..." bulleted form it uses interactively: a command's own name,
+	// immediately followed by its arity, then a variable number of lines for
+	// its flags/key-spec/acl-category/tip/subcommand fields that we don't
+	// need. Scanning for our own requested names is therefore both
+	// sufficient and robust to that variable-length tail.
+	lines := strings.Split(output, "\n")
+	arities := make(map[string]int, len(names))
+	for i := 0; i < len(lines)-1; i++ {
+		name := strings.TrimSpace(lines[i])
+		if !wanted[name] {
+			continue
+		}
+		if arity, err := strconv.Atoi(strings.TrimSpace(lines[i+1])); err == nil {
+			arities[name] = arity
+		}
+	}
+	return arities, nil
+}
+
+// placeholdersNeeded returns how many placeholder arguments must be
+// appended to tokens to satisfy arity (as returned by commandArities), or 0
+// if arity is unknown (ok is false) or already satisfied.
+func placeholdersNeeded(tokens []string, arity int, ok bool) int {
+	if !ok {
+		return 0
+	}
+	minTokens := arity
+	if arity < 0 {
+		minTokens = -arity
+	}
+	if needed := minTokens - len(tokens); needed > 0 {
+		return needed
+	}
+	return 0
+}
+
+// aclDryRun execs `<valkeyCli...> ACL DRYRUN <user> <tokens...>` in
+// podName's server container, padding tokens with minArgs placeholder
+// arguments up front (see commandArities/placeholdersNeeded) and, if that
+// wasn't enough, growing the padding further until Valkey stops reporting a
+// wrong-arity error. It returns the command's own last line of output (i.e.
+// with any valkey-cli warnings, such as the insecure-password-on-the-
+// command-line notice, stripped).
+func aclDryRun(podName string, valkeyCli []string, user string, tokens []string, minArgs int) (string, error) {
+	args := append([]string{}, tokens...)
+	for i := 0; i < minArgs; i++ {
+		args = append(args, "x")
+	}
+	for extra := 0; extra <= maxAclDryRunPlaceholders; extra++ {
+		kubectlArgs := []string{"exec", podName, "-c", "server", "--"}
+		kubectlArgs = append(kubectlArgs, valkeyCli...)
+		kubectlArgs = append(kubectlArgs, "ACL", "DRYRUN", user)
+		kubectlArgs = append(kubectlArgs, args...)
+
+		output, err := utils.Run(exec.Command("kubectl", kubectlArgs...))
+		if err != nil {
+			return "", err
+		}
+		result := lastNonEmptyLine(output)
+		if !strings.Contains(result, "wrong number of arguments") {
+			return result, nil
+		}
+		args = append(args, "x")
+	}
+	return "", fmt.Errorf("exceeded %d placeholder arguments without resolving arity for %q", maxAclDryRunPlaceholders, strings.Join(tokens, " "))
+}
+
+// lastNonEmptyLine returns the last non-empty line of output, trimmed. It's
+// used to strip valkey-cli's warnings (printed on their own line before the
+// actual reply) from combined stdout+stderr output.
+func lastNonEmptyLine(output string) string {
+	lines := utils.GetNonEmptyLines(output)
+	if len(lines) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(lines[len(lines)-1])
+}

--- a/test/e2e/valkeycluster_test.go
+++ b/test/e2e/valkeycluster_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
+	"github.com/valkey-io/valkey-operator/internal/aclscan"
 	controller "github.com/valkey-io/valkey-operator/internal/controller"
 	"github.com/valkey-io/valkey-operator/test/utils"
 )
@@ -659,6 +660,52 @@ EOF`,
 					len(disallowedCommands), output)
 			}
 			Eventually(verifyDeniedPermissionsOfOperatorUser).Should(Succeed())
+
+			By("validating the _operator ACL covers every command the operator runs")
+			verifyOperatorAclCoverage := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secrets", "valkey-cluster-sample-users", "-o", "jsonpath={.data.defaultpw}")
+
+				b64Password, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				decoded, err := base64.StdEncoding.DecodeString(b64Password)
+				g.Expect(err).NotTo(HaveOccurred())
+				defaultPassword := string(decoded)
+
+				cmd = exec.Command("kubectl", "get", "pods",
+					"-l", fmt.Sprintf("valkey.io/cluster=%s", withUserClusterName),
+					"-o", "jsonpath={.items[0].metadata.name}")
+				podName, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				podName = strings.TrimSpace(podName)
+				g.Expect(podName).NotTo(BeEmpty())
+
+				// Commands are discovered by statically scanning the operator's own
+				// source (cmd/, internal/) for valkey-go client calls, rather than
+				// relying on a hand-maintained list that can silently drift. This
+				// fails whenever new code issues a command the "_operator" ACL in
+				// internal/controller/users.go doesn't grant.
+				commands, err := aclscan.OperatorCommands()
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(commands).NotTo(BeEmpty())
+
+				valkeyCli := []string{"valkey-cli", "-a", defaultPassword}
+				arities, err := commandArities(podName, valkeyCli, commands)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				var denied []string
+				for _, command := range commands {
+					arity, ok := arities[commandName(command.Tokens)]
+					minArgs := placeholdersNeeded(command.Tokens, arity, ok)
+					result, err := aclDryRun(podName, valkeyCli, "_operator", command.Tokens, minArgs)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to run ACL DRYRUN for %q (%s)", command, command.Pos)
+					if result != "OK" {
+						denied = append(denied, fmt.Sprintf("%s (%s): %s", command, command.Pos, result))
+					}
+				}
+				g.Expect(denied).To(BeEmpty(),
+					"the _operator ACL is missing permissions for commands used in code:\n%s", strings.Join(denied, "\n"))
+			}
+			Eventually(verifyOperatorAclCoverage).Should(Succeed())
 
 		})
 


### PR DESCRIPTION
This PR closes [#389](https://github.com/valkey-io/valkey-operator/issues/389)

### Summary

Adds an AST-based scan that discovers every Valkey command the operator's reconciliation code issues, and wires it into the e2e suite so the _operator system user's ACL is verified against the live cluster via ACL DRYRUN instead of being checked by hand.

### Features / Behaviour Changes

- New `internal/aclscan` package: statically scans `cmd/` and `internal/` for valkey-go client calls (`client.B().Xxx()...Build()` builder chains and raw `Arbitrary(...)` calls) and returns the set of Valkey commands the operator can issue.
- New e2e test step (in `test/e2e/valkeycluster_test.go`) that runs `ACL DRYRUN _operator <command>` for every command aclscan discovers against a live cluster, and fails if any command is denied — catching drift between the `_operator` ACL in `internal/controller/users.go` and what the code actually does.
- New `hack/aclscan` CLI for manually listing the commands aclscan discovers (`go run ./hack/aclscan`), useful when updating the `_operator` ACL by hand.


### Implementation

- `internal/aclscan/aclscan.go`: resolves valkey-go builder method names (e.g. `ClusterSetConfigEpoch`) to their literal command tokens (e.g. `CLUSTER SET-CONFIG-EPOCH`) by parsing valkey-go's own generated command builders on disk via `go/ast`/`go/parser`, rather than hand-maintaining the mapping — so it stays correct across valkey-go version bumps. `Arbitrary(...)` calls are matched separately since they forward a caller-supplied slice rather than a static literal.
- `test/e2e/acl_dryrun_helper_test.go`: helper that runs `COMMAND INFO` once for all discovered commands to look up each one's arity, then pads each command with the right number of placeholder arguments (e.g. CLUSTER SET-CONFIG-EPOCH x) before calling `ACL DRYRUN`, so a "wrong number of arguments" reply isn't misread as a permission denial. Falls back to incrementally growing the padding (up to `maxAclDryRunPlaceholders`) for any command whose arity couldn't be resolved up front.
- The new e2e assertion is appended to the existing "It" block that already exercises the `_operator` user's permissions in `test/e2e/valkeycluster_test.go`, reusing its cluster/pod setup.

`internal/aclscan/aclscan.go`'s `isBuilderEntryPoint`/`firstAppendLiterals`/`isBuilderCall` are the core of the AST matching and are the parts most worth double-checking against valkey-go's actual generated code shape.

### Limitations

- Only two call shapes are recognized (builder-pattern and `Arbitrary`); a valkey-go call issued through some other pattern would silently not be picked up. This mirrors how the operator currently issues all of its commands, but is a blind spot if that changes.
- The scan is static (source-level), not a runtime trace, so it can't account for commands assembled dynamically from non-literal strings.
- `TestOperatorCommands` in `internal/aclscan/aclscan_test.go` pins the current command list; it needs a one-line update whenever the operator starts issuing a new command (intentional — it's meant to force a conscious ACL review, as noted in the test's doc comment).

### Testing

- `go test ./internal/aclscan/...` — unit tests for command discovery, builder-token parsing, and dedupe.
- `pre-commit run --all-files` — passes for the new code, shows issues in internal/valkey/cluster_rebalance_test.go which should be addressed separatly
- New e2e step run against a live cluster (`make test-e2e` / `ginkgo`, ACL coverage assertion in `valkeycluster_test.go`) to confirm `ACL DRYRUN` reports `OK` for every discovered command against the current `_operator` ACL.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)

Hope this matches your idea [@jdheyburn](https://github.com/jdheyburn) ! 
Open for feedback and ideas




