### PR TITLE
fix: generate the commands.allow/deny pattern and widen it to what Valkey accepts

### DIFF
--- a/api/v1alpha1/valkeyacls_types.go
+++ b/api/v1alpha1/valkeyacls_types.go
@@ -76,11 +76,11 @@ type CommandsAclSpec struct {
 	// Subcommands (client|setname, config|get, etc.)
 
 	// Allowed commands for this user
-	// +kubebuilder:validation:Items:Pattern=^[@a-z|]+$}
+	// +kubebuilder:validation:items:Pattern=`^[@A-Za-z0-9|_-]+$`
 	Allow []string `json:"allow,omitempty"`
 
 	// Denied commands for this user
-	// +kubebuilder:validation:Items:Pattern=^[@a-z|]+$}
+	// +kubebuilder:validation:items:Pattern=`^[@A-Za-z0-9|_-]+$`
 	Deny []string `json:"deny,omitempty"`
 }
 

--- a/api/v1alpha1/valkeyacls_types.go
+++ b/api/v1alpha1/valkeyacls_types.go
@@ -76,11 +76,11 @@ type CommandsAclSpec struct {
 	// Subcommands (client|setname, config|get, etc.)
 
 	// Allowed commands for this user
-	// +kubebuilder:validation:items:Pattern=`^[@A-Za-z0-9|_-]+$`
+	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$`
 	Allow []string `json:"allow,omitempty"`
 
 	// Denied commands for this user
-	// +kubebuilder:validation:items:Pattern=`^[@A-Za-z0-9|_-]+$`
+	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$`
 	Deny []string `json:"deny,omitempty"`
 }
 

--- a/api/v1alpha1/valkeyacls_types.go
+++ b/api/v1alpha1/valkeyacls_types.go
@@ -77,11 +77,11 @@ type CommandsAclSpec struct {
 	// Subcommands (client|setname, config|get, etc.)
 
 	// Allowed commands for this user
-	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$`
+	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*(\|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*)?)$`
 	Allow []string `json:"allow,omitempty"`
 
 	// Denied commands for this user
-	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$`
+	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*(\|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*)?)$`
 	Deny []string `json:"deny,omitempty"`
 }
 

--- a/api/v1alpha1/valkeyacls_types.go
+++ b/api/v1alpha1/valkeyacls_types.go
@@ -73,14 +73,15 @@ type CommandsAclSpec struct {
 
 	// Command categories (@all, @read, @write, @admin, etc.)
 	// Individual commands (get, set, ping, etc.)
+	// Module commands (json.set, bf.add, etc.)
 	// Subcommands (client|setname, config|get, etc.)
 
 	// Allowed commands for this user
-	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$`
+	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$`
 	Allow []string `json:"allow,omitempty"`
 
 	// Denied commands for this user
-	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$`
+	// +kubebuilder:validation:items:Pattern=`^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$`
 	Deny []string `json:"deny,omitempty"`
 }
 

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3619,11 +3619,13 @@ spec:
                         allow:
                           description: Allowed commands for this user
                           items:
+                            pattern: ^[@A-Za-z0-9|_-]+$
                             type: string
                           type: array
                         deny:
                           description: Denied commands for this user
                           items:
+                            pattern: ^[@A-Za-z0-9|_-]+$
                             type: string
                           type: array
                       type: object

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3619,13 +3619,13 @@ spec:
                         allow:
                           description: Allowed commands for this user
                           items:
-                            pattern: ^[@A-Za-z0-9|_-]+$
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$
                             type: string
                           type: array
                         deny:
                           description: Denied commands for this user
                           items:
-                            pattern: ^[@A-Za-z0-9|_-]+$
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$
                             type: string
                           type: array
                       type: object

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3619,13 +3619,13 @@ spec:
                         allow:
                           description: Allowed commands for this user
                           items:
-                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$
                             type: string
                           type: array
                         deny:
                           description: Denied commands for this user
                           items:
-                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\|[A-Za-z0-9_-]+)?)$
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$
                             type: string
                           type: array
                       type: object

--- a/config/crd/bases/valkey.io_valkeyclusters.yaml
+++ b/config/crd/bases/valkey.io_valkeyclusters.yaml
@@ -3619,13 +3619,13 @@ spec:
                         allow:
                           description: Allowed commands for this user
                           items:
-                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*(\|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*)?)$
                             type: string
                           type: array
                         deny:
                           description: Denied commands for this user
                           items:
-                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*(\|[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)*)?)$
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*(\|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*)?)$
                             type: string
                           type: array
                       type: object

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -390,7 +390,7 @@ users:
 `users` defines per-user [ACL rules](https://valkey.io/topics/acl/) distributed to every node via a Secret mounted into each pod.
 
 - `passwordSecret` — one or more password keys from a Secret (multiple keys supported for rotation)
-- `commands` — command categories (`@read`, `@write`, `@admin`, etc.), individual commands, and subcommands to allow or deny
+- `commands` — command categories (`@read`, `@write`, `@admin`, etc.), individual commands, and subcommands to allow or deny. Entries are validated on admission: a category is `@` followed by letters, a command is a name optionally followed by one `|` and a subcommand. The name itself is not checked against the server, so a well-formed but unknown command is only rejected later by Valkey when the ACL is loaded
 - `keys` — key patterns by access type: `readWrite`, `readOnly`, `writeOnly`
 - `channels` — pub/sub channel patterns
 - `permissions` — raw ACL string appended after any generated rules

--- a/docs/valkeycluster.md
+++ b/docs/valkeycluster.md
@@ -390,7 +390,7 @@ users:
 `users` defines per-user [ACL rules](https://valkey.io/topics/acl/) distributed to every node via a Secret mounted into each pod.
 
 - `passwordSecret` — one or more password keys from a Secret (multiple keys supported for rotation)
-- `commands` — command categories (`@read`, `@write`, `@admin`, etc.), individual commands, and subcommands to allow or deny. Entries are validated on admission: a category is `@` followed by letters, a command is a name optionally followed by one `|` and a subcommand. The name itself is not checked against the server, so a well-formed but unknown command is only rejected later by Valkey when the ACL is loaded
+- `commands` — command categories (`@read`, `@write`, `@admin`, etc.), individual commands, module commands (`json.set`), and subcommands to allow or deny. Entries are validated on admission: a category is `@` followed by letters, a command is a dot-separated name optionally followed by one `|` and a subcommand. The name itself is not checked against the server, so a well-formed but unknown command is only rejected later by Valkey when the ACL is loaded. Module commands are in no category except `@all`, so they must be granted individually
 - `keys` — key patterns by access type: `readWrite`, `readOnly`, `writeOnly`
 - `channels` — pub/sub channel patterns
 - `permissions` — raw ACL string appended after any generated rules

--- a/internal/controller/valkeycluster_acl_commands_validation_test.go
+++ b/internal/controller/valkeycluster_acl_commands_validation_test.go
@@ -103,6 +103,24 @@ var _ = Describe("users commands validation", func() {
 		}
 	})
 
+	// Character-class-only validation let these through. Valkey rejects every
+	// one of them, so the pattern has to constrain structure, not just the
+	// alphabet.
+	It("rejects entries with the right characters but the wrong shape", func() {
+		for _, entry := range []string{
+			"@",
+			"@@read",
+			"@-read",
+			"|",
+			"get|",
+			"|get",
+			"get||set",
+			"client|no|evict",
+		} {
+			Expect(applyWithCommands(entry)).NotTo(Succeed(), "entry %q must be rejected", entry)
+		}
+	})
+
 	It("rejects a bad entry in commands.deny as well", func() {
 		counter++
 		cluster := &valkeyiov1alpha1.ValkeyCluster{

--- a/internal/controller/valkeycluster_acl_commands_validation_test.go
+++ b/internal/controller/valkeycluster_acl_commands_validation_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
+)
+
+// The pattern markers on commands.allow/deny were malformed, so controller-gen
+// dropped them and any string reached the ACL file. Valkey then rejected the
+// file at ACL LOAD (#395).
+var _ = Describe("users commands validation", func() {
+	var (
+		ctx     context.Context
+		counter int
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	// applyWithCommands creates a cluster carrying a single user whose
+	// commands.allow holds entry, and returns the API server's verdict.
+	applyWithCommands := func(entry string) error {
+		counter++
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("acl-cmd-%d", counter),
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+				Users: []valkeyiov1alpha1.UserAclSpec{{
+					Name:       "alice",
+					Enabled:    true,
+					NoPassword: true,
+					Commands:   valkeyiov1alpha1.CommandsAclSpec{Allow: []string{entry}},
+				}},
+			},
+		}
+		err := k8sClient.Create(ctx, cluster)
+		if err == nil {
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, cluster)
+			})
+		}
+		return err
+	}
+
+	// Every one of these is accepted by Valkey's own ACL parser. Categories and
+	// plain commands aside, the awkward ones carry a digit, an underscore or a
+	// hyphen, and Valkey normalises case, so the pattern cannot be lowercase
+	// letters only.
+	It("accepts command entries that Valkey accepts", func() {
+		for _, entry := range []string{
+			"@read",
+			"@all",
+			"get",
+			"client|setname",
+			"cluster|set-config-epoch",
+			"restore-asking",
+			"eval_ro",
+			"bitfield_ro",
+			"memory|malloc-stats",
+			"GET",
+			"CLIENT|SETNAME",
+		} {
+			Expect(applyWithCommands(entry)).To(Succeed(), "entry %q must be accepted", entry)
+		}
+	})
+
+	It("rejects entries that cannot be a command or category", func() {
+		for _, entry := range []string{
+			"THIS IS NOT A COMMAND !!!",
+			"get set",
+			"get;flushall",
+			"+get",
+			"",
+		} {
+			Expect(applyWithCommands(entry)).NotTo(Succeed(), "entry %q must be rejected", entry)
+		}
+	})
+
+	It("rejects a bad entry in commands.deny as well", func() {
+		counter++
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("acl-cmd-deny-%d", counter),
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+				Users: []valkeyiov1alpha1.UserAclSpec{{
+					Name:       "alice",
+					Enabled:    true,
+					NoPassword: true,
+					Commands:   valkeyiov1alpha1.CommandsAclSpec{Deny: []string{"NOT A COMMAND"}},
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).NotTo(Succeed())
+	})
+})

--- a/internal/controller/valkeycluster_acl_commands_validation_test.go
+++ b/internal/controller/valkeycluster_acl_commands_validation_test.go
@@ -125,6 +125,11 @@ var _ = Describe("users commands validation", func() {
 			".set",
 			"json.",
 			"json..set",
+			"-get",
+			"get-",
+			"-",
+			"--",
+			"-flushall",
 		} {
 			Expect(applyWithCommands(entry)).NotTo(Succeed(), "entry %q must be rejected", entry)
 		}

--- a/internal/controller/valkeycluster_acl_commands_validation_test.go
+++ b/internal/controller/valkeycluster_acl_commands_validation_test.go
@@ -72,7 +72,8 @@ var _ = Describe("users commands validation", func() {
 	// Every one of these is accepted by Valkey's own ACL parser. Categories and
 	// plain commands aside, the awkward ones carry a digit, an underscore or a
 	// hyphen, and Valkey normalises case, so the pattern cannot be lowercase
-	// letters only.
+	// letters only. Module commands are dotted (json.set, bf.add) and are in no
+	// category except @all, so they can only be granted individually.
 	It("accepts command entries that Valkey accepts", func() {
 		for _, entry := range []string{
 			"@read",
@@ -86,6 +87,11 @@ var _ = Describe("users commands validation", func() {
 			"memory|malloc-stats",
 			"GET",
 			"CLIENT|SETNAME",
+			"json.set",
+			"JSON.SET",
+			"bf.add",
+			"ft._list",
+			"json.debug|memory",
 		} {
 			Expect(applyWithCommands(entry)).To(Succeed(), "entry %q must be accepted", entry)
 		}
@@ -116,6 +122,9 @@ var _ = Describe("users commands validation", func() {
 			"|get",
 			"get||set",
 			"client|no|evict",
+			".set",
+			"json.",
+			"json..set",
 		} {
 			Expect(applyWithCommands(entry)).NotTo(Succeed(), "entry %q must be rejected", entry)
 		}

--- a/internal/controller/valkeycluster_acl_commands_validation_test.go
+++ b/internal/controller/valkeycluster_acl_commands_validation_test.go
@@ -130,6 +130,10 @@ var _ = Describe("users commands validation", func() {
 			"-",
 			"--",
 			"-flushall",
+			"json.-set",
+			"json.set-",
+			"get|-x",
+			"a--b",
 		} {
 			Expect(applyWithCommands(entry)).NotTo(Succeed(), "entry %q must be rejected", entry)
 		}


### PR DESCRIPTION
This PR closes #395

### Summary

The pattern markers on `commands.allow` and `commands.deny` were malformed, so controller-gen dropped them and the CRD validated nothing. This makes them generate, and widens the expression to match what Valkey actually accepts.

### Features / Behaviour Changes

- `commands.allow` and `commands.deny` entries are now validated at admission.
- Entries that Valkey accepts keep working, including subcommands, and names carrying a digit, underscore or hyphen.

### Implementation

The marker read `+kubebuilder:validation:Items:Pattern=^[@a-z|]+$}` — capitalised `Items`, plus a stray brace. controller-gen ignores unknown markers without warning, so the generated schema was a bare `items: {type: string}`.

Lowercasing `items` alone is not enough. The original expression rejects 15 of the 396 commands in `COMMAND LIST` on valkey 9.0.0:

```
bitfield_ro          client|import-source  client|no-evict
client|no-touch      cluster|count-failure-reports
cluster|set-config-epoch                   cluster|slot-stats
eval_ro              evalsha_ro            fcall_ro
georadius_ro         georadiusbymember_ro  memory|malloc-stats
restore-asking       sort_ro
```

`cluster|set-config-epoch` is in the operator's own `_operator` ACL. Valkey also accepts uppercase and normalises it on the way in:

```
127.0.0.1:6379> ACL SETUSER upper on nopass +GET ~*
OK
127.0.0.1:6379> ACL LIST
user upper on nopass sanitize-payload ~* resetchannels -@all +get
```

So a lowercase-only pattern would reject specs that work today.

The expression matches the grammar rather than just the alphabet:

```
^(@[A-Za-z]+|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*(\|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*)?)$
```

A category is `@` plus letters; a command is a name of dot-separated segments, each of hyphen-separated words, optionally followed by one pipe and a subcommand of the same shape. Dots cover module commands (`json.set`, `bf.add`, `ft._list`), which are in no category except `@all` and can only be granted individually; hyphens sit only inside a segment, so `-get`, `get-` and `a--b` are rejected. Checked against valkey 9.0.0: all 396 entries of `COMMAND LIST` and all 21 `ACL CAT` categories match, uppercase forms included.

### Limitations

This is admission-level validation only. It rejects strings that cannot be a command or category; it does not check the name against the running server's command table, so a well-formed but nonexistent command (`+notacommand`) still fails later at `ACL LOAD`. Catching that needs a server round trip.

The rule is new validation on an existing `v1alpha1` field, so a stored CR carrying free text will now fail on update. Such a CR is already broken at runtime, since Valkey rejects the ACL file either way.

#396 covers the separate reporting problem: while a node cannot apply the ACL, the cluster still reports `Ready/ClusterHealthy`.

### Testing

`make test` passes.

New `valkeycluster_acl_commands_validation_test.go` asserts against envtest that the awkward-but-valid entries above are accepted, including uppercase forms, that free text, embedded spaces, a leading `+` and an empty string are rejected in both `allow` and `deny`, and that structurally invalid entries carrying only legal characters are rejected: `@`, `@@read`, `@-read`, `|`, `get|`, `|get`, `get||set`, `client|no|evict`.

Two negative controls, both confirmed:

- restoring the malformed marker fails the specs on `entry "THIS IS NOT A COMMAND !!!" must be rejected`
- restoring a character-class-only pattern fails them on `entry "@" must be rejected`

Valkey 9.0.0 rejects all eight of the structurally invalid entries above, e.g. `ERR Error in ACL SETUSER modifier '+get|': Syntax error`. Also scanned the repo for existing command values the pattern would reject; there are none.

### Documentation

`docs/valkeycluster.md` already described the three accepted forms. Added the validation rule itself to the `commands` bullet, plus the caveat that the name is not checked against the server's command table.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [x] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)

