### PR TITLE
fix: surface a failed ACL apply on the cluster status

### DIFF
--- a/api/v1alpha1/valkeycluster_types.go
+++ b/api/v1alpha1/valkeycluster_types.go
@@ -542,6 +542,7 @@ const (
 	ReasonNoSlots                  = "NoSlotsAvailable"
 	ReasonRebalancingSlots         = "RebalancingSlots"
 	ReasonRebalanceFailed          = "RebalanceFailed"
+	ReasonACLApplyFailed           = "ACLApplyFailed"
 	ReasonUsersAclError            = "UsersACLError"
 	ReasonUpdatingNodes            = "UpdatingNodes"
 	ReasonSystemUsersAclError      = "SystemUsersACLError"

--- a/api/v1alpha1/valkeynode_types.go
+++ b/api/v1alpha1/valkeynode_types.go
@@ -223,6 +223,14 @@ const (
 	// is a hash of the managed ACL (see aclRevisionUser); permission-only
 	// edits are therefore honoured too.
 	ValkeyNodeConditionACLApplied = "ACLApplied"
+	// ValkeyNodeReasonApplied, ValkeyNodeReasonPendingPropagation and
+	// ValkeyNodeReasonApplyFailed are the reasons ACLApplied and
+	// LiveConfigApplied carry. The distinction matters to anything aggregating
+	// them: propagation is the normal state after an edit and clears itself once
+	// the mounted file catches up, while a failed apply does not clear on its own.
+	ValkeyNodeReasonApplied            = "Applied"
+	ValkeyNodeReasonPendingPropagation = "PendingPropagation"
+	ValkeyNodeReasonApplyFailed        = "ApplyFailed"
 	// ValkeyNodeConditionWorkloadRollPending indicates a rolling pod-template update
 	// is intentionally deferred: the desired template differs from live, and
 	// Spec.WorkloadRevision has not yet authorized that template. Status True means

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -93,6 +93,7 @@ Common reasons:
 - `NodeAddFailed` – failed to add a node to the cluster
 - `RebalanceFailed` – slot rebalancing failed (scale-out or scale-in)
 - `PodUnschedulable` – Kubernetes scheduler cannot place one or more Valkey pods, for example because strict topology spread constraints cannot be satisfied
+- `ACLApplyFailed` – one or more nodes report `ACLApplied=False/ApplyFailed`, so the users declared in `spec.users` are not in effect on those nodes. See [`ACLApplied`](#aclapplied)
 
 ---
 
@@ -216,7 +217,7 @@ Common reasons when `ACLApplied=False`:
 Common reasons when `ACLApplied=True`:
 - `Applied` – the desired ACL revision is live.
 
-> **Note:** The operator appends a disabled bookkeeping user, `_operator_acl_revision`, to the aclfile. Its only password is a hash of the whole managed ACL, so a node reports `ACLApplied=True` only once the running server has loaded that exact revision. This keeps the condition honest for permission-only edits, which leave every user and password unchanged but still change the revision hash. The user is disabled (`off`) and cannot authenticate; it is expected to appear in `ACL LIST`. The condition is informational and does not block the cluster controller's one-at-a-time progress. On a failed apply the node controller emits a `LiveACLApplyFailed` warning event and retries with backoff.
+> **Note:** The operator appends a disabled bookkeeping user, `_operator_acl_revision`, to the aclfile. Its only password is a hash of the whole managed ACL, so a node reports `ACLApplied=True` only once the running server has loaded that exact revision. This keeps the condition honest for permission-only edits, which leave every user and password unchanged but still change the revision hash. The user is disabled (`off`) and cannot authenticate; it is expected to appear in `ACL LIST`. The condition does not block the cluster controller's one-at-a-time progress, but a failure it cannot resolve is carried up: while any node reports `ApplyFailed`, the cluster sets [`Degraded`](#degraded) with reason `ACLApplyFailed` and a message naming the nodes, and `status.state` reports `Degraded` because it takes that condition ahead of `Ready`. `PendingPropagation` is deliberately not carried up, since it is the normal state after every ACL edit and clears itself once the mounted aclfile catches up. On a failed apply the node controller emits a `LiveACLApplyFailed` warning event and retries with backoff.
 
 #### `WorkloadRollPending`
 Indicates that a rolling pod-template update is intentionally deferred: the ValkeyNode controller has built a pod template that differs from the live StatefulSet or Deployment, but `spec.workloadRevision` has not yet authorized that template. This is expected staging while the cluster advances rolls one node at a time, not an error.

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -57,3 +57,32 @@ func TestSetCondition(t *testing.T) {
 	g.Expect(progressingCond).NotTo(BeNil())
 	g.Expect(progressingCond.Status).To(Equal(metav1.ConditionTrue))
 }
+
+// TestNodesWithFailedACL pins the distinction the cluster status depends on:
+// a failed apply is surfaced, propagation is not. Reporting propagation would
+// take the cluster out of healthy on every routine ACL edit, since it is the
+// normal state until the mounted aclfile catches up.
+func TestNodesWithFailedACL(t *testing.T) {
+	g := NewWithT(t)
+
+	node := func(name, reason string, status metav1.ConditionStatus) valkeyiov1alpha1.ValkeyNode {
+		n := valkeyiov1alpha1.ValkeyNode{}
+		n.Name = name
+		meta.SetStatusCondition(&n.Status.Conditions, metav1.Condition{
+			Type:   valkeyiov1alpha1.ValkeyNodeConditionACLApplied,
+			Status: status,
+			Reason: reason,
+		})
+		return n
+	}
+
+	nodes := &valkeyiov1alpha1.ValkeyNodeList{Items: []valkeyiov1alpha1.ValkeyNode{
+		node("applied", valkeyiov1alpha1.ValkeyNodeReasonApplied, metav1.ConditionTrue),
+		node("propagating", valkeyiov1alpha1.ValkeyNodeReasonPendingPropagation, metav1.ConditionFalse),
+		node("broken", valkeyiov1alpha1.ValkeyNodeReasonApplyFailed, metav1.ConditionFalse),
+		{}, // no ACLApplied condition at all
+	}}
+
+	g.Expect(nodesWithFailedACL(nodes)).To(Equal([]string{"broken"}))
+	g.Expect(nodesWithFailedACL(&valkeyiov1alpha1.ValkeyNodeList{})).To(BeEmpty())
+}

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -401,10 +401,23 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Cluster is healthy - set all positive conditions
-	r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "ClusterReady", "ReconcileCluster", "Cluster ready with %d shards and %d replicas", cluster.Spec.Shards, cluster.Spec.Replicas)
 	setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonClusterHealthy, "Cluster is healthy", metav1.ConditionTrue)
 	setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonReconcileComplete, "No changes needed", metav1.ConditionFalse)
-	meta.RemoveStatusCondition(&cluster.Status.Conditions, valkeyiov1alpha1.ConditionDegraded)
+	// A node whose ACL the operator cannot apply leaves the declared users out of
+	// Valkey while every other check passes, so the cluster would otherwise read
+	// as fully healthy with an ACL that is not in effect.
+	//
+	// Degraded is cleared only in the healthy branch. Removing it first and
+	// setting it again would hand SetStatusCondition an absent condition every
+	// reconcile, which resets LastTransitionTime and loses when the failure
+	// actually started.
+	if failed := nodesWithFailedACL(nodes); len(failed) > 0 {
+		setCondition(cluster, valkeyiov1alpha1.ConditionDegraded, valkeyiov1alpha1.ReasonACLApplyFailed,
+			fmt.Sprintf("ACL not applied on %s", strings.Join(failed, ", ")), metav1.ConditionTrue)
+	} else {
+		meta.RemoveStatusCondition(&cluster.Status.Conditions, valkeyiov1alpha1.ConditionDegraded)
+		r.Recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "ClusterReady", "ReconcileCluster", "Cluster ready with %d shards and %d replicas", cluster.Spec.Shards, cluster.Spec.Replicas)
+	}
 	setCondition(cluster, valkeyiov1alpha1.ConditionClusterFormed, valkeyiov1alpha1.ReasonTopologyComplete, "All nodes joined cluster", metav1.ConditionTrue)
 	setCondition(cluster, valkeyiov1alpha1.ConditionSlotsAssigned, valkeyiov1alpha1.ReasonAllSlotsAssigned, "All slots assigned", metav1.ConditionTrue)
 
@@ -1755,4 +1768,20 @@ func (r *ValkeyClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Named("valkeycluster").
 		Complete(r)
+}
+
+// nodesWithFailedACL returns the names of nodes whose ACL the operator tried to
+// apply and could not. PendingPropagation is deliberately not included: it is
+// the normal state after every ACL edit and clears itself once the mounted
+// aclfile catches up, so reporting it would take the cluster out of healthy on
+// every routine user change.
+func nodesWithFailedACL(nodes *valkeyiov1alpha1.ValkeyNodeList) []string {
+	var failed []string
+	for i := range nodes.Items {
+		c := meta.FindStatusCondition(nodes.Items[i].Status.Conditions, valkeyiov1alpha1.ValkeyNodeConditionACLApplied)
+		if c != nil && c.Status == metav1.ConditionFalse && c.Reason == valkeyiov1alpha1.ValkeyNodeReasonApplyFailed {
+			failed = append(failed, nodes.Items[i].Name)
+		}
+	}
+	return failed
 }

--- a/internal/controller/valkeynode_controller.go
+++ b/internal/controller/valkeynode_controller.go
@@ -213,13 +213,13 @@ func (r *ValkeyNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err != nil {
 		log.Error(err, "failed to apply live config")
 		r.Recorder.Eventf(node, nil, corev1.EventTypeWarning, "LiveConfigApplyFailed", "ApplyLiveConfig", "Failed to apply live config: %v", err)
-		if condErr := r.setLiveConfigCondition(ctx, node, metav1.ConditionFalse, "ApplyFailed", err.Error()); condErr != nil {
+		if condErr := r.setLiveConfigCondition(ctx, node, metav1.ConditionFalse, valkeyiov1alpha1.ValkeyNodeReasonApplyFailed, err.Error()); condErr != nil {
 			log.Error(condErr, "failed to set LiveConfigApplied condition")
 		}
 		return ctrl.Result{}, err
 	}
 	if applied {
-		if condErr := r.setLiveConfigCondition(ctx, node, metav1.ConditionTrue, "Applied", "Live config applied"); condErr != nil {
+		if condErr := r.setLiveConfigCondition(ctx, node, metav1.ConditionTrue, valkeyiov1alpha1.ValkeyNodeReasonApplied, "Live config applied"); condErr != nil {
 			log.Error(condErr, "failed to set LiveConfigApplied condition")
 			return ctrl.Result{}, condErr
 		}
@@ -242,7 +242,7 @@ func (r *ValkeyNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err != nil {
 		log.Error(err, "failed to apply live ACL")
 		r.Recorder.Eventf(node, nil, corev1.EventTypeWarning, "LiveACLApplyFailed", "ApplyLiveACL", "Failed to apply live ACL: %v", err)
-		if condErr := r.setACLCondition(ctx, node, metav1.ConditionFalse, "ApplyFailed", err.Error()); condErr != nil {
+		if condErr := r.setACLCondition(ctx, node, metav1.ConditionFalse, valkeyiov1alpha1.ValkeyNodeReasonApplyFailed, err.Error()); condErr != nil {
 			log.Error(condErr, "failed to set ACLApplied condition")
 		}
 		return ctrl.Result{}, err
@@ -252,14 +252,14 @@ func (r *ValkeyNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Secret, so it loaded stale content. Report that rather than claiming
 		// the desired passwords are live, and reload again on the requeue.
 		log.V(1).Info("desired ACL passwords not live yet, waiting for the aclfile volume to propagate")
-		if condErr := r.setACLCondition(ctx, node, metav1.ConditionFalse, "PendingPropagation",
+		if condErr := r.setACLCondition(ctx, node, metav1.ConditionFalse, valkeyiov1alpha1.ValkeyNodeReasonPendingPropagation,
 			"Waiting for the mounted aclfile to reflect the desired ACL"); condErr != nil {
 			log.Error(condErr, "failed to set ACLApplied condition")
 			return ctrl.Result{}, condErr
 		}
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
-	if condErr := r.setACLCondition(ctx, node, metav1.ConditionTrue, "Applied",
+	if condErr := r.setACLCondition(ctx, node, metav1.ConditionTrue, valkeyiov1alpha1.ValkeyNodeReasonApplied,
 		"Desired ACL passwords are live"); condErr != nil {
 		log.Error(condErr, "failed to set ACLApplied condition")
 		return ctrl.Result{}, condErr


### PR DESCRIPTION
This PR closes #396

### Summary

A node whose ACL the operator cannot apply reports `ACLApplied=False/ApplyFailed` and keeps retrying, but nothing carried that up to the ValkeyCluster. Every other check passed, so the cluster read as `Ready/ClusterHealthy` while the declared users were not in Valkey.

### Features / Behaviour Changes

While any node reports a failed apply, the cluster sets `Degraded` with reason `ACLApplyFailed` and a message naming the nodes. `kubectl get valkeycluster` shows it, since `updateStatus` already checks `Degraded` ahead of `Ready`.

`Ready` is left True. The data path is unaffected and the cluster is genuinely serving; what is wrong is that the ACL the user declared is not in effect.

### Implementation

The check runs on the otherwise-healthy path, right after the existing `RemoveStatusCondition(Degraded)`. That placement gives the clear for free: when no node reports a failure the condition is simply not set again. `Degraded` is already what this controller uses for `NodeAddFailed`, `RebalanceFailed` and `PodUnschedulable`, so no new condition type was needed.

`PendingPropagation` is deliberately excluded. It is the normal state after every ACL edit, lasting until the mounted aclfile catches up, so surfacing it would take a cluster out of healthy on every routine user change. The run below shows that window lasting 78 seconds on a one-node cluster.

The reason strings `ACLApplied` and `LiveConfigApplied` share are promoted to constants, since the cluster controller now has to match one of them.

### Limitations

Only the healthy path is covered. When the cluster is degraded for another reason, that reason wins, which seems right: the cluster is already not reporting healthy, which is the misleading state this fixes.

### Testing

`TestNodesWithFailedACL` pins the distinction the aggregation depends on: `ApplyFailed` is collected, `PendingPropagation` and `Applied` are not, and a node with no `ACLApplied` condition is ignored.

Verified on k3d against a one-shard cluster, using a user whose `commands.allow` carries `@bogus` so Valkey rejects the `ACL LOAD`.

Healthy baseline: `state=Ready reason=ClusterHealthy`, no `Degraded`, node `ACLApplied=True/Applied`.

After the bad ACL was applied, the node sat at `PendingPropagation` for 78 seconds with the cluster still `Ready` and `Degraded` absent, which is the behaviour the exclusion above is protecting. At 81 seconds the mounted file caught up, the `ACL LOAD` was refused, and the node moved to `ApplyFailed`:

```
NAME      STATE      REASON           AGE
aclfail   Degraded   ACLApplyFailed   2m41s
```

```
Ready=True/ClusterHealthy
Degraded=True/ACLApplyFailed  msg=ACL not applied on aclfail-0-0
```

Repairing the ACL cleared it after 84 seconds, back to `Ready/ClusterHealthy` with `Degraded` absent.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [x] Tests are added or updated.
- [ ] Documentation files are updated.
- [x] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
