### PR TITLE
doc: Fix wrong tech call meeting time in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The operator simplifies deploying Valkey Clusters on Kubernetes, handling scalin
 > - 🙏 [Ask questions](https://github.com/valkey-io/valkey-operator/discussions/categories/q-a)
 > - 🐛 [Report bugs](https://github.com/valkey-io/valkey-operator/issues)
 >
-> Want to discuss the operator development? Join the [tech call every Friday at 11:00-11:30 US Eastern](https://zoom-lfx.platform.linuxfoundation.org/meeting/99658320446?password=2eae4006-633e-4fed-aa93-631ab2101421).
+> Want to discuss the operator development? Join the [tech call every Thursday at 14:00 UTC](https://zoom-lfx.platform.linuxfoundation.org/meeting/99658320446?password=2eae4006-633e-4fed-aa93-631ab2101421).
 
 ## Getting Started
 


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey Operator!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-operator/blob/main/CONTRIBUTING.md)

-->

### Summary

README.md shows the wrong day of week and time for the techcall.

### Implementation

Changed README.md to have the right time in UTC.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message explains what changed and why
- [ ] Tests are added or updated.
- [x] Documentation files are updated.
- [ ] I have run pre-commit locally (`pre-commit run --all-files` or hooks on commit)
