### PR TITLE
fix(cluster): reap ValkeyNodes with unparseable topology labels

### DIFF
--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -1738,12 +1738,21 @@ func (r *ValkeyClusterReconciler) deleteExcessValkeyNodes(ctx context.Context, c
 	deleted := false
 	for i := range allNodes.Items {
 		node := &allNodes.Items[i]
-		shardIndex, err := strconv.Atoi(node.Labels[LabelShardIndex])
-		if err != nil {
-			continue
-		}
-		nodeIndex, err := strconv.Atoi(node.Labels[LabelNodeIndex])
-		if err != nil {
+		shardIndex, shardErr := strconv.Atoi(node.Labels[LabelShardIndex])
+		nodeIndex, nodeErr := strconv.Atoi(node.Labels[LabelNodeIndex])
+		if shardErr != nil || nodeErr != nil || shardIndex < 0 || nodeIndex < 0 {
+			// The node carries this cluster's label but its topology labels
+			// are missing or unparseable, so it can never become a valid
+			// member (names and slot assignment derive from these labels).
+			// The cluster controller still lists it on every reconcile while
+			// the scale-in path counts it as extra, wedging the cluster in
+			// Reconciling forever. Reap it like any other excess node, and
+			// name it in an event so the wedge is diagnosable (#403).
+			if pruned, err := r.deleteInvalidTopologyNode(ctx, cluster, node); err != nil {
+				return false, err
+			} else if pruned {
+				deleted = true
+			}
 			continue
 		}
 		if shardIndex >= int(cluster.Spec.Shards) || nodeIndex >= nodesPerShard {
@@ -1759,6 +1768,21 @@ func (r *ValkeyClusterReconciler) deleteExcessValkeyNodes(ctx context.Context, c
 		}
 	}
 	return deleted, nil
+}
+
+// deleteInvalidTopologyNode reaps a ValkeyNode whose shard-index/node-index
+// labels are missing or unparseable. Returns true when it deleted the node.
+func (r *ValkeyClusterReconciler) deleteInvalidTopologyNode(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster, node *valkeyiov1alpha1.ValkeyNode) (bool, error) {
+	log := logf.FromContext(ctx)
+	if err := r.Delete(ctx, node); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("delete ValkeyNode %s with invalid topology labels: %w", node.Name, err)
+		}
+		return false, nil
+	}
+	log.Info("deleted ValkeyNode with invalid topology labels", "name", node.Name, "shard-index", node.Labels[LabelShardIndex], "node-index", node.Labels[LabelNodeIndex])
+	r.Recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "ValkeyNodeDeleted", "ScaleIn", "Deleted ValkeyNode %s with invalid topology labels (shard-index %q, node-index %q)", node.Name, node.Labels[LabelShardIndex], node.Labels[LabelNodeIndex])
+	return true, nil
 }
 
 // shardIndexFromState determines the shard index for a given Valkey Cluster

--- a/internal/controller/valkeycluster_excess_nodes_test.go
+++ b/internal/controller/valkeycluster_excess_nodes_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2026 Valkey Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
+)
+
+// Regression test for https://github.com/valkey-io/valkey-operator/issues/403:
+// a ValkeyNode carrying the cluster label but with unparseable topology
+// labels was silently skipped by deleteExcessValkeyNodes while the scale-in
+// path still counted it as extra, wedging the cluster in Reconciling
+// forever with nothing naming the offending node.
+var _ = Describe("deleteExcessValkeyNodes", func() {
+	const clusterName = "excess-nodes-test"
+
+	var (
+		testCtx      context.Context
+		r            *ValkeyClusterReconciler
+		fakeRecorder *events.FakeRecorder
+		cluster      *valkeyiov1alpha1.ValkeyCluster
+	)
+
+	makeNode := func(name string, labels map[string]string) {
+		GinkgoHelper()
+		node := &valkeyiov1alpha1.ValkeyNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    labels,
+			},
+		}
+		Expect(k8sClient.Create(testCtx, node)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		testCtx = context.Background()
+		fakeRecorder = events.NewFakeRecorder(100)
+		r = &ValkeyClusterReconciler{
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  fakeRecorder,
+		}
+		cluster = &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   1,
+				Replicas: 0,
+			},
+		}
+		Expect(k8sClient.Create(testCtx, cluster)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+		Expect(k8sClient.List(testCtx, nodeList,
+			client.InNamespace("default"),
+			client.MatchingLabels{LabelCluster: clusterName})).To(Succeed())
+		for i := range nodeList.Items {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(testCtx, &nodeList.Items[i]))).To(Succeed())
+		}
+		Expect(client.IgnoreNotFound(k8sClient.Delete(testCtx, cluster))).To(Succeed())
+	})
+
+	It("deletes a ValkeyNode with unparseable topology labels and names it in an event", func() {
+		By("creating a node with the cluster label but a garbage shard-index")
+		badNode := clusterName + "-bad-0"
+		makeNode(badNode, map[string]string{
+			LabelCluster:    clusterName,
+			LabelShardIndex: "not-a-number",
+			LabelNodeIndex:  "0",
+		})
+
+		By("running the excess-node prune")
+		deleted, err := r.deleteExcessValkeyNodes(testCtx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue(), "malformed node must be reaped, not skipped")
+
+		By("verifying the node is gone")
+		got := &valkeyiov1alpha1.ValkeyNode{}
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: badNode, Namespace: "default"}, got)
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		By("verifying an event names the offending node")
+		evts := collectEvents(fakeRecorder)
+		Expect(evts).To(ContainElement(ContainSubstring(badNode)))
+		By("verifying the full event contract: Warning type, reason, raw label values")
+		Expect(evts).To(ContainElement(ContainSubstring("Warning")))
+		Expect(evts).To(ContainElement(ContainSubstring("ValkeyNodeDeleted")))
+		Expect(evts).To(ContainElement(ContainSubstring("not-a-number")))
+	})
+
+	It("deletes a ValkeyNode with an unparseable node-index and valid shard-index", func() {
+		By("creating a node with garbage node-index but a good shard-index")
+		badIdxNode := clusterName + "-badidx-0"
+		makeNode(badIdxNode, map[string]string{
+			LabelCluster:    clusterName,
+			LabelShardIndex: "0",
+			LabelNodeIndex:  "bogus",
+		})
+
+		By("running the excess-node prune")
+		deleted, err := r.deleteExcessValkeyNodes(testCtx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue(), "unparseable node-index must be reaped, not skipped")
+
+		By("verifying the node is gone and the event carries the raw values")
+		got := &valkeyiov1alpha1.ValkeyNode{}
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: badIdxNode, Namespace: "default"}, got)
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+		evts := collectEvents(fakeRecorder)
+		Expect(evts).To(ContainElement(ContainSubstring(badIdxNode)))
+		Expect(evts).To(ContainElement(ContainSubstring("Warning")))
+		Expect(evts).To(ContainElement(ContainSubstring("ValkeyNodeDeleted")))
+		Expect(evts).To(ContainElement(ContainSubstring("bogus")))
+	})
+
+	It("deletes a ValkeyNode with negative topology indexes", func() {
+		By("building a node with a negative shard-index via the fake client, which skips label validation")
+		negNode := &valkeyiov1alpha1.ValkeyNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName + "-neg-0",
+				Namespace: "default",
+				Labels: map[string]string{
+					LabelCluster:    clusterName,
+					LabelShardIndex: "-1",
+					LabelNodeIndex:  "0",
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(cluster, negNode).Build()
+		negReconciler := &ValkeyClusterReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  events.NewFakeRecorder(100),
+		}
+
+		By("running the excess-node prune")
+		deleted, err := negReconciler.deleteExcessValkeyNodes(testCtx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue(), "negative index must be reaped, not skipped")
+
+		By("verifying the node is gone")
+		got := &valkeyiov1alpha1.ValkeyNode{}
+		err = fakeClient.Get(testCtx, types.NamespacedName{Name: clusterName + "-neg-0", Namespace: "default"}, got)
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("keeps a valid in-range ValkeyNode", func() {
+		By("creating a healthy shard-0 node-0")
+		goodNode := clusterName + "-0-0"
+		makeNode(goodNode, map[string]string{
+			LabelCluster:    clusterName,
+			LabelShardIndex: "0",
+			LabelNodeIndex:  "0",
+		})
+
+		By("running the excess-node prune")
+		deleted, err := r.deleteExcessValkeyNodes(testCtx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeFalse(), "in-range node must survive the prune")
+
+		By("verifying the node is still present")
+		got := &valkeyiov1alpha1.ValkeyNode{}
+		Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: goodNode, Namespace: "default"}, got)).To(Succeed())
+	})
+
+	It("still deletes an out-of-range ValkeyNode", func() {
+		By("creating a node past the shard count")
+		farNode := clusterName + "-9-0"
+		makeNode(farNode, map[string]string{
+			LabelCluster:    clusterName,
+			LabelShardIndex: "9",
+			LabelNodeIndex:  "0",
+		})
+
+		By("running the excess-node prune")
+		deleted, err := r.deleteExcessValkeyNodes(testCtx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		By("verifying the node is gone")
+		got := &valkeyiov1alpha1.ValkeyNode{}
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: farNode, Namespace: "default"}, got)
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
This PR closes #403

### Summary

A ValkeyNode carrying the cluster label but with missing or unparseable shard-index/node-index labels could never become a valid member, yet the cluster controller listed it on every reconcile while the scale-in path counted it as extra. deleteExcessValkeyNodes skipped it with a bare continue, wedging the cluster in Reconciling indefinitely with nothing naming the offending node. Such nodes are now reaped like any other excess node, with a Warning event naming the node and its bad label values.

### Features / Behaviour Changes

- Nodes with invalid topology labels are deleted instead of silently skipped, so the cluster self-heals instead of wedging.
- A Warning event ValkeyNodeDeleted names the offending node, addressing the undiagnosable-wedge complaint.

### Implementation

- deleteExcessValkeyNodes parses both labels up front; on either parse failure it delegates to a new deleteInvalidTopologyNode helper (log plus Warning event plus Delete with NotFound-tolerant idempotency) and propagates the deleted flag for correct requeue.
- No RBAC or CRD changes: only existing list/delete verbs on ValkeyNodes.

### Limitations

- Only handles nodes already carrying this cluster's label selector; a same-named node in another namespace is untouched by the list scope.

### Testing

- New Ginkgo specs in internal/controller/valkeycluster_excess_nodes_test.go: malformed node reaped plus event names it (fails without the fix with deleted=false, passes with it), valid in-range node survives, out-of-range node still deleted.
- Full go test ./internal/... green. gofmt and go vet clean. envtest, no cluster needed.

### Checklist

- [x] Linked issue above
- [x] DCO signoff on the commit
- [x] Unit tests added, proven to fail without the fix
- [x] No generated files touched