### PR TITLE
fix: refresh topology status while a node roll is stuck

### DIFF
--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -19,7 +19,7 @@ These top-level fields in `.status` provide a high-level, human-readable summary
 
 - **`shards`**: The number of shards currently detected in the Valkey cluster.
 
-- **`readyShards`**: The number of shards that are fully healthy, meaning they have a primary and the desired number of replicas. When Valkey cluster state is not available (for example during `UpdatingNodes`), this counts shards that have a Ready primary Pod (node-index 0).
+- **`readyShards`**: The number of shards that are fully healthy, meaning they have a primary and the desired number of replicas. When Valkey cluster state is not available (for example during `UpdatingNodes`), this counts shards that have at least one Ready Pod.
 
 ---
 
@@ -105,13 +105,13 @@ Indicates whether all nodes have joined the cluster and meet the desired shard/r
 | Status | Meaning |
 |---|---|
 | `True` | All shards and replicas are present and joined. |
-| `False` | Pending nodes, missing shards, missing replicas, or a required primary Pod is not Ready. |
+| `False` | Pending nodes, missing shards, missing replicas, or a shard has no Ready Pod. |
 
 Typical reasons:
 - `ClusterFormed` – Cluster is formed
 - `MissingShards` – waiting for shards
 - `MissingReplicas` – waiting for replicas
-- `UpdatingNodes` – a required primary Pod is not Ready during a ValkeyNode roll
+- `UpdatingNodes` – a shard has no Ready Pod during a ValkeyNode roll
 
 #### `SlotsAssigned`
 Indicates whether all **16384** hash slots are assigned to primaries.
@@ -124,7 +124,7 @@ Indicates whether all **16384** hash slots are assigned to primaries.
 Common reasons:
 - `AllSlotsAssigned` – all 16384 slots are assigned
 - `SlotsUnassigned` – waiting for slots to be assigned
-- `UpdatingNodes` – a required primary Pod is not Ready; slot ownership is not trusted for this generation
+- `UpdatingNodes` – a shard has no Ready Pod; slot ownership is not trusted for this generation
 
 #### `ConfigurationWarning`
 Indicates the operator accepted a spec value it considers risky, rather than rejecting or overriding it.
@@ -723,7 +723,7 @@ default     valkeycluster-sample   Ready          ClusterHealthy   3            
 
 - **Reconciling (UpdatingNodes)**
   - `Reason=UpdatingNodes` indicates a rolling update of ValkeyNode CRs is in progress (one node at a time, replicas before primaries).
-  - If a required primary Pod is not Ready, `readyShards` is less than `spec.shards`.
+  - If a shard has no Ready Pod, `readyShards` is less than `spec.shards`.
   - `ClusterFormed` and `SlotsAssigned` are then False on the current generation.
 
 - **Ready (ClusterHealthy)**

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -19,7 +19,7 @@ These top-level fields in `.status` provide a high-level, human-readable summary
 
 - **`shards`**: The number of shards currently detected in the Valkey cluster.
 
-- **`readyShards`**: The number of shards that are fully healthy, meaning they have a primary and the desired number of replicas.
+- **`readyShards`**: The number of shards that are fully healthy, meaning they have a primary and the desired number of replicas. When Valkey cluster state is not available (for example during `UpdatingNodes`), this counts shards that have a Ready primary Pod (node-index 0).
 
 ---
 
@@ -105,12 +105,13 @@ Indicates whether all nodes have joined the cluster and meet the desired shard/r
 | Status | Meaning |
 |---|---|
 | `True` | All shards and replicas are present and joined. |
-| `False` | Pending nodes, missing shards, or missing replicas. |
+| `False` | Pending nodes, missing shards, missing replicas, or a required primary Pod is not Ready. |
 
 Typical reasons:
 - `ClusterFormed` – Cluster is formed
 - `MissingShards` – waiting for shards
 - `MissingReplicas` – waiting for replicas
+- `UpdatingNodes` – a required primary Pod is not Ready during a ValkeyNode roll
 
 #### `SlotsAssigned`
 Indicates whether all **16384** hash slots are assigned to primaries.
@@ -123,6 +124,7 @@ Indicates whether all **16384** hash slots are assigned to primaries.
 Common reasons:
 - `AllSlotsAssigned` – all 16384 slots are assigned
 - `SlotsUnassigned` – waiting for slots to be assigned
+- `UpdatingNodes` – a required primary Pod is not Ready; slot ownership is not trusted for this generation
 
 #### `ConfigurationWarning`
 Indicates the operator accepted a spec value it considers risky, rather than rejecting or overriding it.
@@ -721,6 +723,8 @@ default     valkeycluster-sample   Ready          ClusterHealthy   3            
 
 - **Reconciling (UpdatingNodes)**
   - `Reason=UpdatingNodes` indicates a rolling update of ValkeyNode CRs is in progress (one node at a time, replicas before primaries).
+  - If a required primary Pod is not Ready, `readyShards` is less than `spec.shards`.
+  - `ClusterFormed` and `SlotsAssigned` are then False on the current generation.
 
 - **Ready (ClusterHealthy)**
   - Once `READYSHARDS` reaches the desired shard count and the cluster is healthy, the summary switches to `Ready / ClusterHealthy`.

--- a/docs/status-conditions.md
+++ b/docs/status-conditions.md
@@ -119,7 +119,7 @@ Indicates whether all **16384** hash slots are assigned to primaries.
 | Status | Meaning |
 |---|---|
 | `True` | All slots are assigned. |
-| `False` (or absent) | Some slots remain unassigned. |
+| `False` (or absent) | Some slots remain unassigned, or a shard has no Ready Pod. |
 
 Common reasons:
 - `AllSlotsAssigned` – all 16384 slots are assigned

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -155,7 +155,7 @@ func TestNodesWithFailedACL(t *testing.T) {
 	g.Expect(nodesWithFailedACL(&valkeyiov1alpha1.ValkeyNodeList{})).To(BeEmpty())
 }
 
-func TestCountReadyPrimaryPods(t *testing.T) {
+func TestCountShardsWithReadyPod(t *testing.T) {
 	g := NewWithT(t)
 
 	pod := func(name, shard, node string, ready bool, deleting bool) corev1.Pod {
@@ -181,28 +181,28 @@ func TestCountReadyPrimaryPods(t *testing.T) {
 		return p
 	}
 
-	g.Expect(countReadyPrimaryPods(nil, 3)).To(Equal(int32(0)))
-	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+	g.Expect(countShardsWithReadyPod(nil, 3)).To(Equal(int32(0)))
+	g.Expect(countShardsWithReadyPod([]corev1.Pod{
 		pod("s0", "0", "0", false, false),
 		pod("s1", "1", "0", true, false),
 		pod("s2", "2", "0", true, false),
 	}, 3)).To(Equal(int32(2)))
-	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+	g.Expect(countShardsWithReadyPod([]corev1.Pod{
 		pod("s0-replica", "0", "1", true, false),
 		pod("s1", "1", "0", true, false),
 		pod("s2", "2", "0", true, false),
-	}, 3)).To(Equal(int32(2)))
-	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+	}, 3)).To(Equal(int32(3)))
+	g.Expect(countShardsWithReadyPod([]corev1.Pod{
 		pod("s0", "0", "0", true, true),
 		pod("s1", "1", "0", true, false),
 		pod("s2", "2", "0", true, false),
 	}, 3)).To(Equal(int32(2)))
-	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+	g.Expect(countShardsWithReadyPod([]corev1.Pod{
 		pod("s0", "0", "0", true, false),
 		pod("s1", "1", "0", true, false),
 		pod("s2", "2", "0", true, false),
 	}, 3)).To(Equal(int32(3)))
-	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+	g.Expect(countShardsWithReadyPod([]corev1.Pod{
 		pod("drain", "3", "0", true, false),
 	}, 3)).To(Equal(int32(0)))
 }

--- a/internal/controller/status_test.go
+++ b/internal/controller/status_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	valkeyiov1alpha1 "github.com/valkey-io/valkey-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
@@ -152,4 +153,56 @@ func TestNodesWithFailedACL(t *testing.T) {
 
 	g.Expect(nodesWithFailedACL(nodes)).To(Equal([]string{"broken"}))
 	g.Expect(nodesWithFailedACL(&valkeyiov1alpha1.ValkeyNodeList{})).To(BeEmpty())
+}
+
+func TestCountReadyPrimaryPods(t *testing.T) {
+	g := NewWithT(t)
+
+	pod := func(name, shard, node string, ready bool, deleting bool) corev1.Pod {
+		p := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Labels: map[string]string{
+					LabelShardIndex: shard,
+					LabelNodeIndex:  node,
+				},
+			},
+		}
+		if ready {
+			p.Status.Conditions = []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}}
+		}
+		if deleting {
+			now := metav1.Now()
+			p.DeletionTimestamp = &now
+		}
+		return p
+	}
+
+	g.Expect(countReadyPrimaryPods(nil, 3)).To(Equal(int32(0)))
+	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+		pod("s0", "0", "0", false, false),
+		pod("s1", "1", "0", true, false),
+		pod("s2", "2", "0", true, false),
+	}, 3)).To(Equal(int32(2)))
+	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+		pod("s0-replica", "0", "1", true, false),
+		pod("s1", "1", "0", true, false),
+		pod("s2", "2", "0", true, false),
+	}, 3)).To(Equal(int32(2)))
+	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+		pod("s0", "0", "0", true, true),
+		pod("s1", "1", "0", true, false),
+		pod("s2", "2", "0", true, false),
+	}, 3)).To(Equal(int32(2)))
+	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+		pod("s0", "0", "0", true, false),
+		pod("s1", "1", "0", true, false),
+		pod("s2", "2", "0", true, false),
+	}, 3)).To(Equal(int32(3)))
+	g.Expect(countReadyPrimaryPods([]corev1.Pod{
+		pod("drain", "3", "0", true, false),
+	}, 3)).To(Equal(int32(0)))
 }

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -208,6 +208,7 @@ func (r *ValkeyClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		setCondition(cluster, valkeyiov1alpha1.ConditionReady, valkeyiov1alpha1.ReasonUpdatingNodes, "Updating ValkeyNodes", metav1.ConditionFalse)
 		setCondition(cluster, valkeyiov1alpha1.ConditionProgressing, valkeyiov1alpha1.ReasonUpdatingNodes, "Updating ValkeyNodes", metav1.ConditionTrue)
+		r.refreshTopologyStatusFromPods(ctx, cluster)
 		_ = r.updateStatus(ctx, cluster, nil)
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
@@ -508,6 +509,72 @@ func podSchedulingIssueForPod(pod *corev1.Pod) *podSchedulingIssue {
 		}
 	}
 	return nil
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// countReadyPrimaryPods counts shards that have a Ready Pod at node-index 0.
+// Node-index 0 is the initial primary. This path does not use CLUSTER NODES.
+func countReadyPrimaryPods(pods []corev1.Pod, desiredShards int32) int32 {
+	if desiredShards <= 0 {
+		return 0
+	}
+	ready := make([]bool, desiredShards)
+	for i := range pods {
+		pod := &pods[i]
+		if !isPodReady(pod) {
+			continue
+		}
+		if pod.Labels[LabelNodeIndex] != "0" {
+			continue
+		}
+		si, err := strconv.Atoi(pod.Labels[LabelShardIndex])
+		if err != nil || si < 0 || si >= int(desiredShards) {
+			continue
+		}
+		ready[si] = true
+	}
+	var n int32
+	for _, ok := range ready {
+		if ok {
+			n++
+		}
+	}
+	return n
+}
+
+// refreshTopologyStatusFromPods sets readyShards from Ready primary Pods.
+// A missing or not-Ready required primary sets ClusterFormed and SlotsAssigned False.
+func (r *ValkeyClusterReconciler) refreshTopologyStatusFromPods(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) {
+	log := logf.FromContext(ctx)
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods, client.InNamespace(cluster.Namespace), client.MatchingLabels(map[string]string{LabelCluster: cluster.Name})); err != nil {
+		log.Error(err, "failed to list Valkey pods for topology status")
+		return
+	}
+	ready := countReadyPrimaryPods(pods.Items, cluster.Spec.Shards)
+	cluster.Status.ReadyShards = ready
+	if ready < cluster.Spec.Shards {
+		setCondition(cluster, valkeyiov1alpha1.ConditionClusterFormed, valkeyiov1alpha1.ReasonUpdatingNodes, "A required primary Pod is not Ready", metav1.ConditionFalse)
+		setCondition(cluster, valkeyiov1alpha1.ConditionSlotsAssigned, valkeyiov1alpha1.ReasonUpdatingNodes, "A required primary Pod is not Ready", metav1.ConditionFalse)
+		return
+	}
+	if c := meta.FindStatusCondition(cluster.Status.Conditions, valkeyiov1alpha1.ConditionClusterFormed); c != nil && c.Status == metav1.ConditionTrue {
+		setCondition(cluster, valkeyiov1alpha1.ConditionClusterFormed, c.Reason, c.Message, metav1.ConditionTrue)
+	}
+	if c := meta.FindStatusCondition(cluster.Status.Conditions, valkeyiov1alpha1.ConditionSlotsAssigned); c != nil && c.Status == metav1.ConditionTrue {
+		setCondition(cluster, valkeyiov1alpha1.ConditionSlotsAssigned, c.Reason, c.Message, metav1.ConditionTrue)
+	}
 }
 
 func headlessServiceName(clusterName string) string {
@@ -1462,10 +1529,13 @@ func (r *ValkeyClusterReconciler) updateStatus(ctx context.Context, cluster *val
 	patchBase := current.DeepCopy()
 	patch := client.MergeFrom(patchBase)
 
-	// Update shard counts
+	// Update shard counts. When Valkey state is nil, keep the in-memory
+	// readyShards value so callers can set it from Pods.
 	if state != nil {
 		current.Status.ReadyShards = r.countReadyShards(state, cluster)
 		current.Status.Shards = int32(len(state.Shards))
+	} else {
+		current.Status.ReadyShards = cluster.Status.ReadyShards
 	}
 
 	// Apply conditions from the in-memory cluster object

--- a/internal/controller/valkeycluster_controller.go
+++ b/internal/controller/valkeycluster_controller.go
@@ -523,9 +523,9 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// countReadyPrimaryPods counts shards that have a Ready Pod at node-index 0.
-// Node-index 0 is the initial primary. This path does not use CLUSTER NODES.
-func countReadyPrimaryPods(pods []corev1.Pod, desiredShards int32) int32 {
+// countShardsWithReadyPod counts shards that have at least one Ready Pod.
+// Node-index is ignored: after failover the live primary may not be index 0.
+func countShardsWithReadyPod(pods []corev1.Pod, desiredShards int32) int32 {
 	if desiredShards <= 0 {
 		return 0
 	}
@@ -533,9 +533,6 @@ func countReadyPrimaryPods(pods []corev1.Pod, desiredShards int32) int32 {
 	for i := range pods {
 		pod := &pods[i]
 		if !isPodReady(pod) {
-			continue
-		}
-		if pod.Labels[LabelNodeIndex] != "0" {
 			continue
 		}
 		si, err := strconv.Atoi(pod.Labels[LabelShardIndex])
@@ -553,8 +550,8 @@ func countReadyPrimaryPods(pods []corev1.Pod, desiredShards int32) int32 {
 	return n
 }
 
-// refreshTopologyStatusFromPods sets readyShards from Ready primary Pods.
-// A missing or not-Ready required primary sets ClusterFormed and SlotsAssigned False.
+// refreshTopologyStatusFromPods sets readyShards from shards that have a Ready Pod.
+// A shard with no Ready Pod sets ClusterFormed and SlotsAssigned False.
 func (r *ValkeyClusterReconciler) refreshTopologyStatusFromPods(ctx context.Context, cluster *valkeyiov1alpha1.ValkeyCluster) {
 	log := logf.FromContext(ctx)
 	pods := &corev1.PodList{}
@@ -562,11 +559,11 @@ func (r *ValkeyClusterReconciler) refreshTopologyStatusFromPods(ctx context.Cont
 		log.Error(err, "failed to list Valkey pods for topology status")
 		return
 	}
-	ready := countReadyPrimaryPods(pods.Items, cluster.Spec.Shards)
+	ready := countShardsWithReadyPod(pods.Items, cluster.Spec.Shards)
 	cluster.Status.ReadyShards = ready
 	if ready < cluster.Spec.Shards {
-		setCondition(cluster, valkeyiov1alpha1.ConditionClusterFormed, valkeyiov1alpha1.ReasonUpdatingNodes, "A required primary Pod is not Ready", metav1.ConditionFalse)
-		setCondition(cluster, valkeyiov1alpha1.ConditionSlotsAssigned, valkeyiov1alpha1.ReasonUpdatingNodes, "A required primary Pod is not Ready", metav1.ConditionFalse)
+		setCondition(cluster, valkeyiov1alpha1.ConditionClusterFormed, valkeyiov1alpha1.ReasonUpdatingNodes, "A shard has no Ready Pod", metav1.ConditionFalse)
+		setCondition(cluster, valkeyiov1alpha1.ConditionSlotsAssigned, valkeyiov1alpha1.ReasonUpdatingNodes, "A shard has no Ready Pod", metav1.ConditionFalse)
 		return
 	}
 	if c := meta.FindStatusCondition(cluster.Status.Conditions, valkeyiov1alpha1.ConditionClusterFormed); c != nil && c.Status == metav1.ConditionTrue {

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -907,7 +907,7 @@ var _ = Describe("UpdatingNodes topology status", func() {
 		Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
 	}
 
-	It("sets readyShards and ClusterFormed from pods when a primary is not Ready", func() {
+	It("sets readyShards and ClusterFormed from pods when a shard has no Ready Pod", func() {
 		cluster, r := createCluster("roll-status-missing-primary")
 		DeferCleanup(func() { cleanupCluster(cluster) })
 
@@ -947,6 +947,32 @@ var _ = Describe("UpdatingNodes topology status", func() {
 		Expect(progressing).NotTo(BeNil())
 		Expect(progressing.Status).To(Equal(metav1.ConditionTrue))
 		Expect(progressing.Reason).To(Equal(valkeyiov1alpha1.ReasonUpdatingNodes))
+	})
+
+	It("keeps ClusterFormed True when a replica Pod is Ready after failover", func() {
+		cluster, r := createCluster("roll-status-replica-ready")
+		DeferCleanup(func() { cleanupCluster(cluster) })
+
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+		markAllNodesReady(cluster.Name)
+		seedStaleHealthyStatus(cluster)
+		createClusterPod(cluster.Name, 0, 1, true)
+		createClusterPod(cluster.Name, 1, 0, true)
+		createClusterPod(cluster.Name, 2, 0, true)
+		bumpImage(cluster)
+
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &valkeyiov1alpha1.ValkeyCluster{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), updated)).To(Succeed())
+		Expect(updated.Status.ReadyShards).To(Equal(int32(3)))
+
+		formed := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionClusterFormed)
+		Expect(formed).NotTo(BeNil())
+		Expect(formed.Status).To(Equal(metav1.ConditionTrue))
+		Expect(formed.ObservedGeneration).To(Equal(updated.Generation))
 	})
 
 	It("keeps ClusterFormed True when every primary Pod is Ready during a roll", func() {

--- a/internal/controller/valkeycluster_controller_test.go
+++ b/internal/controller/valkeycluster_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -783,6 +784,200 @@ var _ = Describe("updateStatus", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cluster.Status.State).To(Equal(valkeyiov1alpha1.ClusterStateReconciling))
 		Expect(cluster.Status.Reason).To(Equal(valkeyiov1alpha1.ReasonInitializing))
+	})
+
+	It("writes readyShards from the in-memory cluster when Valkey state is nil", func() {
+		cluster.Status.ReadyShards = 2
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:   valkeyiov1alpha1.ConditionProgressing,
+			Status: metav1.ConditionTrue,
+			Reason: valkeyiov1alpha1.ReasonUpdatingNodes,
+		})
+
+		err := r.updateStatus(ctx, cluster, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cluster.Status.ReadyShards).To(Equal(int32(2)))
+
+		stored := &valkeyiov1alpha1.ValkeyCluster{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), stored)).To(Succeed())
+		Expect(stored.Status.ReadyShards).To(Equal(int32(2)))
+	})
+})
+
+var _ = Describe("UpdatingNodes topology status", func() {
+	ctx := context.Background()
+
+	createCluster := func(name string) (*valkeyiov1alpha1.ValkeyCluster, *ValkeyClusterReconciler) {
+		GinkgoHelper()
+		cluster := &valkeyiov1alpha1.ValkeyCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+			Spec: valkeyiov1alpha1.ValkeyClusterSpec{
+				Shards:   3,
+				Replicas: 0,
+			},
+		}
+		Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+		r := &ValkeyClusterReconciler{
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  events.NewFakeRecorder(100),
+		}
+		return cluster, r
+	}
+
+	cleanupCluster := func(cluster *valkeyiov1alpha1.ValkeyCluster) {
+		GinkgoHelper()
+		nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+		_ = k8sClient.List(ctx, nodeList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: cluster.Name})
+		for i := range nodeList.Items {
+			_ = k8sClient.Delete(ctx, &nodeList.Items[i])
+		}
+		podList := &corev1.PodList{}
+		_ = k8sClient.List(ctx, podList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: cluster.Name})
+		for i := range podList.Items {
+			_ = k8sClient.Delete(ctx, &podList.Items[i])
+		}
+		_ = k8sClient.Delete(ctx, cluster)
+		_ = k8sClient.Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: headlessServiceName(cluster.Name), Namespace: "default"}})
+		_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: GetServerConfigMapName(cluster.Name), Namespace: "default"}})
+		_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: getInternalSecretName(cluster.Name), Namespace: "default"}})
+	}
+
+	createClusterPod := func(clusterName string, shard, node int, ready bool) {
+		GinkgoHelper()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d-%d", clusterName, shard, node),
+				Namespace: "default",
+				Labels: map[string]string{
+					LabelCluster:    clusterName,
+					LabelShardIndex: strconv.Itoa(shard),
+					LabelNodeIndex:  strconv.Itoa(node),
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "server",
+					Image: DefaultImage,
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		if !ready {
+			return
+		}
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		}}
+		Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+	}
+
+	markAllNodesReady := func(clusterName string) {
+		GinkgoHelper()
+		nodeList := &valkeyiov1alpha1.ValkeyNodeList{}
+		Expect(k8sClient.List(ctx, nodeList, client.InNamespace("default"), client.MatchingLabels{LabelCluster: clusterName})).To(Succeed())
+		Expect(nodeList.Items).To(HaveLen(3))
+		for i := range nodeList.Items {
+			node := &nodeList.Items[i]
+			node.Status.Ready = true
+			node.Status.ObservedGeneration = node.Generation
+			Expect(k8sClient.Status().Update(ctx, node)).To(Succeed())
+		}
+	}
+
+	seedStaleHealthyStatus := func(cluster *valkeyiov1alpha1.ValkeyCluster) {
+		GinkgoHelper()
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+		cluster.Status.ReadyShards = 3
+		cluster.Status.Shards = 3
+		setCondition(cluster, valkeyiov1alpha1.ConditionClusterFormed, valkeyiov1alpha1.ReasonTopologyComplete, "All nodes joined cluster", metav1.ConditionTrue)
+		setCondition(cluster, valkeyiov1alpha1.ConditionSlotsAssigned, valkeyiov1alpha1.ReasonAllSlotsAssigned, "All slots assigned", metav1.ConditionTrue)
+		Expect(k8sClient.Status().Update(ctx, cluster)).To(Succeed())
+	}
+
+	bumpImage := func(cluster *valkeyiov1alpha1.ValkeyCluster) {
+		GinkgoHelper()
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+		cluster.Spec.Image = "valkey/valkey:9.1.0"
+		Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
+	}
+
+	It("sets readyShards and ClusterFormed from pods when a primary is not Ready", func() {
+		cluster, r := createCluster("roll-status-missing-primary")
+		DeferCleanup(func() { cleanupCluster(cluster) })
+
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+		markAllNodesReady(cluster.Name)
+		seedStaleHealthyStatus(cluster)
+		createClusterPod(cluster.Name, 1, 0, true)
+		createClusterPod(cluster.Name, 2, 0, true)
+		bumpImage(cluster)
+
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &valkeyiov1alpha1.ValkeyCluster{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), updated)).To(Succeed())
+		Expect(updated.Generation).To(BeNumerically(">=", int64(2)))
+		Expect(updated.Status.ReadyShards).To(Equal(int32(2)))
+
+		formed := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionClusterFormed)
+		Expect(formed).NotTo(BeNil())
+		Expect(formed.Status).To(Equal(metav1.ConditionFalse))
+		Expect(formed.Reason).To(Equal(valkeyiov1alpha1.ReasonUpdatingNodes))
+		Expect(formed.ObservedGeneration).To(Equal(updated.Generation))
+
+		slots := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionSlotsAssigned)
+		Expect(slots).NotTo(BeNil())
+		Expect(slots.Status).To(Equal(metav1.ConditionFalse))
+		Expect(slots.ObservedGeneration).To(Equal(updated.Generation))
+
+		ready := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionReady)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+		Expect(ready.Reason).To(Equal(valkeyiov1alpha1.ReasonUpdatingNodes))
+
+		progressing := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionProgressing)
+		Expect(progressing).NotTo(BeNil())
+		Expect(progressing.Status).To(Equal(metav1.ConditionTrue))
+		Expect(progressing.Reason).To(Equal(valkeyiov1alpha1.ReasonUpdatingNodes))
+	})
+
+	It("keeps ClusterFormed True when every primary Pod is Ready during a roll", func() {
+		cluster, r := createCluster("roll-status-primaries-ready")
+		DeferCleanup(func() { cleanupCluster(cluster) })
+
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+		markAllNodesReady(cluster.Name)
+		seedStaleHealthyStatus(cluster)
+		createClusterPod(cluster.Name, 0, 0, true)
+		createClusterPod(cluster.Name, 1, 0, true)
+		createClusterPod(cluster.Name, 2, 0, true)
+		bumpImage(cluster)
+
+		_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cluster)})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &valkeyiov1alpha1.ValkeyCluster{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), updated)).To(Succeed())
+		Expect(updated.Status.ReadyShards).To(Equal(int32(3)))
+
+		formed := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionClusterFormed)
+		Expect(formed).NotTo(BeNil())
+		Expect(formed.Status).To(Equal(metav1.ConditionTrue))
+		Expect(formed.ObservedGeneration).To(Equal(updated.Generation))
+
+		ready := testutils.FindCondition(updated.Status.Conditions, valkeyiov1alpha1.ConditionReady)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+		Expect(ready.Reason).To(Equal(valkeyiov1alpha1.ReasonUpdatingNodes))
 	})
 })
 


### PR DESCRIPTION
When `reconcileValkeyNodes` requeues (`UpdatingNodes`), the controller only set Ready and Progressing. `updateStatus` skipped `readyShards` because Valkey cluster state was nil. `ClusterFormed` stayed True with the previous `observedGeneration` while a shard had no running pod.

On that path the controller now lists pods (no Valkey clients) and:

- sets `status.readyShards` to the number of shards that have at least one Ready Pod
- sets `ClusterFormed` and `SlotsAssigned` False on the current generation if a shard has no Ready Pod

A shard still counts if a replica Pod is Ready and node-index 0 is not (live primary after failover). This does not implement primary failback (#311).

Related: #408

## Testing

`go test ./internal/controller/` covering `UpdatingNodes topology status` and `TestCountShardsWithReadyPod`.